### PR TITLE
If matching 'less than', if the value isn't set then we set it to 0

### DIFF
--- a/xl/trax/search.py
+++ b/xl/trax/search.py
@@ -140,7 +140,10 @@ class _LtMatcher(_Matcher):
     """
     def _matches(self, value):
         try:
-            value = float(value)
+            if value is None:
+                value = 0
+            else:
+                value = float(value)
             content = float(self.content) # kinda inefficient
         except (TypeError, ValueError):
             return False


### PR DESCRIPTION
Fixes #19

I think this shouldn't break anything, but I'd like someone else to review this. 
