### PR TITLE
Ignore git error message

### DIFF
--- a/xl/version.py
+++ b/xl/version.py
@@ -41,7 +41,7 @@ def get_current_revision(directory):
     try:
         return subprocess.check_output([
             'git', 'rev-parse', '--short=7', 'HEAD'
-        ]).strip()
+        ], stderr=-1).strip()
     except subprocess.CalledProcessError:
         return None
 


### PR DESCRIPTION
Currently if no git or git repository is found, an error message is printed to stderr of exaile. This is unnecessary and will be fixed by this commit.