### PR TITLE
Wip/gi/trivial fixes

### DIFF
--- a/data/ui/about_dialog.ui
+++ b/data/ui/about_dialog.ui
@@ -19,7 +19,7 @@ Mathias Brodala
 Andrew Starr-Bochicchio
 Brian Parma
 Dustin Spicuzza
-fidencio
+Fabiano Fidêncio
 Joseph S. Atkinson</property>
     <property name="translator_credits" translatable="yes" context="About dialog translator credits" comments="TRANSLATORS: Add your own name here">Unknown translator</property>
     <property name="artists">Tuomas Kuosmanen

--- a/data/ui/device_manager.ui
+++ b/data/ui/device_manager.ui
@@ -151,7 +151,6 @@
     <property name="default_width">500</property>
     <property name="default_height">350</property>
     <property name="type_hint">dialog</property>
-    <property name="has_separator">False</property>
     <child internal-child="vbox">
       <object class="GtkVBox" id="dialog-vbox1">
         <property name="visible">True</property>

--- a/data/ui/trackproperties_dialog.ui
+++ b/data/ui/trackproperties_dialog.ui
@@ -59,8 +59,10 @@
                     <property name="border_width">6</property>
                     <property name="spacing">5</property>
                     <child>
-                      <object class="GtkComboBoxEntry" id="new_tag_combo">
+                      <object class="GtkComboBoxText" id="new_tag_combo">
                         <property name="visible">True</property>
+                        <property name="has_entry">True</property>
+                        <property name="entry_text_column">0</property>
                         <child internal-child="entry">
                           <object class="GtkEntry" id="new_tag_entry">
                             <signal name="changed" handler="on_new_tag_entry_changed"/>


### PR DESCRIPTION
A few trivial patches:
1) Fix my own name on the "about" dialog
2) device_manager.ui: GtkDialog has no "has_separator" property
3) trackproperties_dialog: GtkComboBoxEntry has been removed from GTK3