### PR TITLE
Add URL to Weblate web site for translation

### DIFF
--- a/doc/dev/contributing.rst
+++ b/doc/dev/contributing.rst
@@ -7,7 +7,7 @@ in various ways:
 
 * Bugfixes
 * Documentation updates
-* Translations
+* Translations on https://hosted.weblate.org/projects/exaile/master/
 * New features + plugins
 
 The best way to contribute is to submit patches/etc via pull request on github.


### PR DESCRIPTION
Before reading the comment for #29 I didn't know that exailes translation is done on Weblate. This adds a URL so that users wanting to contribute to exaile by translating know what to do.
I know that this is no prominent position but at least it gets mentioned.