### PR TITLE
Reduce linter noise for previewdevice and moodar plugins

### DIFF
--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -16,44 +16,47 @@
 # foundation, inc., 675 mass ave, cambridge, ma 02139, usa.
 
 import moodbarprefs
-import cgi, gtk, glib, os, os.path, subprocess, colorsys
-import inspect
-from xl import common, event, player, settings, xdg
+import gtk
+import glib
+import os
+import subprocess
+import colorsys
+from xl import event, player, settings, xdg
 from xl.nls import gettext as _
-from xlgui.preferences import widgets
-import moodbarprefs
 
 import logging
 logger = logging.getLogger(__name__)
 
 ExaileModbar = None
 
+
 class ExModbar(object):
 
-    #Setup and getting values------------------------------------------------
+    # Setup and getting values------------------------------------------------
 
     def __init__(self):
-         self.moodbar=''
-         self.buff=''
-         self.brush=None
-         self.modwidth=0
-         self.curpos=0
-         self.modTimer=None
-         self.haveMod=False
-         self.playingTrack=''
-         self.seeking=False
-         self.setuped=False
-         self.runed=False
-         self.pid=0
-         self.uptime=0
-         self.ivalue=0
-         self.qvalue=0
-         self.moodsDir=os.path.join(xdg.get_cache_dir(), "moods")
-         if not os.path.exists(self.moodsDir):
-             os.mkdir(self.moodsDir)
+        self.moodbar = ''
+        self.buff = ''
+        self.brush = None
+        self.modwidth = 0
+        self.curpos = 0
+        self.modTimer = None
+        self.haveMod = False
+        self.playingTrack = ''
+        self.seeking = False
+        self.setuped = False
+        self.runed = False
+        self.pid = 0
+        self.uptime = 0
+        self.ivalue = 0
+        self.qvalue = 0
+        self.moodsDir = os.path.join(xdg.get_cache_dir(), "moods")
+        if not os.path.exists(self.moodsDir):
+            os.mkdir(self.moodsDir)
 
     def __inner_preference(klass):
         """functionality copy from notyfication"""
+
         def getter(self):
             return settings.get_option(klass.name, klass.default or None)
 
@@ -69,249 +72,250 @@ class ExModbar(object):
 
     darkness = __inner_preference(moodbarprefs.DarknessPreference)
     color = __inner_preference(moodbarprefs.ColorPreference)
+
     def set_ex(self, ex):
-         self.exaile=ex
+        self.exaile = ex
 
     def get_size(self):
-         progress_loc = self.mod.get_allocation()
-         return progress_loc.width
+        progress_loc = self.mod.get_allocation()
+        return progress_loc.width
 
     #Setup-------------------------------------------------------------------
 
     def changeBarToMod(self):
-         place=self.pr.get_parent()
-         self.mod = gtk.DrawingArea()
-         self.mod.pangolayout = self.mod.create_pango_layout("")
-         self.mod.set_size_request(-1, 24)
-         place.remove(self.pr)
-         place.add(self.mod)
-         self.mod.realize()
-         self.mod.show()
+        place = self.pr.get_parent()
+        self.mod = gtk.DrawingArea()
+        self.mod.pangolayout = self.mod.create_pango_layout("")
+        self.mod.set_size_request(-1, 24)
+        place.remove(self.pr)
+        place.add(self.mod)
+        self.mod.realize()
+        self.mod.show()
 
     def changeModToBar(self):
-         if hasattr(self, 'mod'):
-             place=self.mod.get_parent()
-             place.remove(self.mod)
-             place.add(self.pr)
-             self.mod.destroy()
+        if hasattr(self, 'mod'):
+            place = self.mod.get_parent()
+            place.remove(self.mod)
+            place.add(self.pr)
+            self.mod.destroy()
 
     def setupUi(self):
-              self.setuped=True
-              self.pr=self.exaile.gui.main.progress_bar
-              self.changeBarToMod()
-              self.mod.seeking=False
-              self.mod.connect("expose-event", self.drawMod)
-              self.mod.add_events(gtk.gdk.BUTTON_PRESS_MASK)
-              self.mod.add_events(gtk.gdk.BUTTON_RELEASE_MASK)
-              self.mod.add_events(gtk.gdk.POINTER_MOTION_MASK)
-              self.mod.connect("button-press-event", self.modSeekBegin)
-              self.mod.connect("button-release-event", self.modSeekEnd)
-              self.mod.connect("motion-notify-event", self.modSeekMotionNotify)
-              self.brush = self.mod.props.window.new_gc()
+        self.setuped = True
+        self.pr = self.exaile.gui.main.progress_bar
+        self.changeBarToMod()
+        self.mod.seeking = False
+        self.mod.connect("expose-event", self.drawMod)
+        self.mod.add_events(gtk.gdk.BUTTON_PRESS_MASK)
+        self.mod.add_events(gtk.gdk.BUTTON_RELEASE_MASK)
+        self.mod.add_events(gtk.gdk.POINTER_MOTION_MASK)
+        self.mod.connect("button-press-event", self.modSeekBegin)
+        self.mod.connect("button-release-event", self.modSeekEnd)
+        self.mod.connect("motion-notify-event", self.modSeekMotionNotify)
+        self.brush = self.mod.props.window.new_gc()
 
+        track = player.PLAYER.current
 
-              track = player.PLAYER.current
-
-              self.lookformod(track)
+        self.lookformod(track)
 
     def destroy(self):
-         if self.modTimer: glib.source_remove(self.modTimer)
+        if self.modTimer: glib.source_remove(self.modTimer)
 
+    # playing ----------------------------------------------------------------
 
-    #playing ----------------------------------------------------------------
+    def lookformod(self, track):
+        if not track or not (track.is_local() or track.get_tag_raw('__length')):
+            self.haveMod = False
+            return
 
-    def lookformod(self,track):
-         if not track or not (track.is_local() or track.get_tag_raw('__length')):
-             self.haveMod=False
-             return
+        self.playingTrack = str(track.get_loc_for_io())
+        self.playingTrack = self.playingTrack.replace("file://", "")
+        modLoc = self.moodsDir + '/' + self.playingTrack.replace('/',
+                                                                 '-') + ".mood"
+        modLoc = modLoc.replace("'", '')
+        needGen = False
+        self.curpos = player.PLAYER.get_progress()
+        if os.access(modLoc, 0):
+            self.modwidth = 0
+            if not self.readMod(modLoc):
+                needGen = True
+            self.updateplayerpos()
+        else:
+            needGen = True
+        if needGen:
+            self.pid = subprocess.Popen(['/usr/bin/moodbar',
+                                         track.get_local_path(), '-o', modLoc])
+        self.haveMod = not needGen
 
