### PR TITLE
Make moodbar plugin work with preview device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ doc/_build
 # Eclipse settings
 .project
 .pydevproject
+
+# Vim Pymode settings
+.ropeproject
+*.swp

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -547,6 +547,7 @@ class ExModbar(object):
 
 
 def _enable_main_moodbar(exaile):
+    logger.info("Enabling main moodbar")
     global ExaileModbar
     ExaileModbar = ExModbar(
         player=player.PLAYER,
@@ -559,11 +560,20 @@ def _enable_main_moodbar(exaile):
 
 
 def _disable_main_moodbar():
+    logger.info("Disabling main moodbar")
     global ExaileModbar
     ExaileModbar.changeModToBar()
     ExaileModbar.remove_callbacks()
     ExaileModbar.destroy()
     ExaileModbar = None
+
+
+def _enable_preview_moodbar(event, object, nothing):
+    logger.info("Enabling preview moodbar")
+
+
+def _disable_preview_moodbar(event, object, nothing):
+    logger.info("Disabling preview moodbar")
 
 
 def enable(exaile):
@@ -581,10 +591,14 @@ def enable(exaile):
 
 def _enable(eventname, exaile, nothing):
     _enable_main_moodbar(exaile)
+    event.add_callback(_enable_preview_moodbar, 'preview_device_enabled')
+    event.add_callback(_disable_preview_moodbar, 'preview_device_disabled')
 
 
 def disable(exaile):
     _disable_main_moodbar()
+    event.remove_callback(_enable_preview_moodbar, 'preview_device_enabled')
+    event.remove_callback(_disable_preview_moodbar, 'preview_device_disabled')
 
 
 

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -603,6 +603,9 @@ def enable(exaile):
     else:
         _enable(None, exaile, None)
 
+def _get_preview_plugin_if_active(exaile):
+    previewdevice = exaile.plugins.enabled_plugins.get('previewdevice', None)
+    return getattr(previewdevice, 'PREVIEW_PLUGIN', None)
 
 def _enable(eventname, exaile, nothing):
     _enable_main_moodbar(exaile)
@@ -610,15 +613,8 @@ def _enable(eventname, exaile, nothing):
     event.add_callback(_enable_preview_moodbar, 'preview_device_enabled')
     event.add_callback(_disable_preview_moodbar, 'preview_device_disabling')
 
-    try:
-        import previewdevice
-        preview_plugin = previewdevice.PREVIEW_PLUGIN
-        hooked = preview_plugin.hooked
-    except ImportError:
-        preview_plugin = None
-        hooked = False
-
-    if hooked:  # Attach code fails unless preview player's gui is displayed
+    preview_plugin = _get_preview_plugin_if_active(exaile)
+    if getattr(preview_plugin, 'hooked', False):
         _enable_preview_moodbar('', preview_plugin, None)
 
 
@@ -628,15 +624,8 @@ def disable(exaile):
     event.remove_callback(_enable_preview_moodbar, 'preview_device_enabled')
     event.remove_callback(_disable_preview_moodbar, 'preview_device_disabling')
 
-    try:
-        import previewdevice
-        preview_plugin = previewdevice.PREVIEW_PLUGIN
-        hooked = preview_plugin.hooked
-    except (ImportError, AttributeError):
-        preview_plugin = None
-        hooked = False
-
-    if hooked:
+    preview_plugin = _get_preview_plugin_if_active(exaile)
+    if getattr(preview_plugin, 'hooked', False):
         _disable_preview_moodbar('', preview_plugin, None)
 
 

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -34,7 +34,10 @@ class ExModbar(object):
 
     # Setup and getting values------------------------------------------------
 
-    def __init__(self):
+    def __init__(self, player, progress_bar):
+        self.pr = progress_bar
+        self.player = player
+
         self.moodbar = ''
         self.buff = ''
         self.brush = None
@@ -73,9 +76,6 @@ class ExModbar(object):
     darkness = __inner_preference(moodbarprefs.DarknessPreference)
     color = __inner_preference(moodbarprefs.ColorPreference)
 
-    def set_ex(self, ex):
-        self.exaile = ex
-
     def get_size(self):
         progress_loc = self.mod.get_allocation()
         return progress_loc.width
@@ -101,7 +101,6 @@ class ExModbar(object):
 
     def setupUi(self):
         self.setuped = True
-        self.pr = self.exaile.gui.main.progress_bar
         self.changeBarToMod()
         self.mod.seeking = False
         self.mod.connect("expose-event", self.drawMod)
@@ -113,9 +112,33 @@ class ExModbar(object):
         self.mod.connect("motion-notify-event", self.modSeekMotionNotify)
         self.brush = self.mod.props.window.new_gc()
 
-        track = player.PLAYER.current
+        track = self.player.current
 
         self.lookformod(track)
+
+    def add_callbacks(self):
+        event.add_callback(
+            self.play_start,
+            'playback_track_start',
+            self.player
+        )
+        event.add_callback(
+            self.play_end,
+            'playback_player_end',
+            self.player
+        )
+
+    def remove_callbacks(self):
+        event.remove_callback(
+            self.play_start,
+            'playback_track_start',
+            self.player
+        )
+        event.remove_callback(
+            self.play_end,
+            'playback_player_end',
+            self.player
+        )
 
     def destroy(self):
         if self.modTimer: glib.source_remove(self.modTimer)
@@ -133,7 +156,7 @@ class ExModbar(object):
                                                                  '-') + ".mood"
         modLoc = modLoc.replace("'", '')
         needGen = False
