### PR TITLE
Improve comment for translators

### DIFF
--- a/xlgui/preferences/collection.py
+++ b/xlgui/preferences/collection.py
@@ -30,7 +30,7 @@ def _get_default_strip_list():
     #collection panel. For example, in French locales this could be
     #the space-separated list "l' la le les".
     #If this practice is not common in your locale, simply
-    #translate this to an empty string.
+    #translate this to string with single space.
     default_strip_list = _("the")
     return [v.lower() for v in default_strip_list.split(' ') if v is not '']
 


### PR DESCRIPTION
When the translation is empty, gettext treats it as not translated, so it returns original value. So languages which keep the translation empty will get "the" here...