-         self.playingTrack=str(track.get_loc_for_io())
-         self.playingTrack=self.playingTrack.replace("file://","")
-         modLoc=self.moodsDir+'/'+ self.playingTrack.replace('/','-')+".mood"
-         modLoc=modLoc.replace("'",'')
-         needGen=False
-         self.curpos=player.PLAYER.get_progress()
-         if os.access(modLoc, 0):
-             self.modwidth=0
-             if not self.readMod(modLoc):
-                 needGen=True
-             self.updateplayerpos()
-         else: needGen=True
-         if needGen:
-             self.pid = subprocess.Popen(['/usr/bin/moodbar',
-                 track.get_local_path(), '-o', modLoc])
-         self.haveMod=not needGen
-
-         if self.modTimer: glib.source_remove(self.modTimer)
-         self.modTimer = glib.timeout_add_seconds(1, self.updateMod)
-
+        if self.modTimer: glib.source_remove(self.modTimer)
+        self.modTimer = glib.timeout_add_seconds(1, self.updateMod)
 
     def play_start(self, type, player, track):
-         self.lookformod(track)
+        self.lookformod(track)
 
-    def play_end (self, type, player, track):
-         if self.modTimer: glib.source_remove(self.modTimer)
-         self.modTimer = None
-         self.haveMod = False
-         self.mod.queue_draw_area(0, 0, self.get_size(), 24)
+    def play_end(self, type, player, track):
+        if self.modTimer: glib.source_remove(self.modTimer)
+        self.modTimer = None
+        self.haveMod = False
+        self.mod.queue_draw_area(0, 0, self.get_size(), 24)
 
-    #update player's ui -----------------------------------------------------
+    # update player's ui -----------------------------------------------------
 
     def updateMod(self):
-         self.updateplayerpos()
-         if not self.haveMod:
-           logger.debug(_('Searching for mood...'))
-           modLoc=self.moodsDir+'/'+ self.playingTrack.replace('/','-')+".mood"
-           modLoc=modLoc.replace("'",'')
-           if self.readMod(modLoc):
-              logger.debug(_("Mood found."))
-              self.haveMod=True
-              self.modwidth=0
-         self.modTimer = glib.timeout_add_seconds(1, self.updateMod)
+        self.updateplayerpos()
+        if not self.haveMod:
+            logger.debug(_('Searching for mood...'))
+            modLoc = self.moodsDir + '/' + self.playingTrack.replace(
+                '/', '-') + ".mood"
+            modLoc = modLoc.replace("'", '')
+            if self.readMod(modLoc):
+                logger.debug(_("Mood found."))
+                self.haveMod = True
+                self.modwidth = 0
+        self.modTimer = glib.timeout_add_seconds(1, self.updateMod)
 
     def updateplayerpos(self):
-         if self.modTimer: self.curpos=player.PLAYER.get_progress()
-         self.mod.queue_draw_area(0, 0, self.get_size(), 24)
-
+        if self.modTimer: self.curpos = player.PLAYER.get_progress()
+        self.mod.queue_draw_area(0, 0, self.get_size(), 24)
 
     #reading mod from file and update mood preview --------------------------
 
     def readMod(self, moodLoc):
-       retur=True
-       self.moodbar=''
-       try:
-          if moodLoc=='':
-             for i in range(3000):
-                  self.moodbar=self.moodbar+chr(255)
-             return True
-          else:
-             f=open(moodLoc,'rb')
-             for i in range(3000):
-                 r=f.read(1)
-                 if r=='':
-                      r=chr(0)
-                      retur=False
-                 self.moodbar=self.moodbar+r
-             f.close()
-             return retur
+        retur = True
+        self.moodbar = ''
+        try:
+            if moodLoc == '':
+                for i in range(3000):
+                    self.moodbar = self.moodbar + chr(255)
+                return True
+            else:
+                f = open(moodLoc, 'rb')
+                for i in range(3000):
+                    r = f.read(1)
+                    if r == '':
+                        r = chr(0)
+                        retur = False
+                    self.moodbar = self.moodbar + r
+                f.close()
+                return retur
 
-       except:
-          logger.debug(_('Could not read moodbar.'))
-          self.moodbar=''
-          for i in range(3000):
-              self.moodbar=self.moodbar+chr(0)
-          return False
-
+        except:
+            logger.debug(_('Could not read moodbar.'))
+            self.moodbar = ''
+            for i in range(3000):
+                self.moodbar = self.moodbar + chr(0)
+            return False
 
     def genBuff(self):
-        width=self.get_size()
-        self.modwidth=width
-        darkmulti=(1-self.darkness/10)
+        width = self.get_size()
+        self.modwidth = width
+        darkmulti = (1 - self.darkness / 10)
 
         #logger.info(darkmulti)
-        hh=[0.2,0.4,0.7,0.8,0.9,1,1,0.98,0.93,0.85,0.80,0.80,0.80,
-                0.85,0.93,0.98,1,1,0.9,0.8,0.7,0.6,0.4,0.2]
+        hh = [0.2, 0.4, 0.7, 0.8, 0.9, 1, 1, 0.98, 0.93, 0.85, 0.80, 0.80,
+              0.80, 0.85, 0.93, 0.98, 1, 1, 0.9, 0.8, 0.7, 0.6, 0.4, 0.2]
         #hh=[0.5,0.55,0.6,0.65,0.7,1,0.95,0.92,0.88,0.84,0.80,0.80,
         #0.80,0.84,0.88,0.92,0.95,1,0.7,0.65,0.6,0.55,0.5,0.45]
         #hh=[0.2,0.4,0.7,0.8,0.9,1,1,1,1,1,1,1,1,1,1,1,1,1,0.9,0.8,
         # 0.7,0.6,0.4,0.2]
-        self.defaultstyle_old =self.defaultstyle
-        self.theme_old=self.theme
-        self.flat_old=self.flat
-        self.color_old =self.color
-        self.darkness_old =self.darkness
-        self.cursor_old=self.cursor
+        self.defaultstyle_old = self.defaultstyle
+        self.theme_old = self.theme
+        self.flat_old = self.flat
+        self.color_old = self.color
+        self.darkness_old = self.darkness
+        self.cursor_old = self.cursor
         gc = self.brush
         self.bgcolor = self.mod.style.bg[gtk.STATE_NORMAL]
