### PR TITLE
menu: Remove 'Track Properties' item

### DIFF
--- a/xlgui/menu.py
+++ b/xlgui/menu.py
@@ -221,9 +221,6 @@ def __create_tools_menu():
     items.append(_smi('slow-scan-collection', [items[-1].name], _('Rescan Collection (slow)'),
         gtk.STOCK_REFRESH, get_main().controller.on_rescan_collection_forced))
 
-    items.append(_smi('track-properties', [items[-1].name], _('Track _Properties'),
-        gtk.STOCK_PROPERTIES, get_main().controller.on_track_properties))
-
     for item in items:
         providers.register('menubar-tools-menu', item)
 


### PR DESCRIPTION
The main reason for removing the item is that the user has to be lucky
for clicking in the entry having a track selected.
Also, there is no other menu item depending on a track being selected.

The same functionality can be accessed by:
Right-Click on a track -> Properties