-        self.curpos = player.PLAYER.get_progress()
+        self.curpos = self.player.get_progress()
         if os.access(modLoc, 0):
             self.modwidth = 0
             if not self.readMod(modLoc):
@@ -174,7 +197,8 @@ class ExModbar(object):
         self.modTimer = glib.timeout_add_seconds(1, self.updateMod)
 
     def updateplayerpos(self):
-        if self.modTimer: self.curpos = player.PLAYER.get_progress()
+        if self.modTimer:
+            self.curpos = self.player.get_progress()
         self.mod.queue_draw_area(0, 0, self.get_size(), 24)
 
     #reading mod from file and update mood preview --------------------------
@@ -339,7 +363,7 @@ class ExModbar(object):
         #logger.info(greenf)
         this = self.mod
         gc.foreground = this.get_colormap().alloc_color(0x0000, 0x0000, 0x0000)
-        track = player.PLAYER.current
+        track = self.player.current
         if self.theme:
             flatcolor1r, flatcolor1g, flatcolor1b = colorsys.yiq_to_rgb(
                 0.5, self.ivalue, self.qvalue)
@@ -404,7 +428,7 @@ class ExModbar(object):
 
             return False
 
-        track = player.PLAYER.current
+        track = self.player.current
         if not track or not (track.is_local() or \
                  track.get_tag_raw('__length')):
             return
@@ -453,8 +477,8 @@ class ExModbar(object):
                     gc, int(self.curpos * self.modwidth), 10,
                     int(self.curpos * self.modwidth) + 10, -5)
 