-        redf=self.bgcolor.red/255
-        greenf=self.bgcolor.green/255
-        bluef=self.bgcolor.blue/255
-        colortheme=gtk.gdk.Color(self.color)
-        c1,self.ivalue,self.qvalue=colorsys.rgb_to_yiq(float(colortheme.red)/256/256, float(colortheme.green)/256/256, float(colortheme.blue)/256/256)
-        gc.foreground = self.bgcolor;
-        gc.line_width=1
+        redf = self.bgcolor.red / 255
+        greenf = self.bgcolor.green / 255
+        bluef = self.bgcolor.blue / 255
+        colortheme = gtk.gdk.Color(self.color)
+        c1, self.ivalue, self.qvalue = colorsys.rgb_to_yiq(
+            float(colortheme.red) / 256 / 256, float(colortheme.green) / 256 /
+            256, float(colortheme.blue) / 256 / 256)
+        gc.foreground = self.bgcolor
+        gc.line_width = 1
         self.pixmap = gtk.gdk.Pixmap(self.mod.window, width, 24)
         self.pixmap2 = gtk.gdk.Pixmap(self.mod.window, width, 24)
         self.pixmap.draw_rectangle(gc, True, 0, 0, self.modwidth, 24)
         self.pixmap2.draw_rectangle(gc, True, 0, 0, self.modwidth, 24)
         if self.flat:
-             if self.theme:
-                flatcolor1r=float(colortheme.red)/256/256
-                flatcolor1g=float(colortheme.green)/256/256
-                flatcolor1b=float(colortheme.blue)/256/256
-                flatcolor2r=darkmulti*float(colortheme.red)/256/256
-                flatcolor2g=darkmulti*float(colortheme.green)/256/256
-                flatcolor2b=darkmulti*float(colortheme.blue)/256/256
-             else:
-                flatcolor1r=flatcolor1g=flatcolor1b=0.5
-                flatcolor2r=flatcolor2g=flatcolor2b=0.5*darkmulti
+            if self.theme:
+                flatcolor1r = float(colortheme.red) / 256 / 256
+                flatcolor1g = float(colortheme.green) / 256 / 256
+                flatcolor1b = float(colortheme.blue) / 256 / 256
+                flatcolor2r = darkmulti * float(colortheme.red) / 256 / 256
+                flatcolor2g = darkmulti * float(colortheme.green) / 256 / 256
+                flatcolor2b = darkmulti * float(colortheme.blue) / 256 / 256
+            else:
+                flatcolor1r = flatcolor1g = flatcolor1b = 0.5
+                flatcolor2r = flatcolor2g = flatcolor2b = 0.5 * darkmulti
         #render ---------------------------------------------------------
         for x in range(width):
-        #reading color
-           r=float(ord(self.moodbar[int(x*1000/width)*3]))/256
-           g=float(ord(self.moodbar[int(x*1000/width)*3+1]))/256
-           b=float(ord(self.moodbar[int(x*1000/width)*3+2]))/256
-           if (self.theme or self.defaultstyle):
-		          c1,c2,c3=colorsys.rgb_to_yiq(r, g, b)
+            #reading color
+            r = float(ord(self.moodbar[int(x * 1000 / width) * 3])) / 256
+            g = float(ord(self.moodbar[int(x * 1000 / width) * 3 + 1])) / 256
+            b = float(ord(self.moodbar[int(x * 1000 / width) * 3 + 2])) / 256
+            if (self.theme or self.defaultstyle):
+                c1, c2, c3 = colorsys.rgb_to_yiq(r, g, b)
 
-           if (self.theme):
-                c2=c2+self.ivalue
-                if c2>1: c2=1
-                if c2<-1: c2=-1
-                c3=c3+self.qvalue
-                if c3>1: c3=1
-                if c3<-1: c3=-1
-           if self.defaultstyle:
-                r,g,b=colorsys.yiq_to_rgb(0.5,c2,c3)
-                waluelength=int(c1*24)
-           else:
-			    if self.theme:
-				    r,g,b=colorsys.yiq_to_rgb(c1,c2,c3)
-           if not self.defaultstyle:
-                buff=''
+            if (self.theme):
+                c2 = c2 + self.ivalue
+                if c2 > 1: c2 = 1
+                if c2 < -1: c2 = -1
+                c3 = c3 + self.qvalue
+                if c3 > 1: c3 = 1
+                if c3 < -1: c3 = -1
+            if self.defaultstyle:
+                r, g, b = colorsys.yiq_to_rgb(0.5, c2, c3)
+                waluelength = int(c1 * 24)
+            else:
+                if self.theme:
+                    r, g, b = colorsys.yiq_to_rgb(c1, c2, c3)
+            if not self.defaultstyle:
+                buff = ''
                 for h in range(24):
-                   buff=buff+chr(int(r*255*hh[h]+redf*(1-hh[h])))+chr(int(g*255*hh[h]+greenf*(1-hh[h])))+chr(int(b*255*hh[h]+bluef*(1-hh[h])))
+                    buff = buff + chr(int(r * 255 * hh[h] + redf * (
+                        1 - hh[h]))) + chr(int(g * 255 * hh[h] + greenf *
+                                               (1 - hh[h]))) + chr(int(
+                                                   b * 255 * hh[h] + bluef *
+                                                   (1 - hh[h])))
                 self.pixmap.draw_rgb_image(gc, x, 0, 1, 24,
-                         gtk.gdk.RGB_DITHER_NONE, buff, 3)
+                                           gtk.gdk.RGB_DITHER_NONE, buff, 3)
 
                 if self.cursor:
-                   buff2=''
-                   for h in range(24*3):
-                         buff2=buff2+chr(int(ord(buff[h])*(darkmulti+(1-darkmulti)*(1-hh[int(h/3)]))))
+                    buff2 = ''
+                    for h in range(24 * 3):
+                        buff2 = buff2 + chr(int(ord(buff[h]) *
+                                                (darkmulti + (1 - darkmulti) *
+                                                 (1 - hh[int(h / 3)]))))
 
-                   self.pixmap2.draw_rgb_image(gc, x, 0, 1, 24,
-                         gtk.gdk.RGB_DITHER_NONE, buff2, 3)
+                    self.pixmap2.draw_rgb_image(gc, x, 0, 1, 24,
+                                                gtk.gdk.RGB_DITHER_NONE, buff2,
+                                                3)
 
