### PR TITLE
[gi] Drop GtkStock support for preferences pages

### DIFF
--- a/plugins/history/history_preferences.py
+++ b/plugins/history/history_preferences.py
@@ -35,7 +35,7 @@ import os
 name = _('History')
 basedir = os.path.dirname(os.path.realpath(__file__))
 ui = os.path.join(basedir, 'history_preferences.ui')
-icon = Gtk.STOCK_GOTO_FIRST
+icon = 'document-open-recent'
 
 
 # defaults

--- a/plugins/previewdevice/previewprefs.py
+++ b/plugins/previewdevice/previewprefs.py
@@ -38,7 +38,7 @@ import os
 name = _('Preview Device')
 basedir = os.path.dirname(os.path.realpath(__file__))
 ui = os.path.join(basedir, 'previewprefs.ui')
-icon = Gtk.STOCK_MEDIA_PLAY
+icon = 'media-playback-start'
 
 
 def __autoconfig():

--- a/xlgui/preferences/__init__.py
+++ b/xlgui/preferences/__init__.py
@@ -157,14 +157,8 @@ class PreferencesDialog(object):
                 if isinstance(page.icon, GdkPixbuf.Pixbuf):
                     icon = page.icon
                 else:
-                    stock_id = Gtk.stock_lookup(page.icon)
-
-                    if stock_id is not None:
-                        icon = icons.MANAGER.pixbuf_from_stock(
-                            stock_id[0], Gtk.IconSize.MENU)
-                    else:
-                        icon = icons.MANAGER.pixbuf_from_icon_name(
-                            page.icon, Gtk.IconSize.MENU)
+                    icon = icons.MANAGER.pixbuf_from_icon_name(
+                        page.icon, Gtk.IconSize.MENU)
 
             self.model.append(self.plug_root, [page, page.name, icon])
 


### PR DESCRIPTION
GtkStock support was broken when porting to Gtk3.
This change makes the "history" and "preview device" plugins start.