-            length = player.PLAYER.current.get_tag_raw('__length')
-            seconds = player.PLAYER.get_time()
+            length = self.player.current.get_tag_raw('__length')
+            seconds = self.player.get_time()
             remaining_seconds = length - seconds
             text = ("%d:%02d / %d:%02d" %
                     (seconds // 60, seconds % 60, remaining_seconds // 60,
@@ -484,7 +508,7 @@ class ExModbar(object):
 
     def modSeekEnd(self, this, event):
         self.seeking = False
-        track = player.PLAYER.current
+        track = self.player.current
         if not track or not (track.is_local() or \
                 track.get_tag_raw('__length')):
             return
@@ -501,11 +525,11 @@ class ExModbar(object):
         #redrawMod(self)
 
         seconds = float(value * length)
-        player.PLAYER.seek(seconds)
+        self.player.seek(seconds)
 
     def modSeekMotionNotify(self, this, event):
         if self.seeking:
-            track = player.PLAYER.current
+            track = self.player.current
             if not track or not (track.is_local() or \
                     track.get_tag_raw('__length')):
                 return
@@ -524,8 +548,10 @@ class ExModbar(object):
 
 def enable(exaile):
     global ExaileModbar
-    ExaileModbar = ExModbar()
-    ExaileModbar.set_ex(exaile)
+    ExaileModbar=ExModbar(
+        player=player.PLAYER,
+        progress_bar=exaile.gui.main.progress_bar
+    )
 
     try:
         subprocess.call(['moodbar', '--help'], stdout=-1, stderr=-1)
@@ -543,19 +569,12 @@ def _enable(eventname, exaile, nothing):
     global ExaileModbar
     ExaileModbar.readMod('')
     ExaileModbar.setupUi()
-    event.add_callback(ExaileModbar.play_start, 'playback_track_start',
-                       player.PLAYER)
-    event.add_callback(ExaileModbar.play_end, 'playback_player_end',
-                       player.PLAYER)
-
+    ExaileModbar.add_callbacks()
 
 def disable(exaile):
     global ExaileModbar
     ExaileModbar.changeModToBar()
-    event.remove_callback(ExaileModbar.play_start, 'playback_track_start',
-                          player.PLAYER)
-    event.remove_callback(ExaileModbar.play_end, 'playback_player_end',
-                          player.PLAYER)
+    ExaileModbar.remove_callbacks()
     ExaileModbar.destroy()
     ExaileModbar = None
 

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -28,6 +28,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 ExaileModbar = None
+PreviewMoodbar = None
 
 
 class ExModbar(object):
@@ -547,8 +548,8 @@ class ExModbar(object):
 
 
 def _enable_main_moodbar(exaile):
-    logger.info("Enabling main moodbar")
     global ExaileModbar
+    logger.info("Enabling main moodbar")
     ExaileModbar = ExModbar(
         player=player.PLAYER,
         progress_bar=exaile.gui.main.progress_bar
@@ -560,20 +561,34 @@ def _enable_main_moodbar(exaile):
 
 
 def _disable_main_moodbar():
-    logger.info("Disabling main moodbar")
     global ExaileModbar
+    logger.info("Disabling main moodbar")
     ExaileModbar.changeModToBar()
     ExaileModbar.remove_callbacks()
     ExaileModbar.destroy()
     ExaileModbar = None
 
 
-def _enable_preview_moodbar(event, object, nothing):
+def _enable_preview_moodbar(event, preview_plugin, nothing):
+    global PreviewMoodbar
     logger.info("Enabling preview moodbar")
+    PreviewMoodbar = ExModbar(
+        player=preview_plugin.player,
+        progress_bar=preview_plugin.progress_bar
+    )
+
+    PreviewMoodbar.readMod('')
+    PreviewMoodbar.setupUi()
+    PreviewMoodbar.add_callbacks()
 
 
-def _disable_preview_moodbar(event, object, nothing):
+def _disable_preview_moodbar(event, preview_plugin, nothing):
+    global PreviewMoodbar
     logger.info("Disabling preview moodbar")
+    PreviewMoodbar.changeModToBar()
+    PreviewMoodbar.remove_callbacks()
+    PreviewMoodbar.destroy()
+    PreviewMoodbar = None
 
 
 def enable(exaile):
@@ -591,15 +606,34 @@ def enable(exaile):
 
 def _enable(eventname, exaile, nothing):
     _enable_main_moodbar(exaile)
+
     event.add_callback(_enable_preview_moodbar, 'preview_device_enabled')
     event.add_callback(_disable_preview_moodbar, 'preview_device_disabled')
+
+    try:
+        import previewdevice
+        preview_plugin = previewdevice.PREVIEW_PLUGIN
+    except ImportError:
+        preview_plugin = None
+
+    if preview_plugin:
+        _enable_preview_moodbar('', preview_plugin, None)
 
 
 def disable(exaile):
     _disable_main_moodbar()
+
     event.remove_callback(_enable_preview_moodbar, 'preview_device_enabled')
     event.remove_callback(_disable_preview_moodbar, 'preview_device_disabled')
 
+    try:
+        import previewdevice
+        preview_plugin = previewdevice.PREVIEW_PLUGIN
+    except ImportError:
+        preview_plugin = None
+
+    if preview_plugin:
+        _disable_preview_moodbar('', preview_plugin, None)
 
 
 def get_preferences_pane():

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -546,13 +546,27 @@ class ExModbar(object):
     #------------------------------------------------------------------------
 
 
-def enable(exaile):
+def _enable_main_moodbar(exaile):
     global ExaileModbar
-    ExaileModbar=ExModbar(
+    ExaileModbar = ExModbar(
         player=player.PLAYER,
         progress_bar=exaile.gui.main.progress_bar
     )
 
+    ExaileModbar.readMod('')
+    ExaileModbar.setupUi()
+    ExaileModbar.add_callbacks()
+
+
+def _disable_main_moodbar():
+    global ExaileModbar
+    ExaileModbar.changeModToBar()
+    ExaileModbar.remove_callbacks()
+    ExaileModbar.destroy()
+    ExaileModbar = None
+
+
+def enable(exaile):
     try:
         subprocess.call(['moodbar', '--help'], stdout=-1, stderr=-1)
     except OSError:
@@ -566,17 +580,12 @@ def enable(exaile):
 
 
 def _enable(eventname, exaile, nothing):
-    global ExaileModbar
-    ExaileModbar.readMod('')
-    ExaileModbar.setupUi()
-    ExaileModbar.add_callbacks()
+    _enable_main_moodbar(exaile)
+
 
 def disable(exaile):
-    global ExaileModbar
-    ExaileModbar.changeModToBar()
-    ExaileModbar.remove_callbacks()
-    ExaileModbar.destroy()
-    ExaileModbar = None
+    _disable_main_moodbar()
+
 
 
 def get_preferences_pane():

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -549,7 +549,7 @@ class ExModbar(object):
 
 def _enable_main_moodbar(exaile):
     global ExaileModbar
-    logger.info("Enabling main moodbar")
+    logger.debug("Enabling main moodbar")
     ExaileModbar = ExModbar(
         player=player.PLAYER,
         progress_bar=exaile.gui.main.progress_bar
@@ -562,7 +562,7 @@ def _enable_main_moodbar(exaile):
 
 def _disable_main_moodbar():
     global ExaileModbar
-    logger.info("Disabling main moodbar")
+    logger.debug("Disabling main moodbar")
     ExaileModbar.changeModToBar()
     ExaileModbar.remove_callbacks()
     ExaileModbar.destroy()
@@ -571,7 +571,7 @@ def _disable_main_moodbar():
 
 def _enable_preview_moodbar(event, preview_plugin, nothing):
     global PreviewMoodbar
-    logger.info("Enabling preview moodbar")
+    logger.debug("Enabling preview moodbar")
     PreviewMoodbar = ExModbar(
         player=preview_plugin.player,
         progress_bar=preview_plugin.progress_bar
@@ -584,7 +584,7 @@ def _enable_preview_moodbar(event, preview_plugin, nothing):
 
 def _disable_preview_moodbar(event, preview_plugin, nothing):
     global PreviewMoodbar
-    logger.info("Disabling preview moodbar")
+    logger.debug("Disabling preview moodbar")
     PreviewMoodbar.changeModToBar()
     PreviewMoodbar.remove_callbacks()
     PreviewMoodbar.destroy()
@@ -608,15 +608,17 @@ def _enable(eventname, exaile, nothing):
     _enable_main_moodbar(exaile)
 
     event.add_callback(_enable_preview_moodbar, 'preview_device_enabled')
-    event.add_callback(_disable_preview_moodbar, 'preview_device_disabled')
+    event.add_callback(_disable_preview_moodbar, 'preview_device_disabling')
 
     try:
         import previewdevice
         preview_plugin = previewdevice.PREVIEW_PLUGIN
+        hooked = preview_plugin.hooked
     except ImportError:
         preview_plugin = None
+        hooked = False
 
-    if preview_plugin:
+    if hooked:  # Attach code fails unless preview player's gui is displayed
         _enable_preview_moodbar('', preview_plugin, None)
 
 
@@ -624,15 +626,17 @@ def disable(exaile):
     _disable_main_moodbar()
 
     event.remove_callback(_enable_preview_moodbar, 'preview_device_enabled')
-    event.remove_callback(_disable_preview_moodbar, 'preview_device_disabled')
+    event.remove_callback(_disable_preview_moodbar, 'preview_device_disabling')
 
     try:
         import previewdevice
         preview_plugin = previewdevice.PREVIEW_PLUGIN
+        hooked = preview_plugin.hooked
     except ImportError:
         preview_plugin = None
+        hooked = False
 
-    if preview_plugin:
+    if hooked:
         _disable_preview_moodbar('', preview_plugin, None)
 
 

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -632,7 +632,7 @@ def disable(exaile):
         import previewdevice
         preview_plugin = previewdevice.PREVIEW_PLUGIN
         hooked = preview_plugin.hooked
-    except ImportError:
+    except (ImportError, AttributeError):
         preview_plugin = None
         hooked = False
 

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -43,6 +43,9 @@ from xlgui.widgets import menu, playback
 
 import previewprefs
 
+import logging
+logger = logging.getLogger(__name__)
+
 PREVIEW_PLUGIN = None
 
 
@@ -107,9 +110,12 @@ class SecondaryOutputPlugin(object):
             self._init_gui_hooks()
 
         # We're ready; teall anyone who might be interested
-        event.log_event('preview_device_enabled', self, None)
+        logger.debug('Preview Device Enabled')
+        # event.log_event('preview_device_enabled', self, None)
 
     def disable_plugin(self, exaile):
+        logger.debug('Disabling Preview Device')
+        event.log_event('preview_device_disabling', self, None)
         self._destroy_gui_hooks()
         self._destroy_gui()
         self.player.stop()
@@ -117,8 +123,7 @@ class SecondaryOutputPlugin(object):
         self.player = None
         self.queue = None
 
-        # We're all through; tell anyone who might be interested
-        event.log_event('preview_device_disabled', self, None)
+        logger.debug('Preview Device Disabled')
 
     def _init_gui(self):
         self.pane = gtk.HPaned()
@@ -251,6 +256,9 @@ class SecondaryOutputPlugin(object):
         self.hooked = True
         settings.set_option('plugin/previewdevice/shown', True)
 
+        logger.debug("Preview device gui hooked")
+        event.log_event('preview_device_enabled', self, None)
+
     def _destroy_gui_hooks(self):
         '''
             Removes any hooks from the main Exaile GUI
@@ -283,6 +291,7 @@ class SecondaryOutputPlugin(object):
 
         self.hooked = False
         settings.set_option('plugin/previewdevice/shown', False)
+        logger.debug('Preview device unhooked')
 
     #
     # Menu events

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -135,11 +135,11 @@ class SecondaryOutputPlugin(object):
             self._on_playpause_button_clicked
         )
 
-        progress_bar = playback.SeekProgressBar(self.player, use_markers=False)
+        self.progress_bar = playback.SeekProgressBar(self.player, use_markers=False)
 
         play_toolbar = gtk.HBox()
         play_toolbar.pack_start(self.playpause_button, expand=False, fill=False)
-        play_toolbar.pack_start(progress_bar)
+        play_toolbar.pack_start(self.progress_bar)
 
         # stick our player controls into this box
         self.pane1_box = gtk.VBox()

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -107,7 +107,7 @@ class SecondaryOutputPlugin(object):
             self._init_gui_hooks()
 
         # We're ready; teall anyone who might be interested
-        event.log_event('previewdevice_enabled', self, None)
+        event.log_event('preview_device_enabled', self, None)
 
     def disable_plugin(self, exaile):
         self._destroy_gui_hooks()
@@ -118,7 +118,7 @@ class SecondaryOutputPlugin(object):
         self.queue = None
 
         # We're all through; tell anyone who might be interested
-        event.log_event('previewdevice_disabled', self, None)
+        event.log_event('preview_device_disabled', self, None)
 
     def _init_gui(self):
         self.pane = gtk.HPaned()

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -106,6 +106,9 @@ class SecondaryOutputPlugin(object):
         if settings.get_option('plugin/previewdevice/shown', True):
             self._init_gui_hooks()
 
+        # We're ready; teall anyone who might be interested
+        event.log_event('previewdevice_enabled', self, None)
+
     def disable_plugin(self, exaile):
         self._destroy_gui_hooks()
         self._destroy_gui()
@@ -113,6 +116,9 @@ class SecondaryOutputPlugin(object):
 
         self.player = None
         self.queue = None
+
+        # We're all through; tell anyone who might be interested
+        event.log_event('previewdevice_disabled', self, None)
 
     def _init_gui(self):
         self.pane = gtk.HPaned()

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -109,9 +109,6 @@ class SecondaryOutputPlugin(object):
         if settings.get_option('plugin/previewdevice/shown', True):
             self._init_gui_hooks()
 
-        # We're ready; teall anyone who might be interested
-        logger.debug('Preview Device Enabled')
-        # event.log_event('preview_device_enabled', self, None)
 
     def disable_plugin(self, exaile):
         logger.debug('Disabling Preview Device')


### PR DESCRIPTION
I like the info the moodbar gives me but I find I want it more from the preview device than the main player (because I'm previewing stuff live to decide what to play). This PR refactors the moodbar somewhat to abstract out the dependencies on the player and its gui, and then applies another instance to the preview device, when that is activated. To make this work I have added a couple of events to the preview device, and made it keep a reference to its progress bar which the moodbar plugin can see.

*    I have not changed the minor version numbers of either of the plugins. I guess you will want to do that, if you accept this, to reflect the fact that they have been modified.