-           else:
+            else:
                 if self.flat:
-                   gc.foreground = self.mod.get_colormap().alloc_color(
-                      int(flatcolor1r*0xFFFF),
-                      int(flatcolor1g*0xFFFF),
-                      int(flatcolor1b*0xFFFF)
-                   )
+                    gc.foreground = self.mod.get_colormap().alloc_color(
+                        int(flatcolor1r * 0xFFFF), int(flatcolor1g * 0xFFFF),
+                        int(flatcolor1b * 0xFFFF))
                 else:
-                   gc.foreground = self.mod.get_colormap().alloc_color(
-                      int(r*0xFFFF),
-                      int(g*0xFFFF),
-                      int(b*0xFFFF)
-                   )
-                self.pixmap.draw_line(gc, x, 13-waluelength, x, 12+waluelength)
+                    gc.foreground = self.mod.get_colormap().alloc_color(
+                        int(r * 0xFFFF), int(g * 0xFFFF), int(b * 0xFFFF))
+                self.pixmap.draw_line(gc, x, 13 - waluelength, x,
+                                      12 + waluelength)
 
                 if self.cursor:
-                  if self.flat:
-                     gc.foreground = self.mod.get_colormap().alloc_color(
-                        int(flatcolor2r*0xFFFF),
-                        int(flatcolor2g*0xFFFF),
-                        int(flatcolor2b*0xFFFF)
-                     )
-                  else:
-                     r,g,b=colorsys.yiq_to_rgb(0.5*darkmulti,c2,c3)
-                     gc.foreground = self.mod.get_colormap().alloc_color(
-                        int(r*0xFFFF),
-                        int(g*0xFFFF),
-                        int(b*0xFFFF)
-                     )
-                  self.pixmap2.draw_line(gc, x, 13-waluelength, x, 12+waluelength)
+                    if self.flat:
+                        gc.foreground = self.mod.get_colormap().alloc_color(
+                            int(flatcolor2r * 0xFFFF),
+                            int(flatcolor2g * 0xFFFF),
+                            int(flatcolor2b * 0xFFFF))
+                    else:
+                        r, g, b = colorsys.yiq_to_rgb(0.5 * darkmulti, c2, c3)
+                        gc.foreground = self.mod.get_colormap().alloc_color(
+                            int(r * 0xFFFF), int(g * 0xFFFF), int(b * 0xFFFF))
+                    self.pixmap2.draw_line(gc, x, 13 - waluelength, x,
+                                           12 + waluelength)
 
         #if not self.defaultstyle:
         #    self.pixmap2.draw_drawable(gc,self.pixmap, 0, 0, 0, 0, self.modwidth, 24)
@@ -322,175 +326,168 @@ class ExModbar(object):
         #    gc.function=gtk.gdk.COPY
         return b
 
-
     #Drawing mood UI---------------------------------------------------------
 
-    def drawMod(self,this,area):
-         darkmulti=(1-self.darkness/10)
-         self.uptime+=1
-         gc = self.brush
-         self.bgcolor = self.mod.style.bg[gtk.STATE_NORMAL]
-         redf=self.bgcolor.red
-         greenf=self.bgcolor.green
-         bluef=self.bgcolor.blue
-         #logger.info(greenf)
-         this=self.mod
-         gc.foreground = this.get_colormap().alloc_color(
-             0x0000,
-             0x0000,
-             0x0000
-         )
-         track = player.PLAYER.current
-         if self.theme:
-                flatcolor1r,flatcolor1g,flatcolor1b=colorsys.yiq_to_rgb(0.5,self.ivalue,self.qvalue)
-                flatcolor2r,flatcolor2g,flatcolor2b=colorsys.yiq_to_rgb(0.5*darkmulti,self.ivalue,self.qvalue)
-         else:
-                flatcolor1r=flatcolor1g=flatcolor1b=0.5
-                flatcolor2r=flatcolor2g=flatcolor2b=0.5*darkmulti
-         try:
+    def drawMod(self, this, area):
+        darkmulti = (1 - self.darkness / 10)
+        self.uptime += 1
+        gc = self.brush
+        self.bgcolor = self.mod.style.bg[gtk.STATE_NORMAL]
+        redf = self.bgcolor.red
+        greenf = self.bgcolor.green
+        bluef = self.bgcolor.blue
+        #logger.info(greenf)
+        this = self.mod
+        gc.foreground = this.get_colormap().alloc_color(0x0000, 0x0000, 0x0000)
+        track = player.PLAYER.current
+        if self.theme:
+            flatcolor1r, flatcolor1g, flatcolor1b = colorsys.yiq_to_rgb(
+                0.5, self.ivalue, self.qvalue)
+            flatcolor2r, flatcolor2g, flatcolor2b = colorsys.yiq_to_rgb(
+                0.5 * darkmulti, self.ivalue, self.qvalue)
+        else:
+            flatcolor1r = flatcolor1g = flatcolor1b = 0.5
+            flatcolor2r = flatcolor2g = flatcolor2b = 0.5 * darkmulti
+        try:
 
-            if not self.get_size()==self.modwidth:
-                  self.buff=self.genBuff()
-            if (not self.defaultstyle==self.defaultstyle_old or
-                 not self.theme==self.theme_old or
-                 not self.flat==self.flat_old or
-                 not self.color==self.color_old or
-                 not self.darkness==self.darkness_old or
-                 not self.cursor==self.cursor_old):
-                    self.buff=self.genBuff()
+            if not self.get_size() == self.modwidth:
+                self.buff = self.genBuff()
+            if (not self.defaultstyle == self.defaultstyle_old or
+                not self.theme == self.theme_old or
+                not self.flat == self.flat_old or
+                not self.color == self.color_old or
+                not self.darkness == self.darkness_old or
+                not self.cursor == self.cursor_old):
+                self.buff = self.genBuff()
             if (self.haveMod):
-                 this.props.window.draw_drawable(gc,self.pixmap, 0, 0, 0, 0, self.modwidth, 24)
+                this.props.window.draw_drawable(gc, self.pixmap, 0, 0, 0, 0,
+                                                self.modwidth, 24)
 
             else:
