### PR TITLE
[gi] Fix main menu button warning

### DIFF
--- a/plugins/mainmenubutton/__init__.py
+++ b/plugins/mainmenubutton/__init__.py
@@ -98,7 +98,7 @@ class MainMenuButton(Gtk.ToggleButton, notebook.NotebookAction):
         self.unparent()
         Gtk.Button.destroy(self)
 
-    def get_menu_position(self, menu, unknown):
+    def get_menu_position(self, menu, x, y, unknown):
         """
             Positions the menu at the right of the button
         """


### PR DESCRIPTION
Fix the warning `TypeError: get_menu_position() takes exactly 3 arguments (5 given)` when opening and closing main menu