### PR TITLE
Log compilation detection only in debug mode

### DIFF
--- a/xl/collection.py
+++ b/xl/collection.py
@@ -695,7 +695,7 @@ class Library(object):
                 artist not in ccheck[basedir][album]:
             if not (basedir, album) in compilations:
                 compilations.append((basedir, album))
-                logger.info("Compilation %(album)r detected in %(dir)r" %
+                logger.debug("Compilation %(album)r detected in %(dir)r" %
                         {'album': album, 'dir': basedir})
 
         ccheck[basedir][album].append(artist)


### PR DESCRIPTION
I think it is not necessary to log compilation detection in normal mode since this is just informative for debugging purposes.