-              if not self.defaultstyle:
-                for i in range(5):
-                   gc.foreground = this.get_colormap().alloc_color(
-                       int(flatcolor1r*0xFFFF*i/5+redf*((5-float(i))/5)),
-                       int(flatcolor1g*0xFFFF*i/5+greenf*((5-float(i))/5)),
-                       int(flatcolor1b*0xFFFF*i/5+bluef*((5-float(i))/5))
-                   )
-                   this.props.window.draw_rectangle(gc, True, 0, 0+i,
-                           self.modwidth, 24-i*2)
+                if not self.defaultstyle:
+                    for i in range(5):
+                        gc.foreground = this.get_colormap().alloc_color(
+                            int(flatcolor1r * 0xFFFF * i / 5 + redf *
+                                ((5 - float(i)) / 5)),
+                            int(flatcolor1g * 0xFFFF * i / 5 + greenf *
+                                ((5 - float(i)) / 5)),
+                            int(flatcolor1b * 0xFFFF * i / 5 + bluef *
+                                ((5 - float(i)) / 5)))
+                        this.props.window.draw_rectangle(gc, True, 0, 0 + i,
+                                                         self.modwidth,
+                                                         24 - i * 2)
 
-              if self.modTimer and track.is_local():
-                   gc.foreground = this.get_colormap().alloc_color(
-                       int(flatcolor2r*0xFFFF),
-                       int(flatcolor2g*0xFFFF),
-                       int(flatcolor2b*0xFFFF)
-                   )
-                   this.props.window.draw_rectangle(gc, True,
-                             (self.modwidth/10)*(self.uptime%10),
-                             5, self.modwidth/10, 14)
-              if self.defaultstyle:
-                   gc.foreground = this.get_colormap().alloc_color(
-                       int(flatcolor1r*0xFFFF),
-                       int(flatcolor1g*0xFFFF),
-                       int(flatcolor1b*0xFFFF)
-                   )
-                   this.props.window.draw_rectangle(gc, True,
-                           0,12, self.modwidth, 2)
+                if self.modTimer and track.is_local():
+                    gc.foreground = this.get_colormap().alloc_color(
+                        int(flatcolor2r * 0xFFFF), int(flatcolor2g * 0xFFFF),
+                        int(flatcolor2b * 0xFFFF))
+                    this.props.window.draw_rectangle(gc, True,
+                                                     (self.modwidth / 10) *
+                                                     (self.uptime % 10), 5,
+                                                     self.modwidth / 10, 14)
+                if self.defaultstyle:
+                    gc.foreground = this.get_colormap().alloc_color(
+                        int(flatcolor1r * 0xFFFF), int(flatcolor1g * 0xFFFF),
+                        int(flatcolor1b * 0xFFFF))
+                    this.props.window.draw_rectangle(gc, True, 0, 12,
+                                                     self.modwidth, 2)
 
-         except:
+        except:
             for i in range(5):
-              gc.foreground = this.get_colormap().alloc_color(
-                  int(0xFFFF*i/5),
-                  0x0000,
-                  0x0000
-              )
-              this.props.window.draw_rectangle(gc, True, 0, 0+i,
-                     self.modwidth, 24-i*2)
+                gc.foreground = this.get_colormap().alloc_color(
+                    int(0xFFFF * i / 5), 0x0000, 0x0000)
+                this.props.window.draw_rectangle(gc, True, 0, 0 + i,
+                                                 self.modwidth, 24 - i * 2)
 
             #if track and track.is_local():
             #self.lookformod(track)
 
             return False
 
-         track = player.PLAYER.current
-         if not track or not (track.is_local() or \
-                 track.get_tag_raw('__length')): return
+        track = player.PLAYER.current
+        if not track or not (track.is_local() or \
+                 track.get_tag_raw('__length')):
+            return
 
-         if self.modTimer:
+        if self.modTimer:
             if self.cursor:
                 if not self.haveMod:
-                   if not self.defaultstyle:
-                      for i in range(5):
-                          gc.foreground = this.get_colormap().alloc_color(
-                              int(flatcolor2r*0xFFFF*i/5+int(redf*((5-float(i))/5))),
-                              int(flatcolor2g*0xFFFF*i/5+int(greenf*((5-float(i))/5))),
-                              int(flatcolor2b*0xFFFF*i/5+int(bluef*((5-float(i))/5)))
-                          )
-                          this.props.window.draw_rectangle(gc, True, 0, 0+i,
-                                 int(self.curpos*self.modwidth), 24-i*2)
-                   else:
-                      gc.foreground = this.get_colormap().alloc_color(
-                          int(flatcolor2r*0xFFFF),
-                          int(flatcolor2g*0xFFFF),
-                          int(flatcolor2b*0xFFFF)
-                      )
-                      this.props.window.draw_rectangle(gc, True,
-                           0,12, int(self.curpos*self.modwidth), 2)
+                    if not self.defaultstyle:
+                        for i in range(5):
+                            gc.foreground = this.get_colormap().alloc_color(
+                                int(flatcolor2r * 0xFFFF * i / 5 + int(redf * (
+                                    (5 - float(i)) / 5))),
+                                int(flatcolor2g * 0xFFFF * i / 5 + int(greenf * (
+                                    (5 - float(i)) / 5))),
+                                int(flatcolor2b * 0xFFFF * i / 5 + int(bluef * (
+                                    (5 - float(i)) / 5))))
+                            this.props.window.draw_rectangle(
+                                gc, True, 0, 0 + i,
+                                int(self.curpos * self.modwidth), 24 - i * 2)
+                    else:
+                        gc.foreground = this.get_colormap().alloc_color(
+                            int(flatcolor2r * 0xFFFF),
+                            int(flatcolor2g * 0xFFFF),
+                            int(flatcolor2b * 0xFFFF))
+                        this.props.window.draw_rectangle(
+                            gc, True, 0, 12, int(self.curpos * self.modwidth),
+                            2)
                 else:
-                    this.props.window.draw_drawable(gc,self.pixmap2, 0, 0, 0, 0, int(self.curpos*self.modwidth), 24)
-
+                    this.props.window.draw_drawable(gc, self.pixmap2, 0, 0, 0,
+                                                    0, int(self.curpos *
+                                                           self.modwidth), 24)
 
             else:
-                gc.foreground  = self.bgcolor;
-                gc.line_width=2
-                this.props.window.draw_arc(gc, True, int(self.curpos*self.modwidth)-15,
-                        -5, 30, 30,  60*64, 60*64)
-                gc.foreground = this.get_colormap().alloc_color(
-                    0x0000,
-                    0x0000,
-                    0x0000
-                )
+                gc.foreground = self.bgcolor
+                gc.line_width = 2
+                this.props.window.draw_arc(
+                    gc, True, int(self.curpos * self.modwidth) - 15, -5, 30,
+                    30, 60 * 64, 60 * 64)
+                gc.foreground = this.get_colormap().alloc_color(0x0000, 0x0000,
+                                                                0x0000)
 
