### PR TITLE
Fix window type_hint property to "dialog"

### DIFF
--- a/data/ui/collection_manager.ui
+++ b/data/ui/collection_manager.ui
@@ -38,7 +38,7 @@
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Collection Manager</property>
     <property name="modal">True</property>
-    <property name="type_hint">utility</property>
+    <property name="type_hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="content_area">
         <property name="visible">True</property>

--- a/data/ui/covermanager.ui
+++ b/data/ui/covermanager.ui
@@ -35,7 +35,7 @@
     <property name="border_width">3</property>
     <property name="title" translatable="yes">Cover Manager</property>
     <property name="window_position">center-on-parent</property>
-    <property name="type_hint">utility</property>
+    <property name="type_hint">dialog</property>
     <signal name="delete-event" handler="on_window_delete_event" swapped="no"/>
     <child>
       <object class="GtkBox" id="content_area">

--- a/data/ui/coverwindow.ui
+++ b/data/ui/coverwindow.ui
@@ -7,7 +7,7 @@
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
     <property name="window_position">center-on-parent</property>
     <property name="destroy_with_parent">True</property>
-    <property name="type_hint">utility</property>
+    <property name="type_hint">dialog</property>
     <child>
       <object class="GtkBox" id="vbox">
         <property name="visible">True</property>

--- a/data/ui/device_manager.ui
+++ b/data/ui/device_manager.ui
@@ -18,7 +18,7 @@
     <property name="title" translatable="yes">Add Device</property>
     <property name="default_width">500</property>
     <property name="default_height">350</property>
-    <property name="type_hint">utility</property>
+    <property name="type_hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
@@ -228,6 +228,7 @@
     <property name="title" translatable="yes">Device Manager</property>
     <property name="default_width">700</property>
     <property name="default_height">450</property>
+    <property name="type_hint">dialog</property>
     <child>
       <object class="GtkBox" id="hbox1">
         <property name="visible">True</property>

--- a/data/ui/preferences/preferences_dialog.ui
+++ b/data/ui/preferences/preferences_dialog.ui
@@ -23,7 +23,7 @@
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Preferences</property>
     <property name="window_position">center-on-parent</property>
-    <property name="type_hint">utility</property>
+    <property name="type_hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox11">
         <property name="visible">True</property>

--- a/data/ui/trackproperties_dialog.ui
+++ b/data/ui/trackproperties_dialog.ui
@@ -5,7 +5,7 @@
   <object class="GtkWindow" id="TrackPropertiesDialog">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Track Properties</property>
-    <property name="type_hint">utility</property>
+    <property name="type_hint">dialog</property>
     <child>
       <object class="GtkBox" id="main_container">
         <property name="visible">True</property>


### PR DESCRIPTION
With this change windows comply to the EWMH [1]. This reverts the previous change 04a0595. See #101 for details [3]

[1] http://standards.freedesktop.org/wm-spec/wm-spec-latest.html#idm140200472629520
[2] https://github.com/genodeftest/exaile/commit/04a059508ec182cc23e0b58eb7af2b6e26da1548
[3] https://github.com/exaile/exaile/pull/101#issuecomment-110265566