### PR TITLE
Makes the moodbar plugin work on the Preview Device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ doc/_build
 # Eclipse settings
 .project
 .pydevproject
+
+# Vim Pymode settings
+.ropeproject

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ doc/_build
 
 # Vim Pymode settings
 .ropeproject
+*.swp

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -588,7 +588,7 @@ def _enable_preview_moodbar(event, preview_plugin, nothing):
 
 
 def _disable_preview_moodbar(event, preview_plugin, nothing):
-    global ExaileModbar
+    global PreviewMoodbar
     logger.info("Disabling preview moodbar")
     PreviewMoodbar.changeModToBar()
     PreviewMoodbar.remove_callbacks()

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -554,7 +554,7 @@ class ExModbar(object):
 
 def _enable_main_moodbar(exaile):
     global ExaileModbar
-    logger.info("Enabling main moodbar")
+    logger.debug("Enabling main moodbar")
     ExaileModbar = ExModbar(
         player=player.PLAYER,
         progress_bar=exaile.gui.main.progress_bar
@@ -567,7 +567,7 @@ def _enable_main_moodbar(exaile):
 
 def _disable_main_moodbar():
     global ExaileModbar
-    logger.info("Disabling main moodbar")
+    logger.debug("Disabling main moodbar")
     ExaileModbar.changeModToBar()
     ExaileModbar.remove_callbacks()
     ExaileModbar.destroy()
@@ -576,7 +576,7 @@ def _disable_main_moodbar():
 
 def _enable_preview_moodbar(event, preview_plugin, nothing):
     global PreviewMoodbar
-    logger.info("Enabling preview moodbar")
+    logger.debug("Enabling preview moodbar")
     PreviewMoodbar = ExModbar(
         player=preview_plugin.player,
         progress_bar=preview_plugin.progress_bar
@@ -589,7 +589,7 @@ def _enable_preview_moodbar(event, preview_plugin, nothing):
 
 def _disable_preview_moodbar(event, preview_plugin, nothing):
     global PreviewMoodbar
-    logger.info("Disabling preview moodbar")
+    logger.debug("Disabling preview moodbar")
     PreviewMoodbar.changeModToBar()
     PreviewMoodbar.remove_callbacks()
     PreviewMoodbar.destroy()
@@ -613,15 +613,17 @@ def _enable(eventname, exaile, nothing):
     _enable_main_moodbar(exaile)
 
     event.add_callback(_enable_preview_moodbar, 'preview_device_enabled')
-    event.add_callback(_disable_preview_moodbar, 'preview_device_disabled')
+    event.add_callback(_disable_preview_moodbar, 'preview_device_disabling')
 
     try:
         import previewdevice
         preview_plugin = previewdevice.PREVIEW_PLUGIN
+        hooked = preview_plugin.hooked
     except ImportError:
         preview_plugin = None
+        hooked = False
 
-    if preview_plugin:
+    if hooked:  # Attach code fails unless preview player's gui is displayed
         _enable_preview_moodbar('', preview_plugin, None)
 
 
@@ -629,15 +631,17 @@ def disable(exaile):
     _disable_main_moodbar()
 
     event.remove_callback(_enable_preview_moodbar, 'preview_device_enabled')
-    event.remove_callback(_disable_preview_moodbar, 'preview_device_disabled')
+    event.remove_callback(_disable_preview_moodbar, 'preview_device_disabling')
 
     try:
         import previewdevice
         preview_plugin = previewdevice.PREVIEW_PLUGIN
+        hooked = preview_plugin.hooked
     except ImportError:
         preview_plugin = None
+        hooked = False
 
-    if preview_plugin:
+    if hooked:
         _disable_preview_moodbar('', preview_plugin, None)
 
 def get_preferences_pane():

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -552,6 +552,7 @@ class ExModbar(object):
 
 
 def _enable_main_moodbar(exaile):
+    logger.info("Enabling main moodbar")
     global ExaileModbar
     ExaileModbar = ExModbar(
         player=player.PLAYER,
@@ -564,11 +565,20 @@ def _enable_main_moodbar(exaile):
 
 
 def _disable_main_moodbar():
+    logger.info("Disabling main moodbar")
     global ExaileModbar
     ExaileModbar.changeModToBar()
     ExaileModbar.remove_callbacks()
     ExaileModbar.destroy()
     ExaileModbar = None
+
+
+def _enable_preview_moodbar(event, object, nothing):
+    logger.info("Enabling preview moodbar")
+
+
+def _disable_preview_moodbar(event, object, nothing):
+    logger.info("Disabling preview moodbar")
 
 
 def enable(exaile):
@@ -583,12 +593,17 @@ def enable(exaile):
     else:
         _enable(None, exaile, None)
 
+
 def _enable(eventname, exaile, nothing):
     _enable_main_moodbar(exaile)
+    event.add_callback(_enable_preview_moodbar, 'preview_device_enabled')
+    event.add_callback(_disable_preview_moodbar, 'preview_device_disabled')
 
 
 def disable(exaile):
     _disable_main_moodbar()
+    event.remove_callback(_enable_preview_moodbar, 'preview_device_enabled')
+    event.remove_callback(_disable_preview_moodbar, 'preview_device_disabled')
 
 
 def get_preferences_pane():

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -551,14 +551,27 @@ class ExModbar(object):
     #------------------------------------------------------------------------
 
 
-
-def enable(exaile):
+def _enable_main_moodbar(exaile):
     global ExaileModbar
-    ExaileModbar=ExModbar(
+    ExaileModbar = ExModbar(
         player=player.PLAYER,
         progress_bar=exaile.gui.main.progress_bar
     )
 
+    ExaileModbar.readMod('')
+    ExaileModbar.setupUi()
+    ExaileModbar.add_callbacks()
+
+
+def _disable_main_moodbar():
+    global ExaileModbar
+    ExaileModbar.changeModToBar()
+    ExaileModbar.remove_callbacks()
+    ExaileModbar.destroy()
+    ExaileModbar = None
+
+
+def enable(exaile):
     try:
         subprocess.call(['moodbar', '--help'], stdout=-1, stderr=-1)
     except OSError:
@@ -571,17 +584,12 @@ def enable(exaile):
         _enable(None, exaile, None)
 
 def _enable(eventname, exaile, nothing):
-    global ExaileModbar
-    ExaileModbar.readMod('')
-    ExaileModbar.setupUi()
-    ExaileModbar.add_callbacks()
+    _enable_main_moodbar(exaile)
+
 
 def disable(exaile):
-    global ExaileModbar
-    ExaileModbar.changeModToBar()
-    ExaileModbar.remove_callbacks()
-    ExaileModbar.destroy()
-    ExaileModbar = None
+    _disable_main_moodbar()
+
 
 def get_preferences_pane():
     return moodbarprefs

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -16,12 +16,13 @@
 # foundation, inc., 675 mass ave, cambridge, ma 02139, usa.
 
 import moodbarprefs
-import cgi, gtk, glib, os, os.path, subprocess, colorsys
-import inspect
-from xl import common, event, player, settings, xdg
+import gtk
+import glib
+import os
+import subprocess
+import colorsys
+from xl import event, player, settings, xdg
 from xl.nls import gettext as _
-from xlgui.preferences import widgets
-import moodbarprefs
 
 import logging
 logger = logging.getLogger(__name__)
@@ -96,23 +97,23 @@ class ExModbar(object):
              self.mod.destroy()
 
     def setupUi(self):
-              self.setuped=True
-              self.pr=self.exaile.gui.main.progress_bar
-              self.changeBarToMod()
-              self.mod.seeking=False
-              self.mod.connect("expose-event", self.drawMod)
-              self.mod.add_events(gtk.gdk.BUTTON_PRESS_MASK)
-              self.mod.add_events(gtk.gdk.BUTTON_RELEASE_MASK)
-              self.mod.add_events(gtk.gdk.POINTER_MOTION_MASK)
-              self.mod.connect("button-press-event", self.modSeekBegin)
-              self.mod.connect("button-release-event", self.modSeekEnd)
-              self.mod.connect("motion-notify-event", self.modSeekMotionNotify)
-              self.brush = self.mod.props.window.new_gc()
+            self.setuped=True
+            self.pr=self.exaile.gui.main.progress_bar
+            self.changeBarToMod()
+            self.mod.seeking=False
+            self.mod.connect("expose-event", self.drawMod)
+            self.mod.add_events(gtk.gdk.BUTTON_PRESS_MASK)
+            self.mod.add_events(gtk.gdk.BUTTON_RELEASE_MASK)
+            self.mod.add_events(gtk.gdk.POINTER_MOTION_MASK)
+            self.mod.connect("button-press-event", self.modSeekBegin)
+            self.mod.connect("button-release-event", self.modSeekEnd)
+            self.mod.connect("motion-notify-event", self.modSeekMotionNotify)
+            self.brush = self.mod.props.window.new_gc()
 
 
-              track = player.PLAYER.current
+            track = player.PLAYER.current
 
-              self.lookformod(track)
+            self.lookformod(track)
 
     def destroy(self):
          if self.modTimer: glib.source_remove(self.modTimer)
@@ -252,7 +253,7 @@ class ExModbar(object):
            g=float(ord(self.moodbar[int(x*1000/width)*3+1]))/256
            b=float(ord(self.moodbar[int(x*1000/width)*3+2]))/256
            if (self.theme or self.defaultstyle):
-		          c1,c2,c3=colorsys.rgb_to_yiq(r, g, b)
+                c1,c2,c3=colorsys.rgb_to_yiq(r, g, b)
 
            if (self.theme):
                 c2=c2+self.ivalue
@@ -265,8 +266,8 @@ class ExModbar(object):
                 r,g,b=colorsys.yiq_to_rgb(0.5,c2,c3)
                 waluelength=int(c1*24)
            else:
-			    if self.theme:
-				    r,g,b=colorsys.yiq_to_rgb(c1,c2,c3)
+                if self.theme:
+                    r,g,b=colorsys.yiq_to_rgb(c1,c2,c3)
            if not self.defaultstyle:
                 buff=''
                 for h in range(24):
@@ -570,7 +571,3 @@ def get_preferences_pane():
 #python: ../../src/xcb_io.c:176: process_responses: Assertion `!(req && current_request && !(((long) (req->sequence) - (long) (current_request)) <= 0))' failed.
 
 #0.0.4 haven't errors
-
-
-
-

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -637,7 +637,7 @@ def disable(exaile):
         import previewdevice
         preview_plugin = previewdevice.PREVIEW_PLUGIN
         hooked = preview_plugin.hooked
-    except ImportError:
+    except (ImportError, AttributeError):
         preview_plugin = None
         hooked = False
 

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -43,6 +43,9 @@ from xlgui.widgets import menu, playback
 
 import previewprefs
 
+import logging
+logger = logging.getLogger(__name__)
+
 PREVIEW_PLUGIN = None
 
 
@@ -107,9 +110,12 @@ class SecondaryOutputPlugin(object):
             self._init_gui_hooks()
 
         # We're ready; teall anyone who might be interested
-        event.log_event('preview_device_enabled', self, None)
+        logger.debug('Preview Device Enabled')
+        # event.log_event('preview_device_enabled', self, None)
 
     def disable_plugin(self, exaile):
+        logger.debug('Disabling Preview Device')
+        event.log_event('preview_device_disabling', self, None)
         self._destroy_gui_hooks()
         self._destroy_gui()
         self.player.stop()
@@ -117,8 +123,7 @@ class SecondaryOutputPlugin(object):
         self.player = None
         self.queue = None
 
-        # We're all through; tell anyone who might be interested
-        event.log_event('preview_device_disabled', self, None)
+        logger.debug('Preview Device Disabled')
 
     def _init_gui(self):
         self.pane = gtk.HPaned()
@@ -251,6 +256,9 @@ class SecondaryOutputPlugin(object):
         self.hooked = True
         settings.set_option('plugin/previewdevice/shown', True)
 
+        logger.debug("Preview device gui hooked")
+        event.log_event('preview_device_enabled', self, None)
+
     def _destroy_gui_hooks(self):
         '''
             Removes any hooks from the main Exaile GUI
@@ -283,6 +291,7 @@ class SecondaryOutputPlugin(object):
 
         self.hooked = False
         settings.set_option('plugin/previewdevice/shown', False)
+        logger.debug('Preview device unhooked')
 
     #
     # Menu events

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -135,11 +135,11 @@ class SecondaryOutputPlugin(object):
             self._on_playpause_button_clicked
         )
 
-        progress_bar = playback.SeekProgressBar(self.player, use_markers=False)
+        self.progress_bar = playback.SeekProgressBar(self.player, use_markers=False)
 
         play_toolbar = gtk.HBox()
         play_toolbar.pack_start(self.playpause_button, expand=False, fill=False)
-        play_toolbar.pack_start(progress_bar)
+        play_toolbar.pack_start(self.progress_bar)
 
         # stick our player controls into this box
         self.pane1_box = gtk.VBox()

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -107,7 +107,7 @@ class SecondaryOutputPlugin(object):
             self._init_gui_hooks()
 
         # We're ready; teall anyone who might be interested
-        event.log_event('previewdevice_enabled', self, None)
+        event.log_event('preview_device_enabled', self, None)
 
     def disable_plugin(self, exaile):
         self._destroy_gui_hooks()
@@ -118,7 +118,7 @@ class SecondaryOutputPlugin(object):
         self.queue = None
 
         # We're all through; tell anyone who might be interested
-        event.log_event('previewdevice_disabled', self, None)
+        event.log_event('preview_device_disabled', self, None)
 
     def _init_gui(self):
         self.pane = gtk.HPaned()

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -106,6 +106,9 @@ class SecondaryOutputPlugin(object):
         if settings.get_option('plugin/previewdevice/shown', True):
             self._init_gui_hooks()
 
+        # We're ready; teall anyone who might be interested
+        event.log_event('previewdevice_enabled', self, None)
+
     def disable_plugin(self, exaile):
         self._destroy_gui_hooks()
         self._destroy_gui()
@@ -113,6 +116,9 @@ class SecondaryOutputPlugin(object):
 
         self.player = None
         self.queue = None
+
+        # We're all through; tell anyone who might be interested
+        event.log_event('previewdevice_disabled', self, None)
 
     def _init_gui(self):
         self.pane = gtk.HPaned()

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -24,12 +24,9 @@
 # do so. If you do not wish to do so, delete this exception statement
 # from your version.
 
-import glib
 import gtk
-import gobject
 
 import os
-import time
 
 from xl import (
     event,
@@ -42,7 +39,7 @@ from xl import (
 from xl.nls import gettext as _
 
 from xlgui import guiutil, main
-from xlgui.widgets import menu, dialogs, playback
+from xlgui.widgets import menu, playback
 
 import previewprefs
 

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -30,9 +30,9 @@ import gobject
 
 import os
 import time
- 
+
 from xl import (
-    event, 
+    event,
     providers,
     player,
     settings,
@@ -52,70 +52,74 @@ PREVIEW_PLUGIN = None
 def get_preferences_pane():
     return previewprefs
 
+
 def enable(exaile):
     '''Called on plugin enable'''
     if exaile.loading:
         event.add_callback(_enable, 'gui_loaded')
     else:
         _enable(None, exaile, None)
-        
+
+
 def _enable(eventname, exaile, nothing):
 
     global PREVIEW_PLUGIN
     PREVIEW_PLUGIN = SecondaryOutputPlugin(exaile)
-    
+
+
 def disable(exaile):
     '''Called on plugin disable'''
-    
+
     global PREVIEW_PLUGIN
     if PREVIEW_PLUGIN is not None:
         PREVIEW_PLUGIN.disable_plugin(exaile)
         PREVIEW_PLUGIN = None
-        
+
 
 class SecondaryOutputPlugin(object):
     '''Implements logic for plugin'''
-    
+
     def __init__(self, exaile):
-    
+
         self.exaile = exaile
         self.hooked = False
         self.resuming = False
-    
+
         #
         # Initialize the player objects needed
         #
-    
+
         self.player = player.get_player('preview_device')
-        self.queue = player.queue.PlayQueue( self.player, 
-                                             location=os.path.join(xdg.get_data_dir(), 'preview_device_queue.state'),
-                                             name='Preview Device Queue')
-        
+        self.queue = player.queue.PlayQueue(
+            self.player,
+            location=os.path.join(
+                xdg.get_data_dir(),
+                'preview_device_queue.state'
+            ),
+            name='Preview Device Queue'
+        )
+
         #
         # Initialize the GUI stuff
         #
-    
+
         self._init_gui()
-        
+
         # preserve state
         if settings.get_option('plugin/previewdevice/shown', True):
             self._init_gui_hooks()
-    
-    
+
     def disable_plugin(self, exaile):
-    
         self._destroy_gui_hooks()
         self._destroy_gui()
         self.player.stop()
-        
+
         self.player = None
         self.queue = None
-        
-        
+
     def _init_gui(self):
-    
         self.pane = gtk.HPaned()
-        
+
         # stolen from main
         self.info_area = main.MainWindowTrackInfoPane(self.player)
         self.info_area.set_auto_update(True)
@@ -125,67 +129,74 @@ class SecondaryOutputPlugin(object):
 
         volume_control = playback.VolumeControl(self.player)
         self.info_area.get_action_area().pack_start(volume_control)
-        
+
         self.playpause_button = gtk.Button()
         self.playpause_button.set_relief(gtk.RELIEF_NONE)
         self._on_playback_end(None, None, None)
-        self.playpause_button.connect('button-press-event', self._on_playpause_button_clicked)
-        
+        self.playpause_button.connect(
+            'button-press-event',
+            self._on_playpause_button_clicked
+        )
+
         progress_bar = playback.SeekProgressBar(self.player, use_markers=False)
-        
+
         play_toolbar = gtk.HBox()
         play_toolbar.pack_start(self.playpause_button, expand=False, fill=False)
         play_toolbar.pack_start(progress_bar)
-        
+
         # stick our player controls into this box
         self.pane1_box = gtk.VBox()
-        
+
         self.pane2_box = gtk.VBox()
         self.pane2_box.pack_start(self.info_area, expand=False, fill=False)
-        self.pane2_box.pack_start(play_toolbar, expand=False, fill=False) 
-        
+        self.pane2_box.pack_start(play_toolbar, expand=False, fill=False)
+
         self.pane.pack1(self.pane1_box, resize=True, shrink=True)
         self.pane.pack2(self.pane2_box, resize=True, shrink=True)
-        
+
         # setup menus
-        
-        # add menu item to 'view' to display our playlist 
-        self.menu = menu.check_menu_item('preview_player', '', _('Preview Player'), \
-            lambda *e: self.hooked, self._on_view )
-            
+
+        # add menu item to 'view' to display our playlist
+        self.menu = menu.check_menu_item(
+            'preview_player',
+            '',
+            _('Preview Player'),
+            lambda *e: self.hooked,
+            self._on_view
+        )
+
         providers.register('menubar-view-menu', self.menu)
-        
-        self.preview_menuitem = menu.simple_menu_item('_preview', ['enqueue'], 
+
+        self.preview_menuitem = menu.simple_menu_item('_preview', ['enqueue'],
                 _('Preview'), callback=self._on_preview,
-                condition_fn=lambda n,p,c: not c['selection-empty'])
-        
+                condition_fn=lambda n, p, c: not c['selection-empty'])
+
         # TODO: Setup on other context menus
-        self.preview_provides = [ 'track-panel-menu',
-                                  'playlist-context-menu']
-        
+        self.preview_provides = [
+            'track-panel-menu',
+            'playlist-context-menu',
+        ]
+
         for provide in self.preview_provides:
             providers.register(provide, self.preview_menuitem)
-        
+
         self._on_option_set('gui_option_set', settings, 'gui/show_info_area')
         self._on_option_set('gui_option_set', settings, 'gui/show_info_area_covers')
         event.add_callback(self._on_option_set, 'option_set')
 
-        
     def _destroy_gui(self):
-    
         event.remove_callback(self._on_option_set, 'option_set')
-        
+
         for provide in self.preview_provides:
             providers.unregister(provide, self.preview_menuitem)
         providers.unregister('menubar-view-menu', self.menu)
-        
+
         self.info_area.destroy()
         self.playpause_button.destroy()
-        
+
         self.pane2_box.destroy()
         self.pane1_box.destroy()
         self.pane.destroy()
-      
 
     def _setup_events(self, setup):
         setup(self._on_playback_resume, 'playback_player_resume', self.player)
@@ -193,122 +204,115 @@ class SecondaryOutputPlugin(object):
         setup(self._on_playback_error, 'playback_error', self.player)
         setup(self._on_playback_start, 'playback_track_start', self.player)
         setup(self._on_toggle_pause, 'playback_toggle_pause', self.player)
-        
-        
+
     def _init_gui_hooks(self):
         '''
             Initializes any hooks into the main Exaile GUI
-            
+
             Note that this is rather ugly, but currently exaile doesn't really
             have a better way to do this, and there isn't a better place to
-            stick our gui objects. 
+            stick our gui objects.
         '''
-    
+
         if self.hooked:
             return
-        
+
         # the info_area will be where we sit, and the info_area
         # will be duplicated for two sides
-        
+
         # need to move the play_toolbar, and duplicate it
         # also once for each side
-        
+
         info_area = main.mainwindow().info_area
         play_toolbar = main.mainwindow().builder.get_object('play_toolbar')
-    
+
         parent = play_toolbar.get_parent()
         parent.remove(play_toolbar)
-        
+
         parent = info_area.get_parent()
         parent.remove(info_area)
-        
+
         parent.pack_start(self.pane, expand=False, fill=False)
         parent.reorder_child(self.pane, 0)
-        
+
         # stick the main player controls into this box
         self.pane1_box.pack_start(info_area, expand=False, fill=False)
-        self.pane1_box.pack_start(play_toolbar, expand=False, fill=False) 
-        
+        self.pane1_box.pack_start(play_toolbar, expand=False, fill=False)
+
         # and do it
         self.pane.show_all()
-        
+
         # add player events
         self._setup_events(event.add_callback)
-        
+
         self.hooked = True
         settings.set_option('plugin/previewdevice/shown', True)
-        
-            
+
     def _destroy_gui_hooks(self):
         '''
             Removes any hooks from the main Exaile GUI
         '''
-        
+
         if not self.hooked:
             return
-    
+
         info_area = main.mainwindow().info_area
         play_toolbar = main.mainwindow().builder.get_object('play_toolbar')
-        
+
         # detach main GUI elements
         parent = play_toolbar.get_parent()
         parent.remove(play_toolbar)
-        
+
         parent = info_area.get_parent()
         parent.remove(info_area)
-        
+
         # detach the element we added to hold them
         parent = self.pane.get_parent()
         parent.remove(self.pane)
-        
+
         # reattach
         parent.pack_start(info_area, expand=False, fill=False)
         parent.reorder_child(info_area, 0)
         parent.pack_start(play_toolbar, expand=False, fill=False)
-        
+
         # remove player events
-        self._setup_events( event.remove_callback )
-    
+        self._setup_events(event.remove_callback)
+
         self.hooked = False
         settings.set_option('plugin/previewdevice/shown', False)
-        
-        
+
     #
     # Menu events
     #
-    
+
     def _on_view(self, menu, name, parent, context):
         if self.hooked:
             self._destroy_gui_hooks()
         else:
             self._init_gui_hooks()
-    
+
     def _on_preview(self, menu, display_name, playlist_view, context):
         self._init_gui_hooks()
         tracks = context['selected-tracks']
         if len(tracks) > 0:
             self.queue.play(tracks[0])
-        
-    
+
     #
     # Various player events
     #
-    
+
     def _on_playpause_button_clicked(self, widget, event):
         """
             Called when the play button is clicked
         """
-        
+
         if event.button == 1:
             if event.type == gtk.gdk.BUTTON_PRESS and \
-                (self.player.is_paused() or self.player.is_playing()):
-                
+                    (self.player.is_paused() or self.player.is_playing()):
                 self.player.toggle_pause()
-                
             elif event.type == gtk.gdk._2BUTTON_PRESS:
                 self.player.stop()
-        
-        
+
     @guiutil.idle_add()
     def _on_option_set(self, name, object, option):
         """
@@ -321,9 +325,9 @@ class SecondaryOutputPlugin(object):
             else:
                 self.info_area.hide_all()
             self.info_area.set_no_show_all(True)
-            
+
         elif option == 'gui/show_info_area_covers':
-            cover = self.info_area.cover     
+            cover = self.info_area.cover
             cover.set_no_show_all(False)
             if settings.get_option(option, True):
                 cover.show_all()
@@ -345,30 +349,32 @@ class SecondaryOutputPlugin(object):
             self.resuming = False
             return
 
-        image = gtk.image_new_from_stock(gtk.STOCK_MEDIA_PAUSE, 
+        image = gtk.image_new_from_stock(gtk.STOCK_MEDIA_PAUSE,
                                          gtk.ICON_SIZE_BUTTON)
         self.playpause_button.set_image(image)
-        self.playpause_button.set_tooltip_text( _('Pause Playback (double click to stop)') )
+        self.playpause_button.set_tooltip_text(
+            _('Pause Playback (double click to stop)'))
 
     @guiutil.idle_add()
     def _on_playback_end(self, type, player, object):
         """
             Called when playback ends
         """
-        
-        image = gtk.image_new_from_stock(gtk.STOCK_MEDIA_PLAY, 
+
+        image = gtk.image_new_from_stock(gtk.STOCK_MEDIA_PLAY,
                                          gtk.ICON_SIZE_BUTTON)
         self.playpause_button.set_image(image)
-        self.playpause_button.set_tooltip_text( _('Start Playback'))
-        
+        self.playpause_button.set_tooltip_text(_('Start Playback'))
+
     @guiutil.idle_add()
     def _on_playback_error(self, type, player, message):
         """
             Called when there has been a playback error
         """
-        main.mainwindow().message.show_error( _('Playback error encountered!'), message)
-        
-    @guiutil.idle_add()    
+        main.mainwindow().message.show_error(
+            _('Playback error encountered!'), message)
+
+    @guiutil.idle_add()
     def _on_toggle_pause(self, type, player, object):
         """
             Called when the user clicks the play button after playback has
@@ -385,5 +391,3 @@ class SecondaryOutputPlugin(object):
 
         self.playpause_button.set_image(image)
         self.playpause_button.set_tooltip_text(tooltip)
-        
-            


### PR DESCRIPTION
I like the info the moodbar gives me but I find I want it more from the preview device than the main player (because I'm previewing stuff live to decide what to play). This PR refactors the moodbar somewhat to abstract out the dependencies on the player and its gui, and then applies another instance to the preview device, when that is activated. To make this work  I have added a couple of events to the preview device, and made it keep a reference to its progress bar which the moodbar plugin can see. 
I think I'm at a point where I'm ready to invite you to review and comment. 
* I've also added a couple of logger.debugs which you might prefer to have removed?
* Should I also change the minor versions of the two plugins to reflect the changes?
* I've had to play with the possible enable/disable sequences of the two plugins to make sure they work and don't break. I don't understand how the gui stuff actually works, so some of this was trial-and-error. You might know better. 
* Any other suggestions?
Thanks -- Mark