-                this.props.window.draw_line(gc, int(self.curpos*self.modwidth), 10,
-                                      int(self.curpos*self.modwidth)-10, -5)
-                this.props.window.draw_line(gc, int(self.curpos*self.modwidth), 10,
-                                      int(self.curpos*self.modwidth)+10, -5)
+                this.props.window.draw_line(
+                    gc, int(self.curpos * self.modwidth), 10,
+                    int(self.curpos * self.modwidth) - 10, -5)
+                this.props.window.draw_line(
+                    gc, int(self.curpos * self.modwidth), 10,
+                    int(self.curpos * self.modwidth) + 10, -5)
 
             length = player.PLAYER.current.get_tag_raw('__length')
             seconds = player.PLAYER.get_time()
             remaining_seconds = length - seconds
             text = ("%d:%02d / %d:%02d" %
-                ( seconds // 60, seconds % 60, remaining_seconds // 60,
-                remaining_seconds % 60))
-            gc.foreground = this.get_colormap().alloc_color(
-                0x0000,
-                0x0000,
-                0x0000
-            )
+                    (seconds // 60, seconds % 60, remaining_seconds // 60,
+                     remaining_seconds % 60))
+            gc.foreground = this.get_colormap().alloc_color(0x0000, 0x0000,
+                                                            0x0000)
             this.pangolayout.set_text(text)
 
-            this.props.window.draw_layout(gc, int(self.modwidth/2)-35,
-                     4, this.pangolayout)
-            this.props.window.draw_layout(gc, int(self.modwidth/2)-37,
-                     2, this.pangolayout)
-            this.props.window.draw_layout(gc, int(self.modwidth/2)-35,
-                     2, this.pangolayout)
-            this.props.window.draw_layout(gc, int(self.modwidth/2)-37,
-                     4, this.pangolayout)
-            gc.foreground = this.get_colormap().alloc_color(
-                0xFFFF,
-                0xFFFF,
-                0xFFFF
-            )
+            this.props.window.draw_layout(gc, int(self.modwidth / 2) - 35, 4,
+                                          this.pangolayout)
+            this.props.window.draw_layout(gc, int(self.modwidth / 2) - 37, 2,
+                                          this.pangolayout)
+            this.props.window.draw_layout(gc, int(self.modwidth / 2) - 35, 2,
+                                          this.pangolayout)
+            this.props.window.draw_layout(gc, int(self.modwidth / 2) - 37, 4,
+                                          this.pangolayout)
+            gc.foreground = this.get_colormap().alloc_color(0xFFFF, 0xFFFF,
+                                                            0xFFFF)
 
-            this.props.window.draw_layout(gc, int(self.modwidth/2)-36,
-                     3, this.pangolayout)
-
+            this.props.window.draw_layout(gc, int(self.modwidth / 2) - 36, 3,
+                                          this.pangolayout)
 
     #seeking-----------------------------------------------------------------
 
-    def modSeekBegin(self,this,event):
+    def modSeekBegin(self, this, event):
         self.seeking = True
 
-
-    def modSeekEnd(self,this,event):
+    def modSeekEnd(self, this, event):
         self.seeking = False
         track = player.PLAYER.current
         if not track or not (track.is_local() or \
-                track.get_tag_raw('__length')): return
+                track.get_tag_raw('__length')):
+            return
 
         mouse_x, mouse_y = event.get_coords()
         progress_loc = self.get_size()
@@ -498,7 +495,7 @@ class ExModbar(object):
         if value < 0: value = 0
         if value > 1: value = 1
 
-        self.curpos=value
+        self.curpos = value
         length = track.get_tag_raw('__length')
         self.mod.queue_draw_area(0, 0, progress_loc, 24)
         #redrawMod(self)
@@ -506,11 +503,12 @@ class ExModbar(object):
         seconds = float(value * length)
         player.PLAYER.seek(seconds)
 
-    def modSeekMotionNotify(self,this,  event):
+    def modSeekMotionNotify(self, this, event):
         if self.seeking:
             track = player.PLAYER.current
             if not track or not (track.is_local() or \
-                    track.get_tag_raw('__length')): return
+                    track.get_tag_raw('__length')):
+                return
 
             mouse_x, mouse_y = event.get_coords()
             progress_loc = self.get_size()
@@ -518,18 +516,15 @@ class ExModbar(object):
             if value < 0: value = 0
             if value > 1: value = 1
 
-
-            self.curpos=value
+            self.curpos = value
             self.mod.queue_draw_area(0, 0, progress_loc, 24)
-
 
     #------------------------------------------------------------------------
 
 
-
 def enable(exaile):
     global ExaileModbar
-    ExaileModbar=ExModbar()
+    ExaileModbar = ExModbar()
     ExaileModbar.set_ex(exaile)
 
     try:
@@ -543,20 +538,27 @@ def enable(exaile):
     else:
         _enable(None, exaile, None)
 
+
 def _enable(eventname, exaile, nothing):
     global ExaileModbar
     ExaileModbar.readMod('')
     ExaileModbar.setupUi()
-    event.add_callback(ExaileModbar.play_start, 'playback_track_start', player.PLAYER)
-    event.add_callback(ExaileModbar.play_end, 'playback_player_end', player.PLAYER)
+    event.add_callback(ExaileModbar.play_start, 'playback_track_start',
+                       player.PLAYER)
+    event.add_callback(ExaileModbar.play_end, 'playback_player_end',
+                       player.PLAYER)
+
 
 def disable(exaile):
     global ExaileModbar
     ExaileModbar.changeModToBar()
-    event.remove_callback(ExaileModbar.play_start, 'playback_track_start', player.PLAYER)
-    event.remove_callback(ExaileModbar.play_end, 'playback_player_end', player.PLAYER)
+    event.remove_callback(ExaileModbar.play_start, 'playback_track_start',
+                          player.PLAYER)
+    event.remove_callback(ExaileModbar.play_end, 'playback_player_end',
+                          player.PLAYER)
     ExaileModbar.destroy()
     ExaileModbar = None
+
 
 def get_preferences_pane():
     return moodbarprefs
