### PR TITLE
Trivial fixes

### DIFF
--- a/data/ui/about_dialog.ui
+++ b/data/ui/about_dialog.ui
@@ -35,7 +35,7 @@ Mathias Brodala
 Andrew Starr-Bochicchio
 Brian Parma
 Dustin Spicuzza
-fidencio
+Fabiano Fidêncio
 Joseph S. Atkinson</property>
     <property name="translator_credits" translatable="yes" context="About dialog translator credits" comments="TRANSLATORS: Add your own name here">Unknown translator</property>
     <property name="artists">Tuomas Kuosmanen

--- a/xlgui/properties.py
+++ b/xlgui/properties.py
@@ -125,12 +125,12 @@ class TrackPropertiesDialog(gobject.GObject):
         self.trackdata_original = self._tags_copy(tracks)
         self.current_position = current_position
 
-        self._build_from_track(self.current_position)
+        if len(self.trackdata) != 0:
+            self._build_from_track(self.current_position)
+            self.rows[0].field.grab_focus()
 
         self.dialog.resize(600, 350)
         self.dialog.show()
-
-        self.rows[0].field.grab_focus()
 
     def _get_field_widget(self, tag_info, ab):
         tag_type = tag_info.type


### PR DESCRIPTION
Two really simple patches:
1) Fix my own name on the "about" dialog.
2) Avoid to show an exception to the users, when they click in the "Track properties" with no track selected.