@@ -570,7 +572,3 @@ def get_preferences_pane():
 #python: ../../src/xcb_io.c:176: process_responses: Assertion `!(req && current_request && !(((long) (req->sequence) - (long) (current_request)) <= 0))' failed.
 
 #0.0.4 haven't errors
-
-
-
-

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -24,12 +24,9 @@
 # do so. If you do not wish to do so, delete this exception statement
 # from your version.
 
-import glib
 import gtk
-import gobject
 
 import os
-import time
 
 from xl import (
     event,
@@ -42,7 +39,7 @@ from xl import (
 from xl.nls import gettext as _
 
 from xlgui import guiutil, main
-from xlgui.widgets import menu, dialogs, playback
+from xlgui.widgets import menu, playback
 
 import previewprefs
 

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -30,9 +30,9 @@ import gobject
 
 import os
 import time
- 
+
 from xl import (
-    event, 
+    event,
     providers,
     player,
     settings,
@@ -52,70 +52,74 @@ PREVIEW_PLUGIN = None
 def get_preferences_pane():
     return previewprefs
 
+
 def enable(exaile):
     '''Called on plugin enable'''
     if exaile.loading:
         event.add_callback(_enable, 'gui_loaded')
     else:
         _enable(None, exaile, None)
-        
+
+
 def _enable(eventname, exaile, nothing):
 
     global PREVIEW_PLUGIN
     PREVIEW_PLUGIN = SecondaryOutputPlugin(exaile)
-    
+
+
 def disable(exaile):
     '''Called on plugin disable'''
-    
+
     global PREVIEW_PLUGIN
     if PREVIEW_PLUGIN is not None:
         PREVIEW_PLUGIN.disable_plugin(exaile)
         PREVIEW_PLUGIN = None
-        
+
 
 class SecondaryOutputPlugin(object):
     '''Implements logic for plugin'''
-    
+
     def __init__(self, exaile):
-    
+
         self.exaile = exaile
         self.hooked = False
         self.resuming = False
-    
+
         #
         # Initialize the player objects needed
         #
-    
+
         self.player = player.get_player('preview_device')
-        self.queue = player.queue.PlayQueue( self.player, 
-                                             location=os.path.join(xdg.get_data_dir(), 'preview_device_queue.state'),
-                                             name='Preview Device Queue')
-        
+        self.queue = player.queue.PlayQueue(
+            self.player,
+            location=os.path.join(
+                xdg.get_data_dir(),
+                'preview_device_queue.state'
+            ),
+            name='Preview Device Queue'
+        )
+
         #
         # Initialize the GUI stuff
         #
-    
+
         self._init_gui()
-        
+
         # preserve state
         if settings.get_option('plugin/previewdevice/shown', True):
             self._init_gui_hooks()
-    
-    
+
     def disable_plugin(self, exaile):
-    
         self._destroy_gui_hooks()
         self._destroy_gui()
         self.player.stop()
-        
+
         self.player = None
         self.queue = None
-        
-        
+
     def _init_gui(self):
-    
         self.pane = gtk.HPaned()
-        
+
         # stolen from main
         self.info_area = main.MainWindowTrackInfoPane(self.player)
         self.info_area.set_auto_update(True)
@@ -125,67 +129,74 @@ class SecondaryOutputPlugin(object):
 
         volume_control = playback.VolumeControl(self.player)
         self.info_area.get_action_area().pack_start(volume_control)
-        
+
         self.playpause_button = gtk.Button()
         self.playpause_button.set_relief(gtk.RELIEF_NONE)
         self._on_playback_end(None, None, None)
-        self.playpause_button.connect('button-press-event', self._on_playpause_button_clicked)
-        
+        self.playpause_button.connect(
+            'button-press-event',
+            self._on_playpause_button_clicked
+        )
+
         progress_bar = playback.SeekProgressBar(self.player, use_markers=False)
-        
+
         play_toolbar = gtk.HBox()
         play_toolbar.pack_start(self.playpause_button, expand=False, fill=False)
         play_toolbar.pack_start(progress_bar)
-        
+
         # stick our player controls into this box
         self.pane1_box = gtk.VBox()
-        
+
         self.pane2_box = gtk.VBox()
         self.pane2_box.pack_start(self.info_area, expand=False, fill=False)
-        self.pane2_box.pack_start(play_toolbar, expand=False, fill=False) 
-        
+        self.pane2_box.pack_start(play_toolbar, expand=False, fill=False)
+
         self.pane.pack1(self.pane1_box, resize=True, shrink=True)
         self.pane.pack2(self.pane2_box, resize=True, shrink=True)
-        
+
         # setup menus
-        
-        # add menu item to 'view' to display our playlist 
-        self.menu = menu.check_menu_item('preview_player', '', _('Preview Player'), \
-            lambda *e: self.hooked, self._on_view )
-            
+
+        # add menu item to 'view' to display our playlist
+        self.menu = menu.check_menu_item(
+            'preview_player',
+            '',
+            _('Preview Player'),
+            lambda *e: self.hooked,
+            self._on_view
+        )
+
         providers.register('menubar-view-menu', self.menu)
-        
-        self.preview_menuitem = menu.simple_menu_item('_preview', ['enqueue'], 
+
+        self.preview_menuitem = menu.simple_menu_item('_preview', ['enqueue'],
                 _('Preview'), callback=self._on_preview,
-                condition_fn=lambda n,p,c: not c['selection-empty'])
-        
+                condition_fn=lambda n, p, c: not c['selection-empty'])
+
         # TODO: Setup on other context menus
-        self.preview_provides = [ 'track-panel-menu',
-                                  'playlist-context-menu']
-        
+        self.preview_provides = [
+            'track-panel-menu',
+            'playlist-context-menu',
+        ]
+
         for provide in self.preview_provides:
             providers.register(provide, self.preview_menuitem)
-        
+
         self._on_option_set('gui_option_set', settings, 'gui/show_info_area')
         self._on_option_set('gui_option_set', settings, 'gui/show_info_area_covers')
         event.add_callback(self._on_option_set, 'option_set')
 
-        
     def _destroy_gui(self):
-    
         event.remove_callback(self._on_option_set, 'option_set')
-        
+
         for provide in self.preview_provides:
             providers.unregister(provide, self.preview_menuitem)
         providers.unregister('menubar-view-menu', self.menu)
-        
+
         self.info_area.destroy()
         self.playpause_button.destroy()
-        
+
         self.pane2_box.destroy()
         self.pane1_box.destroy()
         self.pane.destroy()
-      
 
     def _setup_events(self, setup):
         setup(self._on_playback_resume, 'playback_player_resume', self.player)
@@ -193,122 +204,115 @@ class SecondaryOutputPlugin(object):
         setup(self._on_playback_error, 'playback_error', self.player)
         setup(self._on_playback_start, 'playback_track_start', self.player)
         setup(self._on_toggle_pause, 'playback_toggle_pause', self.player)
-        
-        
+
     def _init_gui_hooks(self):
         '''
             Initializes any hooks into the main Exaile GUI
-            
+
             Note that this is rather ugly, but currently exaile doesn't really
             have a better way to do this, and there isn't a better place to
-            stick our gui objects. 
+            stick our gui objects.
         '''
-    
+
         if self.hooked:
             return
-        
+
         # the info_area will be where we sit, and the info_area
         # will be duplicated for two sides
-        
+
         # need to move the play_toolbar, and duplicate it
         # also once for each side
-        
+
         info_area = main.mainwindow().info_area
         play_toolbar = main.mainwindow().builder.get_object('play_toolbar')
-    
+
         parent = play_toolbar.get_parent()
         parent.remove(play_toolbar)
-        
+
         parent = info_area.get_parent()
         parent.remove(info_area)
-        
+
         parent.pack_start(self.pane, expand=False, fill=False)
         parent.reorder_child(self.pane, 0)
-        
+
         # stick the main player controls into this box
         self.pane1_box.pack_start(info_area, expand=False, fill=False)
-        self.pane1_box.pack_start(play_toolbar, expand=False, fill=False) 
-        
+        self.pane1_box.pack_start(play_toolbar, expand=False, fill=False)
+
         # and do it
         self.pane.show_all()
-        
+
         # add player events
         self._setup_events(event.add_callback)
-        
+
         self.hooked = True
         settings.set_option('plugin/previewdevice/shown', True)
-        
-            
+
     def _destroy_gui_hooks(self):
         '''
             Removes any hooks from the main Exaile GUI
         '''
-        
+
         if not self.hooked:
             return
-    
+
         info_area = main.mainwindow().info_area
         play_toolbar = main.mainwindow().builder.get_object('play_toolbar')
-        
+
         # detach main GUI elements
         parent = play_toolbar.get_parent()
         parent.remove(play_toolbar)
-        
+
         parent = info_area.get_parent()
         parent.remove(info_area)
-        
+
         # detach the element we added to hold them
         parent = self.pane.get_parent()
         parent.remove(self.pane)
-        
+
         # reattach
         parent.pack_start(info_area, expand=False, fill=False)
         parent.reorder_child(info_area, 0)
         parent.pack_start(play_toolbar, expand=False, fill=False)
-        
+
         # remove player events
-        self._setup_events( event.remove_callback )
-    
+        self._setup_events(event.remove_callback)
+
         self.hooked = False
         settings.set_option('plugin/previewdevice/shown', False)
-        
-        
+
     #
     # Menu events
     #
-    
+
     def _on_view(self, menu, name, parent, context):
         if self.hooked:
             self._destroy_gui_hooks()
         else:
             self._init_gui_hooks()
-    
+
     def _on_preview(self, menu, display_name, playlist_view, context):
         self._init_gui_hooks()
         tracks = context['selected-tracks']
         if len(tracks) > 0:
             self.queue.play(tracks[0])
-        
-    
+
     #
     # Various player events
     #
-    
+
     def _on_playpause_button_clicked(self, widget, event):
         """
             Called when the play button is clicked
         """
-        
+
         if event.button == 1:
             if event.type == gtk.gdk.BUTTON_PRESS and \
-                (self.player.is_paused() or self.player.is_playing()):
-                
+                    (self.player.is_paused() or self.player.is_playing()):
                 self.player.toggle_pause()
-                
             elif event.type == gtk.gdk._2BUTTON_PRESS:
                 self.player.stop()
-        
-        
+
     @guiutil.idle_add()
     def _on_option_set(self, name, object, option):
         """
@@ -321,9 +325,9 @@ class SecondaryOutputPlugin(object):
             else:
                 self.info_area.hide_all()
             self.info_area.set_no_show_all(True)
-            
+
         elif option == 'gui/show_info_area_covers':
-            cover = self.info_area.cover     
+            cover = self.info_area.cover
             cover.set_no_show_all(False)
             if settings.get_option(option, True):
                 cover.show_all()
@@ -345,30 +349,32 @@ class SecondaryOutputPlugin(object):
             self.resuming = False
             return
 
-        image = gtk.image_new_from_stock(gtk.STOCK_MEDIA_PAUSE, 
+        image = gtk.image_new_from_stock(gtk.STOCK_MEDIA_PAUSE,
                                          gtk.ICON_SIZE_BUTTON)
         self.playpause_button.set_image(image)
-        self.playpause_button.set_tooltip_text( _('Pause Playback (double click to stop)') )
+        self.playpause_button.set_tooltip_text(
+            _('Pause Playback (double click to stop)'))
 
     @guiutil.idle_add()
     def _on_playback_end(self, type, player, object):
         """
             Called when playback ends
         """
-        
-        image = gtk.image_new_from_stock(gtk.STOCK_MEDIA_PLAY, 
+
+        image = gtk.image_new_from_stock(gtk.STOCK_MEDIA_PLAY,
                                          gtk.ICON_SIZE_BUTTON)
         self.playpause_button.set_image(image)
-        self.playpause_button.set_tooltip_text( _('Start Playback'))
-        
+        self.playpause_button.set_tooltip_text(_('Start Playback'))
+
     @guiutil.idle_add()
     def _on_playback_error(self, type, player, message):
         """
             Called when there has been a playback error
         """
-        main.mainwindow().message.show_error( _('Playback error encountered!'), message)
-        
-    @guiutil.idle_add()    
+        main.mainwindow().message.show_error(
+            _('Playback error encountered!'), message)
+
+    @guiutil.idle_add()
     def _on_toggle_pause(self, type, player, object):
         """
             Called when the user clicks the play button after playback has
@@ -385,5 +391,3 @@ class SecondaryOutputPlugin(object):
 
         self.playpause_button.set_image(image)
         self.playpause_button.set_tooltip_text(tooltip)
-        
-            


### PR DESCRIPTION
As a precursor to changing these two plugins to work better together, this is a non-functional change to remove unused imports, fix indentation, etc. I used [yapf]https://github.com/google/yapf) on the moodbar plugin `__init__.py` because its indentation and white space were somewhat erratic.