### PR TITLE
Remove GtkStock (the simple part)

### DIFF
--- a/plugins/bookmarks/__init__.py
+++ b/plugins/bookmarks/__init__.py
@@ -102,11 +102,11 @@ class Bookmarks:
 
 
         items = []
-        items.append(_smi('bookmark', [], _('Bookmark This Track'),
+        items.append(_smi('bookmark', [], _('_Bookmark This Track'),
             'bookmark-new', self.add_bookmark))
-        items.append(menu.MenuItem('delete', factory_factory(_('Delete Bookmark'),
+        items.append(menu.MenuItem('delete', factory_factory(_('_Delete Bookmark'),
             'gtk-close', submenu=self.delete_menu), ['bookmark']))
-        items.append(menu.MenuItem('clear', factory_factory(_('Clear Bookmarks'),
+        items.append(menu.MenuItem('clear', factory_factory(_('_Clear Bookmarks'),
             'gtk-clear', callback=self.clear), ['delete']))
         items.append(_sep('sep', ['clear']))
 
@@ -301,7 +301,7 @@ def _enable(exaile):
     # add tools menu items
     providers.register('menubar-tools-menu', _sep('plugin-sep', ['track-properties']))
     
-    item = _smi('bookmarks', ['plugin-sep'], _('Bookmarks'), 
+    item = _smi('bookmarks', ['plugin-sep'], _('_Bookmarks'), 
         'user-bookmarks', submenu=bm.menu)
     providers.register('menubar-tools-menu', item)
 

--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -287,7 +287,7 @@ class DaapManager:
         hmenu = menu.Menu(None)
 
         def hmfactory(menu, parent, context):
-            item = Gtk.MenuItem.new_with_label(_('History'))
+            item = Gtk.MenuItem.new_with_mnemonic(_('History'))
             item.set_submenu(hmenu)
             sens = settings.get_option('plugin/daapclient/history', True)
             item.set_sensitive(sens)

--- a/plugins/equalizer/__init__.py
+++ b/plugins/equalizer/__init__.py
@@ -127,7 +127,7 @@ class EqualizerPlugin:
         self.window = None
 
         # add menu item to tools menu
-        self.MENU_ITEM = menu.simple_menu_item('equalizer', ['plugin-sep'], _('Equalizer'),
+        self.MENU_ITEM = menu.simple_menu_item('equalizer', ['plugin-sep'], _('_Equalizer'),
             callback=lambda *x: self.show_gui(exaile))
         providers.register('menubar-tools-menu', self.MENU_ITEM)
 

--- a/plugins/grouptagger/__init__.py
+++ b/plugins/grouptagger/__init__.py
@@ -106,23 +106,23 @@ class GroupTaggerPlugin(object):
         self.tools_submenu = menu.Menu( None, context_func=lambda p: exaile )
         
         self.tools_submenu.add_item( 
-            menu.simple_menu_item( 'gt_get_tags', [], _('Get all tags from collection'),
+            menu.simple_menu_item( 'gt_get_tags', [], _('_Get all tags from collection'),
                 callback=self.on_get_tags_menu ) 
         )
         
         self.tools_submenu.add_item( 
-            menu.simple_menu_item( 'gt_import', [], _('Import tags from directory'),
+            menu.simple_menu_item( 'gt_import', [], _('_Import tags from directory'),
                 callback=self.on_import_tags ) 
         )
         
         self.tools_submenu.add_item( 
-            menu.simple_menu_item( 'gt_rename', [], _('Mass rename/delete tags'),
+            menu.simple_menu_item( 'gt_rename', [], _('_Mass rename/delete tags'),
                 callback=self.on_mass_rename ) 
         )
         
         # group them together to make it not too long
         self.tools_menuitem = menu.simple_menu_item('grouptagger', ['plugin-sep'], 
-                _('GroupTagger'), submenu=self.tools_submenu )
+                _('_GroupTagger'), submenu=self.tools_submenu )
         providers.register( 'menubar-tools-menu', self.tools_menuitem )
         
         # playlist context menu items

--- a/plugins/grouptagger/gt_widgets.py
+++ b/plugins/grouptagger/gt_widgets.py
@@ -74,7 +74,7 @@ class GTShowTracksMenuItem(menu.MenuItem):
         else:
             display_name =  _('Show tracks with all selected')
         
-        menuitem = Gtk.MenuItem.new_with_label(display_name)
+        menuitem = Gtk.MenuItem.new_with_mnemonic(display_name)
         menuitem.connect('activate', lambda *e: gt_common.create_all_search_playlist( context['groups'], parent.exaile ))
         return menuitem
 

--- a/plugins/history/__init__.py
+++ b/plugins/history/__init__.py
@@ -233,7 +233,7 @@ def __create_history_tab_context_menu():
     items = []
     items.append(smi('save', [], _("Save History"), 'gtk-save',
         lambda w, n, o, c: o.save_history()))
-    items.append(smi('clear', ['save'], _("Clear History"), 'gtk-clear',
+    items.append(smi('clear', ['save'], _("_Clear History"), 'gtk-clear',
         lambda w, n, o, c: o.playlist._clear()))
     items.append(sep('tab-close-sep', ['clear']))
     items.append(smi('tab-close', ['tab-close-sep'], None, 'gtk-close',

--- a/plugins/ipconsole/__init__.py
+++ b/plugins/ipconsole/__init__.py
@@ -154,7 +154,7 @@ def _enable(exaile):
             Create menu item.
     """
     # add menuitem to tools menu
-    item = menu.simple_menu_item('ipconsole', ['plugin-sep'], _('Show IPython Console'),
+    item = menu.simple_menu_item('ipconsole', ['plugin-sep'], _('Show _IPython Console'),
         callback=lambda *x: show_console(exaile)) 
     providers.register('menubar-tools-menu', item)
     

--- a/plugins/lastfmlove/__init__.py
+++ b/plugins/lastfmlove/__init__.py
@@ -133,7 +133,7 @@ class LoveMenuItem(MenuItem):
         """
         global LASTFMLOVER
 
-        item = Gtk.ImageMenuItem.new_with_label(_('Love This Track'))
+        item = Gtk.ImageMenuItem.new_with_mnemonic(_('_Love This Track'))
         item.set_image(Gtk.Image.new_from_icon_name(
             'love', Gtk.IconSize.MENU))
 

--- a/xlgui/main.py
+++ b/xlgui/main.py
@@ -416,11 +416,11 @@ class MainWindow(GObject.GObject):
         """
         widget.__hovered = True
         if event.get_state() & Gdk.ModifierType.SHIFT_MASK:
-            widget.set_image(Gtk.Image.new_from_stock(
-                Gtk.STOCK_STOP, Gtk.IconSize.BUTTON))
+            widget.set_image(Gtk.Image.new_from_icon_name(
+                'process-stop', Gtk.IconSize.BUTTON))
         else:
-            widget.set_image(Gtk.Image.new_from_stock(
-                Gtk.STOCK_MEDIA_STOP, Gtk.IconSize.BUTTON))
+            widget.set_image(Gtk.Image.new_from_icon_name(
+                'media-playback-stop', Gtk.IconSize.BUTTON))
 
     def on_stop_button_leave_notify_event(self, widget, event):
         """
@@ -429,16 +429,16 @@ class MainWindow(GObject.GObject):
         widget.__hovered = False
         if not widget.is_focus() and \
            ~(event.get_state() & Gdk.ModifierType.SHIFT_MASK):
-            widget.set_image(Gtk.Image.new_from_stock(
-                Gtk.STOCK_MEDIA_STOP, Gtk.IconSize.BUTTON))
+            widget.set_image(Gtk.Image.new_from_icon_name(
+                'media-playback-stop', Gtk.IconSize.BUTTON))
 
     def on_stop_button_key_press_event(self, widget, event):
         """
             Shows SPAT icon on Shift key press
         """
         if event.keyval in (Gdk.KEY_Shift_L, Gdk.KEY_Shift_R):
-            widget.set_image(Gtk.Image.new_from_stock(
-                Gtk.STOCK_STOP, Gtk.IconSize.BUTTON))
+            widget.set_image(Gtk.Image.new_from_icon_name(
+                'process-stop', Gtk.IconSize.BUTTON))
             widget.set_data('toggle_spat', True)
 
         if event.keyval in (Gdk.KEY_space, Gdk.KEY_Return):
@@ -452,8 +452,8 @@ class MainWindow(GObject.GObject):
             Resets the button icon
         """
         if event.keyval in (Gdk.KEY_Shift_L, Gdk.KEY_Shift_R):
-            widget.set_image(Gtk.Image.new_from_stock(
-                Gtk.STOCK_MEDIA_STOP, Gtk.IconSize.BUTTON))
+            widget.set_image(Gtk.Image.new_from_icon_name(
+                'media-playback-stop', Gtk.IconSize.BUTTON))
             widget.set_data('toggle_spat', False)
 
     def on_stop_button_focus_out_event(self, widget, event):
@@ -462,8 +462,8 @@ class MainWindow(GObject.GObject):
             the button is still hovered
         """
         if not getattr(widget, '__hovered', False):
-            widget.set_image(Gtk.Image.new_from_stock(
-                Gtk.STOCK_MEDIA_STOP, Gtk.IconSize.BUTTON))
+            widget.set_image(Gtk.Image.new_from_icon_name(
+                'media-playback-stop', Gtk.IconSize.BUTTON))
 
     def on_stop_button_press_event(self, widget, event):
         """
@@ -476,7 +476,7 @@ class MainWindow(GObject.GObject):
             menu = guiutil.Menu()
             menu.append(_("Toggle: Stop after Selected Track"),
                 self.on_spat_clicked,
-                Gtk.STOCK_STOP)
+                'process-stop')
             menu.popup(None, None, None, None, event.button, event.time)
 
     def on_stop_button_release_event(self, widget, event):
@@ -493,15 +493,15 @@ class MainWindow(GObject.GObject):
         """
         target = widget.drag_dest_find_target(context, widget.drag_dest_get_target_list())
         if target == 'exaile-index-list':
-            widget.set_image(Gtk.Image.new_from_stock(
-                Gtk.STOCK_STOP, Gtk.IconSize.BUTTON))
+            widget.set_image(Gtk.Image.new_from_icon_name(
+                'process-stop', Gtk.IconSize.BUTTON))
 
     def on_stop_button_drag_leave(self, widget, context, time):
         """
             Resets the stop button
         """
-        widget.set_image(Gtk.Image.new_from_stock(
-            Gtk.STOCK_MEDIA_STOP, Gtk.IconSize.BUTTON))
+        widget.set_image(Gtk.Image.new_from_icon_name(
+            'media-playback-stop', Gtk.IconSize.BUTTON))
 
     def on_stop_button_drag_data_received(self, widget, context, x, y, selection, info, time):
         """
@@ -634,11 +634,11 @@ class MainWindow(GObject.GObject):
             already begun
         """
         if player.is_paused():
-            image = Gtk.Image.new_from_stock(Gtk.STOCK_MEDIA_PLAY,
+            image = Gtk.Image.new_from_icon_name('media-playback-start',
                 Gtk.IconSize.SMALL_TOOLBAR)
             tooltip = _('Continue Playback')
         else:
-            image = Gtk.Image.new_from_stock(Gtk.STOCK_MEDIA_PAUSE,
+            image = Gtk.Image.new_from_icon_name('media-playback-pause',
                 Gtk.IconSize.SMALL_TOOLBAR)
             tooltip = _('Pause Playback')
 
@@ -817,7 +817,7 @@ class MainWindow(GObject.GObject):
 
         self._update_track_information()
         GLib.idle_add(self.playpause_button.set_image,
-            Gtk.Image.new_from_stock(Gtk.STOCK_MEDIA_PAUSE,
+            Gtk.Image.new_from_icon_name('media-playback-pause',
             Gtk.IconSize.SMALL_TOOLBAR))
         GLib.idle_add(self.playpause_button.set_tooltip_text,
             _('Pause Playback'))
@@ -829,7 +829,7 @@ class MainWindow(GObject.GObject):
         GLib.idle_add(self.window.set_title, 'Exaile')
 
         GLib.idle_add(self.playpause_button.set_image,
-            Gtk.Image.new_from_stock(Gtk.STOCK_MEDIA_PLAY,
+            Gtk.Image.new_from_icon_name('media-playback-start',
             Gtk.IconSize.SMALL_TOOLBAR))
         GLib.idle_add(self.playpause_button.set_tooltip_text,
             _('Start Playback'))

--- a/xlgui/menu.py
+++ b/xlgui/menu.py
@@ -59,8 +59,8 @@ def __create_file_menu():
         dialog.connect('uris-selected', lambda d, uris:
             get_main().controller.open_uris(uris))
         dialog.show()
-    items.append(_smi('open', [items[-1].name], icon_name=Gtk.STOCK_OPEN,
-        callback=open_cb, accelerator='<Control>o'))
+    items.append(_smi('open', [items[-1].name], _("_Open"), 'document-open', 
+        open_cb, accelerator='<Control>o'))
     accelerators.append(Accelerator('<Control>o', open_cb))
 
     def open_uri_cb(*args):
@@ -69,7 +69,7 @@ def __create_file_menu():
             get_main().controller.open_uri(uri))
         dialog.show()
     items.append(_smi('open-uri', [items[-1].name], _("Open _URL"),
-        'applications-internet', open_uri_cb, accelerator='<Control><Shift>o'))
+        'emblem-web', open_uri_cb, accelerator='<Control><Shift>o'))
     accelerators.append(Accelerator('<Control><Shift>o', open_uri_cb))
 
     def open_dirs_cb(*args):
@@ -79,12 +79,12 @@ def __create_file_menu():
             get_main().controller.open_uris(uris))
         dialog.show()
     items.append(_smi('open-dirs', [items[-1].name], _("Open Directories"),
-        None, open_dirs_cb))
+        'folder-open', open_dirs_cb))
 
     items.append(_sep('open-sep', [items[-1].name]))
 
     items.append(_smi('import-playlist', [items[-1].name],
-        _("Import Playlist"), Gtk.STOCK_OPEN, 
+        _("Import Playlist"), 'document-open', 
         lambda *e: get_main().controller.get_panel('playlists').import_playlist()
     ))
     
@@ -106,13 +106,13 @@ def __create_file_menu():
         dialog.connect('message', on_message)
         dialog.show()
     items.append(_smi('export-playlist', [items[-1].name],
-        _("_Export Current Playlist"), Gtk.STOCK_SAVE_AS, export_playlist_cb))
+        _("_Export Current Playlist"), 'document-save-as', export_playlist_cb))
     items.append(_sep('export-sep', [items[-1].name]))
 
     def close_tab_cb(*args):
         get_main().get_selected_page().tab.close()
     items.append(_smi('close-tab', [items[-1].name],
-        _("Close Tab"), Gtk.STOCK_CLOSE, callback=close_tab_cb,
+        _("Close Tab"), 'window-close', close_tab_cb,
         accelerator='<Control>w'))
     accelerators.append(Accelerator('<Control>w', close_tab_cb))
 
@@ -128,8 +128,8 @@ def __create_file_menu():
     def quit_cb(*args):
         from xl import main
         main.exaile().quit()
-    items.append(_smi('quit-application', [items[-1].name],
-        icon_name=Gtk.STOCK_QUIT, callback=quit_cb, accelerator='<Control>q'))
+    items.append(_smi('quit-application', [items[-1].name], _("_Quit"),
+        'application-exit', quit_cb, accelerator='<Control>q'))
     accelerators.append(Accelerator('<Control>q', quit_cb))
 
     for item in items:
@@ -155,14 +155,15 @@ def __create_edit_menu():
     def cover_manager_cb(*args):
         from xlgui.cover import CoverManager
         dialog = CoverManager(get_main().window, get_main().collection)
-    items.append(_smi('cover-manager', [items[-1].name], _("C_overs"), None, cover_manager_cb))
+    items.append(_smi('cover-manager', [items[-1].name], _("C_overs"), 
+    	'image-x-generic', cover_manager_cb))
 
     def preferences_cb(*args):
         from xlgui.preferences import PreferencesDialog
         dialog = PreferencesDialog(get_main().window, get_main().controller)
         dialog.run()
-    items.append(_smi('preferences', [items[-1].name],
-        icon_name=Gtk.STOCK_PREFERENCES, callback=preferences_cb))
+    items.append(_smi('preferences', [items[-1].name], _("_Preferences"),
+        'preferences-system', preferences_cb))
 
     for item in items:
         providers.register('menubar-edit-menu', item)
@@ -176,7 +177,7 @@ def __create_view_menu():
     def show_playing_track_cb(*args):
         get_main().playlist_container.show_current_track()
     items.append(menuitems.ShowCurrentTrackMenuItem('show-playing-track', [],
-        show_playing_track_cb, accelerator='<Control>j'))
+    	show_playing_track_cb, accelerator='<Control>j'))
     accelerators.append(Accelerator('<Control>j', show_playing_track_cb))
 
     items.append(_sep('show-playing-track-sep', [items[-1].name]))
@@ -197,7 +198,7 @@ def __create_view_menu():
         if page:
             page.playlist.clear()
     items.append(_smi('clear-playlist', [items[-1].name], _('C_lear playlist'),
-         Gtk.STOCK_CLEAR, clear_playlist_cb, accelerator='<Control>l'))
+         'edit-clear-all', clear_playlist_cb, accelerator='<Control>l'))
     accelerators.append(Accelerator('<Control>l', clear_playlist_cb))
 
     for item in items:
@@ -213,13 +214,13 @@ def __create_playlist_menu():
 def __create_tools_menu():
     items = []
     items.append(_smi('device-manager', [], _('_Device Manager'),
-        Gtk.STOCK_HARDDISK, lambda *x: get_main().controller.show_devices()))
+        'multimedia-player', lambda *x: get_main().controller.show_devices()))
     
     items.append(_smi('scan-collection', [items[-1].name], _('Re_scan Collection'),
-        Gtk.STOCK_REFRESH, get_main().controller.on_rescan_collection))
+        'view-refresh', get_main().controller.on_rescan_collection))
     
     items.append(_smi('slow-scan-collection', [items[-1].name], _('Rescan Collection (slow)'),
-        Gtk.STOCK_REFRESH, get_main().controller.on_rescan_collection_forced))
+        'view-refresh', get_main().controller.on_rescan_collection_forced))
 
     for item in items:
         providers.register('menubar-tools-menu', item)
@@ -230,8 +231,8 @@ def __create_help_menu():
     def show_about_dialog(widget, name, parent, context):
         dialog = dialogs.AboutDialog(parent.window)
         dialog.show()
-    items.append(_smi('about', [], icon_name=Gtk.STOCK_ABOUT,
-        callback=show_about_dialog))
+    items.append(_smi('about', [], _("_About"), 'help-about',
+        show_about_dialog))
     for item in items:
         providers.register('menubar-help-menu', item)
     for accelerator in accelerators:

--- a/xlgui/menu.py
+++ b/xlgui/menu.py
@@ -78,13 +78,13 @@ def __create_file_menu():
         dialog.connect('uris-selected', lambda d, uris:
             get_main().controller.open_uris(uris))
         dialog.show()
-    items.append(_smi('open-dirs', [items[-1].name], _("Open Directories"),
+    items.append(_smi('open-dirs', [items[-1].name], _("Open _Directories"),
         'folder-open', open_dirs_cb))
 
     items.append(_sep('open-sep', [items[-1].name]))
 
     items.append(_smi('import-playlist', [items[-1].name],
-        _("Import Playlist"), 'document-open', 
+        _("_Import Playlist"), 'document-open', 
         lambda *e: get_main().controller.get_panel('playlists').import_playlist()
     ))
     
@@ -106,13 +106,13 @@ def __create_file_menu():
         dialog.connect('message', on_message)
         dialog.show()
     items.append(_smi('export-playlist', [items[-1].name],
-        _("_Export Current Playlist"), 'document-save-as', export_playlist_cb))
+        _("E_xport Current Playlist"), 'document-save-as', export_playlist_cb))
     items.append(_sep('export-sep', [items[-1].name]))
 
     def close_tab_cb(*args):
         get_main().get_selected_page().tab.close()
     items.append(_smi('close-tab', [items[-1].name],
-        _("Close Tab"), 'window-close', close_tab_cb,
+        _("Close _Tab"), 'window-close', close_tab_cb,
         accelerator='<Control>w'))
     accelerators.append(Accelerator('<Control>w', close_tab_cb))
 
@@ -121,14 +121,14 @@ def __create_file_menu():
         def restart_cb(*args):
             from xl import main
             main.exaile().quit(True)
-        items.append(_smi('restart-application', [items[-1].name], _("Restart"),
+        items.append(_smi('restart-application', [items[-1].name], _("_Restart"),
             callback=restart_cb, accelerator='<Control>r'))
         accelerators.append(Accelerator('<Control>r', restart_cb))
 
     def quit_cb(*args):
         from xl import main
         main.exaile().quit()
-    items.append(_smi('quit-application', [items[-1].name], _("_Quit"),
+    items.append(_smi('quit-application', [items[-1].name], _("_Quit Exaile"),
         'application-exit', quit_cb, accelerator='<Control>q'))
     accelerators.append(Accelerator('<Control>q', quit_cb))
 
@@ -190,14 +190,14 @@ def __create_view_menu():
     items.append(menu.check_menu_item('playlist-utilities', [items[-1].name],
         _("_Playlist Utilities Bar"), playlist_utilities_is_checked, playlist_utilities_cb))
 
-    items.append(_smi('columns', [items[-1].name], _('_Columns'),
+    items.append(_smi('columns', [items[-1].name], _('C_olumns'),
         submenu=menu.ProviderMenu('playlist-columns-menu', get_main())))
 
     def clear_playlist_cb(*args):
         page = get_main().get_selected_page()
         if page:
             page.playlist.clear()
-    items.append(_smi('clear-playlist', [items[-1].name], _('C_lear playlist'),
+    items.append(_smi('clear-playlist', [items[-1].name], _('_Clear playlist'),
          'edit-clear-all', clear_playlist_cb, accelerator='<Control>l'))
     accelerators.append(Accelerator('<Control>l', clear_playlist_cb))
 
@@ -216,10 +216,10 @@ def __create_tools_menu():
     items.append(_smi('device-manager', [], _('_Device Manager'),
         'multimedia-player', lambda *x: get_main().controller.show_devices()))
     
-    items.append(_smi('scan-collection', [items[-1].name], _('Re_scan Collection'),
+    items.append(_smi('scan-collection', [items[-1].name], _('_Rescan Collection'),
         'view-refresh', get_main().controller.on_rescan_collection))
     
-    items.append(_smi('slow-scan-collection', [items[-1].name], _('Rescan Collection (slow)'),
+    items.append(_smi('slow-scan-collection', [items[-1].name], _('Rescan Collection (_slow)'),
         'view-refresh', get_main().controller.on_rescan_collection_forced))
 
     for item in items:

--- a/xlgui/panel/collection.py
+++ b/xlgui/panel/collection.py
@@ -335,8 +335,8 @@ class CollectionPanel(panel.Panel):
             'artist', Gtk.IconSize.SMALL_TOOLBAR)
         self.date_image = icons.MANAGER.pixbuf_from_icon_name(
             'office-calendar', Gtk.IconSize.SMALL_TOOLBAR)
-        self.album_image = icons.MANAGER.pixbuf_from_stock(
-            Gtk.STOCK_CDROM, Gtk.IconSize.SMALL_TOOLBAR)
+        self.album_image = icons.MANAGER.pixbuf_from_icon_name(
+            'image-x-generic', Gtk.IconSize.SMALL_TOOLBAR)
         self.title_image = icons.MANAGER.pixbuf_from_icon_name(
             'audio-x-generic', Gtk.IconSize.SMALL_TOOLBAR)
         self.genre_image = icons.MANAGER.pixbuf_from_icon_name(

--- a/xlgui/panel/device.py
+++ b/xlgui/panel/device.py
@@ -134,7 +134,7 @@ class DevicePanel(panel.Panel):
         thread = DeviceTransferThread(self.device)
         thread.connect('done', lambda *e: self.load_tree())
         self.main.controller.progress_manager.add_monitor(thread,
-                _("Transferring to %s...") % self.name, Gtk.STOCK_GO_UP)
+                _("Transferring to %s...") % self.name, 'go-up')
 
     def get_panel(self):
         return self.collectionpanel.get_panel()

--- a/xlgui/panel/menus.py
+++ b/xlgui/panel/menus.py
@@ -171,17 +171,17 @@ def __create_playlist_panel_menus():
     
     # w, n, o, c: window, name, parent, context
 
-    menu.simple_menu_item('new-playlist', [], _('New Playlist'), 'tab-new',
+    menu.simple_menu_item('new-playlist', [], _('_New Playlist'), 'tab-new',
                           lambda w, n, o, c: o.add_new_playlist()) \
         .register('playlist-panel-menu')
         
     menu.simple_menu_item('new-smart-playlist', ['new-playlist'],
-                          _('New Smart Playlist'), 'tab-new',
+                          _('New _Smart Playlist'), 'tab-new',
                          lambda w, n, o, c: o.add_smart_playlist()) \
         .register('playlist-panel-menu')
         
     menu.simple_menu_item('import-playlist', ['new-smart-playlist'],
-                          _('Import Playlist'), 'document-open',
+                          _('_Import Playlist'), 'document-open',
                          lambda w, n, o, c: o.import_playlist()) \
         .register('playlist-panel-menu')
         
@@ -248,7 +248,7 @@ def __create_radio_panel_menus():
     
     # w, n, o, c: window, name, parent, context
 
-    menu.simple_menu_item('new-station', [], _('New Station'), 'list-add',
+    menu.simple_menu_item('new-station', [], _('_New Station'), 'list-add',
                           lambda w, n, o, c: o._on_add_button_clicked()) \
         .register('radio-panel-menu')
 

--- a/xlgui/panel/menus.py
+++ b/xlgui/panel/menus.py
@@ -171,17 +171,17 @@ def __create_playlist_panel_menus():
     
     # w, n, o, c: window, name, parent, context
 
-    menu.simple_menu_item('new-playlist', [], _('New Playlist'), 'gtk-new',
+    menu.simple_menu_item('new-playlist', [], _('New Playlist'), 'tab-new',
                           lambda w, n, o, c: o.add_new_playlist()) \
         .register('playlist-panel-menu')
         
     menu.simple_menu_item('new-smart-playlist', ['new-playlist'],
-                          _('New Smart Playlist'), 'gtk-new',
+                          _('New Smart Playlist'), 'tab-new',
                          lambda w, n, o, c: o.add_smart_playlist()) \
         .register('playlist-panel-menu')
         
     menu.simple_menu_item('import-playlist', ['new-smart-playlist'],
-                          _('Import Playlist'), 'gtk-open',
+                          _('Import Playlist'), 'document-open',
                          lambda w, n, o, c: o.import_playlist()) \
         .register('playlist-panel-menu')
         
@@ -248,7 +248,7 @@ def __create_radio_panel_menus():
     
     # w, n, o, c: window, name, parent, context
 
-    menu.simple_menu_item('new-station', [], _('New Station'), 'gtk-new',
+    menu.simple_menu_item('new-station', [], _('New Station'), 'list-add',
                           lambda w, n, o, c: o._on_add_button_clicked()) \
         .register('radio-panel-menu')
 

--- a/xlgui/panel/radio.py
+++ b/xlgui/panel/radio.py
@@ -248,8 +248,8 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
             'audio-x-generic', Gtk.IconSize.SMALL_TOOLBAR)
         self.folder = self.tree.render_icon(
             Gtk.STOCK_DIRECTORY, Gtk.IconSize.SMALL_TOOLBAR)
-        self.refresh_image = icons.MANAGER.pixbuf_from_stock(
-            Gtk.STOCK_REFRESH)
+        self.refresh_image = icons.MANAGER.pixbuf_from_icon_name(
+            'view-refresh')
 
         self.custom = self.model.append(None, [self.folder, _("Saved Stations"), None])
         self.radio_root = self.model.append(None, [self.folder, _("Radio "

--- a/xlgui/panels.py
+++ b/xlgui/panels.py
@@ -99,7 +99,7 @@ class PanelNotebook(notebook.SmartNotebook, providers.ProviderHandler):
         self.view_menu = menu.Menu(None)
         
         # setup/register the view menu
-        menu.simple_menu_item('panel-menu', ['show-playing-track'], _('Panels'),
+        menu.simple_menu_item('panel-menu', ['show-playing-track'], _('P_anels'),
                               submenu=self.view_menu) \
                             .register('menubar-view-menu')
         

--- a/xlgui/playlist_container.py
+++ b/xlgui/playlist_container.py
@@ -139,7 +139,7 @@ class PlaylistNotebook(SmartNotebook):
         def factory(menu_, parent, context):
             if self.page_num(parent) == -1:
                 return None
-            item = Gtk.MenuItem.new_with_label(_("Recently Closed Tabs"))
+            item = Gtk.MenuItem.new_with_mnemonic(_("Recently Closed _Tabs"))
             if len(self.tab_history) > 0:
                 item.set_submenu(submenu)
             else:
@@ -519,7 +519,7 @@ class PlaylistContainer(Gtk.HBox):
             self.notebooks[0].add_default_tab()
             
         # menu item
-        item = menu.simple_menu_item('move-tab', [], _('Move to Other View'), None,
+        item = menu.simple_menu_item('move-tab', [], _('_Move to Other View'), None,
             lambda w, n, p, c: self._move_tab(p.tab),
             condition_fn=lambda n, p, c: True if p.tab.notebook in self.notebooks else False )
         providers.register('playlist-tab-context-menu', item)

--- a/xlgui/playlist_container.py
+++ b/xlgui/playlist_container.py
@@ -129,7 +129,8 @@ class PlaylistNotebook(SmartNotebook):
         item = menu.simple_separator('clear-sep',[])
         item.register('playlist-closed-tab-menu', self)
         
-        item = menu.simple_menu_item('clear-history', ['clear-sep'], None, 'gtk-clear',
+        item = menu.simple_menu_item('clear-history', ['clear-sep'], 
+            _("_Clear Tab History"), 'edit-clear-all',
             self.clear_closed_tabs)
         item.register('playlist-closed-tab-menu', self)     
             

--- a/xlgui/preferences/collection.py
+++ b/xlgui/preferences/collection.py
@@ -53,7 +53,7 @@ class CollectionStripArtistPreference(widgets.ListPreference):
 
     def _populate_popup_cb(self, entry, menu):
         from gi.repository import Gtk
-        entry = Gtk.MenuItem.new_with_label(_('Reset to Defaults'))
+        entry = Gtk.MenuItem.new_with_mnemonic(_('Reset to _Defaults'))
         entry.connect('activate', self._reset_to_defaults_cb)
         entry.show()
 

--- a/xlgui/preferences/playback.py
+++ b/xlgui/preferences/playback.py
@@ -33,7 +33,7 @@ from xl.player import pipe
 from xl.nls import gettext as _
 
 name = _('Playback')
-icon = Gtk.STOCK_MEDIA_PLAY
+icon = 'media-playback-start'
 ui = xdg.get_data_path('ui', 'preferences', 'playback.ui')
 
 class EnginePreference(widgets.ComboPreference):

--- a/xlgui/preferences/widgets.py
+++ b/xlgui/preferences/widgets.py
@@ -69,8 +69,8 @@ class Preference(object):
                 _('A restart is required for this change to take effect.'))
 
             button = self.message.add_button(_('Restart'), Gtk.ResponseType.ACCEPT)
-            button.set_image(Gtk.Image.new_from_stock(
-                Gtk.STOCK_REFRESH, Gtk.IconSize.BUTTON))
+            button.set_image(Gtk.Image.new_from_icon_name(
+                'view-refresh', Gtk.IconSize.BUTTON))
 
             self.message.connect('response', self.on_message_response)
 

--- a/xlgui/properties.py
+++ b/xlgui/properties.py
@@ -591,8 +591,8 @@ class TagRow(object):
             self.label.set_alignment(0.0, .50)
 
         self.clear_button = Gtk.Button()
-        self.clear_button.set_image(Gtk.Image.new_from_stock(
-            Gtk.STOCK_CLEAR, Gtk.IconSize.BUTTON))
+        self.clear_button.set_image(Gtk.Image.new_from_icon_name(
+            'edit-clear', Gtk.IconSize.BUTTON))
         self.clear_button.set_relief(Gtk.ReliefStyle.NONE)
         self.clear_button.connect("clicked", self.clear)
 
@@ -604,8 +604,8 @@ class TagRow(object):
         # Remove mode settings
         self.remove_mode = False
         self.remove_button = Gtk.Button()
-        self.remove_button.set_image(Gtk.Image.new_from_stock(
-            Gtk.STOCK_REMOVE, Gtk.IconSize.BUTTON))
+        self.remove_button.set_image(Gtk.Image.new_from_icon_name(
+            'list-remove', Gtk.IconSize.BUTTON))
         self.remove_button.connect("clicked", parent.remove_row, self.tag, self.multi_id)
 
         self.field.register_update_func(parent.update_tag)
@@ -1015,7 +1015,7 @@ class TagImageField(Gtk.HBox):
         self.pixbuf = pixbuf
 
         if pixbuf is None:
-            self.image.set_from_stock(Gtk.STOCK_ADD, Gtk.IconSize.DIALOG)
+            self.image.set_from_icon_name('list-add', Gtk.IconSize.DIALOG)
             self.info_label.set_markup('')
         else:
             self.image.set_from_pixbuf(pixbuf.scale_simple(
@@ -1125,8 +1125,8 @@ class PropertyField(Gtk.HBox):
         if self.property_type == 'location':
             self.folder_button = Gtk.Button()
             self.folder_button.set_tooltip_text(_('Open Directory'))
-            self.folder_button.set_image(Gtk.Image.new_from_stock(
-                Gtk.STOCK_OPEN, Gtk.IconSize.BUTTON))
+            self.folder_button.set_image(Gtk.Image.new_from_icon_name(
+                'folder-open', Gtk.IconSize.BUTTON))
             self.pack_start(self.folder_button, False, False, 0)
             self.folder_button.connect("clicked", self.folder_button_clicked)
 

--- a/xlgui/tray.py
+++ b/xlgui/tray.py
@@ -81,7 +81,7 @@ def __create_tray_context_menu():
         from xl import main
         main.exaile().quit()
     items.append(menu.simple_menu_item('quit-application', [items[-1].name],
-        icon_name=Gtk.STOCK_QUIT, callback=quit_cb))
+        _("_Quit Exaile"), 'application-exit', callback=quit_cb))
     for item in items:
         providers.register('tray-icon-context', item)
 __create_tray_context_menu()

--- a/xlgui/widgets/dialogs.py
+++ b/xlgui/widgets/dialogs.py
@@ -203,15 +203,15 @@ class MultiTextEntryDialog(Gtk.Dialog):
                 for field in self.fields:
                     if len(field.get_text()) > 0:
                         # Unset possible previous marks
-                        field.set_icon_from_stock(
+                        field.set_icon_from_icon_name(
                             Gtk.EntryIconPosition.SECONDARY,
                             None
                         )
                     else:
                         # Mark via warning
-                        field.set_icon_from_stock(
+                        field.set_icon_from_icon_name(
                             Gtk.EntryIconPosition.SECONDARY,
-                            Gtk.STOCK_DIALOG_WARNING
+                            'dialog-warning'
                         )
         self.hide()
 

--- a/xlgui/widgets/filter.py
+++ b/xlgui/widgets/filter.py
@@ -84,7 +84,7 @@ class FilterDialog(Gtk.Dialog):
         btn = Gtk.Button()
         btn.connect('clicked', lambda *x: self.filter.add_row())
         image = Gtk.Image()
-        image.set_from_stock(Gtk.STOCK_ADD, Gtk.IconSize.BUTTON)
+        image.set_from_icon_name('list-add', Gtk.IconSize.BUTTON)
         btn.add(image)
         align = Gtk.Alignment.new(1, 0, 0, 0)
         align.add(btn)
@@ -255,7 +255,7 @@ class FilterWidget(Gtk.Table):
 
         remove_btn = Gtk.Button()
         image = Gtk.Image()
-        image.set_from_stock(Gtk.STOCK_REMOVE, Gtk.IconSize.BUTTON)
+        image.set_from_icon_name('list-remove', Gtk.IconSize.BUTTON)
         remove_btn.add(image)
         remove_btn_handler_id = remove_btn.connect(
             'clicked', self.__remove_clicked, self.n)

--- a/xlgui/widgets/info.py
+++ b/xlgui/widgets/info.py
@@ -239,12 +239,12 @@ class TrackInfoPane(Gtk.Alignment):
             if track == self.__player.current and \
                not self.__player.is_stopped():
 
-                stock_id = Gtk.STOCK_MEDIA_PLAY
+                icon_name = 'media-playback-start'
 
                 if self.__player.is_paused():
-                    stock_id = Gtk.STOCK_MEDIA_PAUSE
+                    icon_name = 'media-playback-pause'
 
-                self.playback_image.set_from_stock(stock_id,
+                self.playback_image.set_from_icon_name(icon_name,
                     Gtk.IconSize.SMALL_TOOLBAR)
 
                 self.__show_progress()

--- a/xlgui/widgets/menu.py
+++ b/xlgui/widgets/menu.py
@@ -208,7 +208,7 @@ class Menu(Gtk.Menu):
         # GTK gets unhappy if we remove the menu items before it's done with them.
         self.connect('hide', lambda *e: GLib.idle_add(self.clear_menu))
         # Placeholder exists to make sure unity doesn't get confused (legacy?)
-        self.placeholder = Gtk.MenuItem.new_with_label('')
+        self.placeholder = Gtk.MenuItem.new_with_mnemonic('')
 
     def get_context(self):
         """

--- a/xlgui/widgets/menuitems.py
+++ b/xlgui/widgets/menuitems.py
@@ -135,7 +135,7 @@ def _properties_cb(widget, name, parent, context, get_tracks_func, dialog_parent
 
 def PropertiesMenuItem(name, after, get_tracks_func=generic_get_tracks_func,
         dialog_parent=None):
-    return menu.simple_menu_item(name, after, None,
+    return menu.simple_menu_item(name, after, _("_Track Properties"),
             'document-properties', _properties_cb,
             callback_args=[get_tracks_func, dialog_parent])
 

--- a/xlgui/widgets/menuitems.py
+++ b/xlgui/widgets/menuitems.py
@@ -62,6 +62,8 @@ class RatingMenuItem(menu.MenuItem):
         self.get_tracks_func = get_tracks_func
         self.rating_set = False
 
+        # TODO: For accessibility it would be nice to add mnemonics or some
+        # other key shortcut thing to the RatingMenu, e.g. "+" and "-"
     def factory(self, menu, parent, context):
         item = rating.RatingMenuItem()
         item.connect('show', self.on_show, menu, parent, context)
@@ -96,7 +98,7 @@ def _enqueue_cb(widget, name, parent, context, get_tracks_func):
     player.QUEUE.extend(tracks)
 
 def EnqueueMenuItem(name, after, get_tracks_func=generic_get_tracks_func):
-    return menu.simple_menu_item(name, after, _("Enqueue"), 'list-add',
+    return menu.simple_menu_item(name, after, _("En_queue"), 'list-add',
             _enqueue_cb, callback_args=[get_tracks_func])
 
 # TODO: move logic into (GUI?) playlist
@@ -119,11 +121,11 @@ def _append_cb(widget, name, parent, context, get_tracks_func, replace=False):
             page.view.play_track_at(offset, tracks[0])
 
 def ReplaceCurrentMenuItem(name, after, get_tracks_func=generic_get_tracks_func):
-    return menu.simple_menu_item(name, after, _("Replace Current"), None,
+    return menu.simple_menu_item(name, after, _("_Replace Current"), None,
             _append_cb, callback_args=[get_tracks_func, True])
 
 def AppendMenuItem(name, after, get_tracks_func=generic_get_tracks_func):
-    return menu.simple_menu_item(name, after, _("Append to Current"),
+    return menu.simple_menu_item(name, after, _("_Append to Current"),
             'list-add', _append_cb, callback_args=[get_tracks_func])
 
 def _properties_cb(widget, name, parent, context, get_tracks_func, dialog_parent):
@@ -146,7 +148,7 @@ def _open_directory_cb(widget, name, parent, context, get_tracks_func):
     common.open_file_directory(track.get_loc_for_io())
 
 def OpenDirectoryMenuItem(name, after, get_tracks_func=generic_get_tracks_func):
-    return menu.simple_menu_item(name, after, _("Open Directory"),
+    return menu.simple_menu_item(name, after, _("_Open Directory"),
             'folder-open', _open_directory_cb, callback_args=[get_tracks_func])
 
 def generic_trash_tracks_func(parent, context, tracks):
@@ -183,7 +185,7 @@ def _on_trash_tracks(widget, name, parent, context,
 def TrashMenuItem(name, after, get_tracks_func=generic_get_tracks_func,
                   trash_tracks_func=generic_trash_tracks_func,
                   delete_tracks_func=generic_delete_tracks_func):
-    return menu.simple_menu_item(name, after, _('Move to Trash'), 'user-trash',
+    return menu.simple_menu_item(name, after, _('_Move to Trash'), 'user-trash',
         _on_trash_tracks, callback_args=[get_tracks_func,
             trash_tracks_func, delete_tracks_func])
 
@@ -221,25 +223,25 @@ class ShowCurrentTrackMenuItem(menu.MenuItem):
 # get_pl_func kwarg
 
 def RenamePlaylistMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('Rename'), 'accessories-text-editor',
+    return menu.simple_menu_item(name, after, _('_Rename'), 'accessories-text-editor',
                           lambda w, n, o, c: o.rename_playlist(get_pl_func(o, c)),
                           condition_fn=lambda n, p, c: not isinstance(c['selected-playlist'], playlist.SmartPlaylist))
     
 def EditPlaylistMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('Edit'), 'accessories-text-editor',
+    return menu.simple_menu_item(name, after, _('_Edit'), 'accessories-text-editor',
                           lambda w, n, o, c: o.edit_smart_playlist(get_pl_func(o, c)),
                           condition_fn=lambda n, p, c: isinstance(c['selected-playlist'], playlist.SmartPlaylist))
 
 def ExportPlaylistMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('Export Playlist'), 'document-save-as',
+    return menu.simple_menu_item(name, after, _('E_xport Playlist'), 'document-save-as',
                           lambda w, n, o, c: dialogs.export_playlist_dialog(get_pl_func(o, c)))
 
 def ExportPlaylistFilesMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('Export Files'), 'document-save-as',
+    return menu.simple_menu_item(name, after, _('Export _Files'), 'document-save-as',
                           lambda w, n, o, c: dialogs.export_playlist_files(get_pl_func(o, c)))
 
 def DeletePlaylistMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('Delete Playlist'), 'edit-delete',
+    return menu.simple_menu_item(name, after, _('_Delete Playlist'), 'edit-delete',
                           lambda w, n, o, c: o.remove_playlist(get_pl_func(o, c)))
     
 

--- a/xlgui/widgets/menuitems.py
+++ b/xlgui/widgets/menuitems.py
@@ -96,7 +96,7 @@ def _enqueue_cb(widget, name, parent, context, get_tracks_func):
     player.QUEUE.extend(tracks)
 
 def EnqueueMenuItem(name, after, get_tracks_func=generic_get_tracks_func):
-    return menu.simple_menu_item(name, after, _("Enqueue"), Gtk.STOCK_ADD,
+    return menu.simple_menu_item(name, after, _("Enqueue"), 'list-add',
             _enqueue_cb, callback_args=[get_tracks_func])
 
 # TODO: move logic into (GUI?) playlist
@@ -124,7 +124,7 @@ def ReplaceCurrentMenuItem(name, after, get_tracks_func=generic_get_tracks_func)
 
 def AppendMenuItem(name, after, get_tracks_func=generic_get_tracks_func):
     return menu.simple_menu_item(name, after, _("Append to Current"),
-            'gtk-add', _append_cb, callback_args=[get_tracks_func])
+            'list-add', _append_cb, callback_args=[get_tracks_func])
 
 def _properties_cb(widget, name, parent, context, get_tracks_func, dialog_parent):
     tracks = get_tracks_func(parent, context)
@@ -134,7 +134,7 @@ def _properties_cb(widget, name, parent, context, get_tracks_func, dialog_parent
 def PropertiesMenuItem(name, after, get_tracks_func=generic_get_tracks_func,
         dialog_parent=None):
     return menu.simple_menu_item(name, after, None,
-            'gtk-properties', _properties_cb,
+            'document-properties', _properties_cb,
             callback_args=[get_tracks_func, dialog_parent])
 
 
@@ -147,7 +147,7 @@ def _open_directory_cb(widget, name, parent, context, get_tracks_func):
 
 def OpenDirectoryMenuItem(name, after, get_tracks_func=generic_get_tracks_func):
     return menu.simple_menu_item(name, after, _("Open Directory"),
-            'gtk-open', _open_directory_cb, callback_args=[get_tracks_func])
+            'folder-open', _open_directory_cb, callback_args=[get_tracks_func])
 
 def generic_trash_tracks_func(parent, context, tracks):
     for track in tracks:
@@ -195,7 +195,7 @@ class ShowCurrentTrackMenuItem(menu.MenuItem):
     def __init__(self, name, after, callback=None, callback_args=[], accelerator=None):
         def factory(container, parent, context):
             item = Gtk.ImageMenuItem.new_with_mnemonic(_("_Show Playing Track"))
-            image = Gtk.Image.new_from_icon_name('gtk-jump-to-ltr',
+            image = Gtk.Image.new_from_icon_name('go-jump',
                     size=Gtk.IconSize.MENU)
             item.set_image(image)
 
@@ -221,25 +221,25 @@ class ShowCurrentTrackMenuItem(menu.MenuItem):
 # get_pl_func kwarg
 
 def RenamePlaylistMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('Rename'), 'gtk-edit',
+    return menu.simple_menu_item(name, after, _('Rename'), 'accessories-text-editor',
                           lambda w, n, o, c: o.rename_playlist(get_pl_func(o, c)),
                           condition_fn=lambda n, p, c: not isinstance(c['selected-playlist'], playlist.SmartPlaylist))
     
 def EditPlaylistMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('Edit'), 'gtk-edit',
+    return menu.simple_menu_item(name, after, _('Edit'), 'accessories-text-editor',
                           lambda w, n, o, c: o.edit_smart_playlist(get_pl_func(o, c)),
                           condition_fn=lambda n, p, c: isinstance(c['selected-playlist'], playlist.SmartPlaylist))
 
 def ExportPlaylistMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('Export Playlist'), 'gtk-save',
+    return menu.simple_menu_item(name, after, _('Export Playlist'), 'document-save-as',
                           lambda w, n, o, c: dialogs.export_playlist_dialog(get_pl_func(o, c)))
 
 def ExportPlaylistFilesMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('Export Files'), 'gtk-save',
+    return menu.simple_menu_item(name, after, _('Export Files'), 'document-save-as',
                           lambda w, n, o, c: dialogs.export_playlist_files(get_pl_func(o, c)))
 
 def DeletePlaylistMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('Delete Playlist'), 'gtk-delete',
+    return menu.simple_menu_item(name, after, _('Delete Playlist'), 'edit-delete',
                           lambda w, n, o, c: o.remove_playlist(get_pl_func(o, c)))
     
 

--- a/xlgui/widgets/notebook.py
+++ b/xlgui/widgets/notebook.py
@@ -202,7 +202,7 @@ class NotebookTab(Gtk.EventBox):
         button.set_relief(Gtk.ReliefStyle.NONE)
         button.set_focus_on_click(False)
         button.set_tooltip_text(_("Close Tab"))
-        button.add(Gtk.Image.new_from_stock(Gtk.STOCK_CLOSE, Gtk.IconSize.MENU))
+        button.add(Gtk.Image.new_from_icon_name('window-close', Gtk.IconSize.MENU))
         button.connect('clicked', self.close)
         button.connect('button-press-event', self.on_button_press)
         

--- a/xlgui/widgets/playback.py
+++ b/xlgui/widgets/playback.py
@@ -1218,7 +1218,7 @@ class NewMarkerMenuItem(MoveMarkerMenuItem):
     """
     def __init__(self, name, after):
         MoveMarkerMenuItem.__init__(self, name, after,
-            _('New Marker'), Gtk.STOCK_NEW)
+            _('New Marker'), 'list-add')
 
     def move_cancel(self):
         """
@@ -1270,13 +1270,12 @@ def __create_marker_context_menu():
         providers.unregister('playback-markers', context['current-marker'])
 
     items.append(menu.simple_menu_item('jumpto-marker',
-        [], icon_name=Gtk.STOCK_JUMP_TO,
-        callback=on_jumpto_item_activate))
+        [], _("_Jump to"), 'go-jump', on_jumpto_item_activate))
     items.append(MoveMarkerMenuItem('move-marker',
         [items[-1].name]))
     items.append(menu.simple_menu_item('remove-marker',
-        [items[-1].name], icon_name=Gtk.STOCK_REMOVE,
-        callback=on_remove_item_activate))
+        [items[-1].name], _("_Remove Marker"), 'list-remove',
+        on_remove_item_activate))
 
     for item in items:
         providers.register('playback-marker-context-menu', item)
@@ -1439,27 +1438,26 @@ def playpause(player):
 
 
 def PlayPauseMenuItem(name, player, after):
-    def factory(menu, parent, context):
+    def factory(name, after, player):
         if player.is_playing():
-            stock_id = Gtk.STOCK_MEDIA_PAUSE
+            icon_name = 'media-playback-pause'
+            label = _("_Pause")
         else:
-            stock_id = Gtk.STOCK_MEDIA_PLAY
-
-        item = Gtk.ImageMenuItem.new_from_stock(stock_id)
-        item.connect('activate', lambda *args: playpause( player ), name, parent, context)
-
-        return item
-    return menu.MenuItem(name, factory, after=after)
+            icon_name = 'media-playback-start'
+            label = _("P_lay")
+        return menu.simple_menu_item(name, after, label, icon_name,
+            callback=lambda *args: playpause(player) )
+    return factory(name, after, player)
 
 def NextMenuItem(name, player, after):
-    return menu.simple_menu_item(name, after, icon_name=Gtk.STOCK_MEDIA_NEXT,
+    return menu.simple_menu_item(name, after, _("_Next Track"), 'media-skip-forward',
         callback=lambda *args: player.queue.next() )
 
 def PrevMenuItem(name, player, after):
-    return menu.simple_menu_item(name, after, icon_name=Gtk.STOCK_MEDIA_PREVIOUS,
+    return menu.simple_menu_item(name, after, _("_Previous Track"), 'media-skip-backward',
         callback=lambda *args: player.queue.prev() )
 
 def StopMenuItem(name, player, after):
-    return menu.simple_menu_item(name, after, icon_name=Gtk.STOCK_MEDIA_STOP,
+    return menu.simple_menu_item(name, after, _("_Stop"), 'media-playback-stop',
         callback=lambda *args: player.stop() )
 

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -149,7 +149,7 @@ class RemoveCurrentMenuItem(menu.MenuItem):
             Sets up the menu item
         """
         item = Gtk.ImageMenuItem.new_with_label(_('Remove Current Track From Playlist'))
-        item.set_image(Gtk.Image.new_from_stock(Gtk.STOCK_REMOVE, Gtk.IconSize.MENU))
+        item.set_image(Gtk.Image.new_from_icon_name('list-remove', Gtk.IconSize.MENU))
         item.connect('activate', self.on_activate, parent, context)
 
         if player.PLAYER.is_stopped():
@@ -219,14 +219,14 @@ def __create_playlist_tab_context_menu():
             page.set_page_name(name)
             playlists.save_playlist(page.playlist)
     
-    items.append(smi('save', ['new-tab-sep'], None, 'gtk-save',
+    items.append(smi('save', ['new-tab-sep'], _("_Save"), 'document-save',
         _save_playlist_cb,
         condition_fn=lambda n, p, c: main.exaile().playlists.has_playlist_name(p.playlist.name)))
-    items.append(smi('saveas', ['save'], None, 'gtk-save-as',
+    items.append(smi('saveas', ['save'], _("Save _As"), 'document-save-as',
         _saveas_playlist_cb))
-    items.append(smi('rename', ['saveas'], _("Rename"), 'gtk-edit',
+    items.append(smi('rename', ['saveas'], _("_Rename"), None,
         lambda w, n, o, c: o.tab.start_rename()))
-    items.append(smi('clear', ['rename'], None, 'gtk-clear',
+    items.append(smi('clear', ['rename'], _("_Clear"), 'edit-clear-all',
         lambda w, n, o, c: o.playlist.clear()))
     items.append(sep('tab-close-sep', ['clear']))
     
@@ -236,7 +236,7 @@ def __create_playlist_tab_context_menu():
     items.append(menuitems.ExportPlaylistMenuItem('export', ['tab-close-sep'], _get_pl_func))
     items.append(menuitems.ExportPlaylistFilesMenuItem('export-files', ['export'], _get_pl_func))
     items.append(sep('tab-export-sep', ['export']))
-    items.append(smi('tab-close', ['tab-export-sep'], None, 'gtk-close',
+    items.append(smi('tab-close', ['tab-export-sep'], _("Close _Tab"), 'window-close',
         lambda w, n, o, c: o.tab.close()))
     for item in items:
         providers.register('playlist-tab-context-menu', item)
@@ -272,17 +272,17 @@ class SPATMenuItem(menu.MenuItem):
             Generates the menu item
         """
         display_name = _('Stop Playback After This Track')
-        stock_id = Gtk.STOCK_STOP
+        icon_name = 'media-playback-stop'
 
         if context['selected-items']:
             selection_position = context['selected-items'][0][0]
 
             if selection_position == parent.playlist.spat_position:
                 display_name = _('Continue Playback After This Track')
-                stock_id = Gtk.STOCK_MEDIA_PLAY
+                icon_name = 'media-playback-play'
 
         menuitem = Gtk.ImageMenuItem.new_with_label(display_name)
-        menuitem.set_image(Gtk.Image.new_from_stock(stock_id,
+        menuitem.set_image(Gtk.Image.new_from_icon_name(icon_name,
             Gtk.IconSize.MENU))
         menuitem.connect('activate', self.on_menuitem_activate,
             parent, context)
@@ -327,8 +327,8 @@ def __create_playlist_context_menu():
         else:
             for position, track in tracks[::-1]:
                 del playlist[position]
-    items.append(smi('remove', [items[-1].name], None,
-        Gtk.STOCK_REMOVE, remove_tracks_cb))
+    items.append(smi('remove', [items[-1].name], _("_Remove from Playlist"),
+        'list-remove', remove_tracks_cb))
 
     items.append(RandomizeMenuItem([items[-1].name]))
 
@@ -346,8 +346,8 @@ def __create_playlist_context_menu():
 
     items.append(sep('sep2', [items[-1].name]))
 
-    items.append(smi('properties', [items[-1].name], None,
-        Gtk.STOCK_PROPERTIES, lambda w, n, o, c: o.show_properties_dialog()))
+    items.append(smi('properties', [items[-1].name], _("Track _Properties"),
+        'document-properties', lambda w, n, o, c: o.show_properties_dialog()))
 
     for item in items:
         providers.register('playlist-context-menu', item)

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -125,15 +125,15 @@ class ModesMenuItem(menu.MenuItem):
 
 class ShuffleModesMenuItem(ModesMenuItem):
     modetype = 'shuffle'
-    display_name = _("Shuffle")
+    display_name = _("S_huffle")
 
 class RepeatModesMenuItem(ModesMenuItem):
     modetype = 'repeat'
-    display_name = _("Repeat")
+    display_name = _("R_epeat")
 
 class DynamicModesMenuItem(ModesMenuItem):
     modetype = 'dynamic'
-    display_name = _("Dynamic")
+    display_name = _("_Dynamic")
 
 class RemoveCurrentMenuItem(menu.MenuItem):
     """
@@ -148,7 +148,7 @@ class RemoveCurrentMenuItem(menu.MenuItem):
         """
             Sets up the menu item
         """
-        item = Gtk.ImageMenuItem.new_with_label(_('Remove Current Track From Playlist'))
+        item = Gtk.ImageMenuItem.new_with_mnemonic(_('Remove _Current Track From Playlist'))
         item.set_image(Gtk.Image.new_from_icon_name('list-remove', Gtk.IconSize.MENU))
         item.connect('activate', self.on_activate, parent, context)
 
@@ -178,10 +178,10 @@ class RandomizeMenuItem(menu.MenuItem):
         """
             Sets up the menu item
         """
-        label = _('Randomize Playlist')
+        label = _('R_andomize Playlist')
 
         if not context['selection-empty']:
-            label = _('Randomize Selection')
+            label = _('R_andomize Selection')
 
         item = Gtk.MenuItem.new_with_mnemonic(label)
         item.connect('activate', self.on_activate, parent, context)
@@ -202,7 +202,7 @@ def __create_playlist_tab_context_menu():
     smi = menu.simple_menu_item
     sep = menu.simple_separator
     items = []
-    items.append(smi('new-tab', [], _("New Playlist"), 'tab-new',
+    items.append(smi('new-tab', [], _("_New Playlist"), 'tab-new',
         lambda w, n, o, c: o.tab.notebook.create_new_playlist()))
     items.append(sep('new-tab-sep', ['new-tab']))
     
@@ -271,17 +271,17 @@ class SPATMenuItem(menu.MenuItem):
         """
             Generates the menu item
         """
-        display_name = _('Stop Playback After This Track')
+        display_name = _('_Stop Playback After This Track')
         icon_name = 'media-playback-stop'
 
         if context['selected-items']:
             selection_position = context['selected-items'][0][0]
 
             if selection_position == parent.playlist.spat_position:
-                display_name = _('Continue Playback After This Track')
+                display_name = _('_Continue Playback After This Track')
                 icon_name = 'media-playback-play'
 
-        menuitem = Gtk.ImageMenuItem.new_with_label(display_name)
+        menuitem = Gtk.ImageMenuItem.new_with_mnemonic(display_name)
         menuitem.set_image(Gtk.Image.new_from_icon_name(icon_name,
             Gtk.IconSize.MENU))
         menuitem.connect('activate', self.on_menuitem_activate,
@@ -346,7 +346,7 @@ def __create_playlist_context_menu():
 
     items.append(sep('sep2', [items[-1].name]))
 
-    items.append(smi('properties', [items[-1].name], _("Track _Properties"),
+    items.append(smi('properties', [items[-1].name], _("_Track Properties"),
         'document-properties', lambda w, n, o, c: o.show_properties_dialog()))
 
     for item in items:

--- a/xlgui/widgets/queue.py
+++ b/xlgui/widgets/queue.py
@@ -38,7 +38,7 @@ def __create_queue_tab_context_menu():
     smi = menu.simple_menu_item
     sep = menu.simple_separator
     items = []
-    items.append(smi('clear', [], None, 'gtk-clear',
+    items.append(smi('clear', [], _("_Clear Queue"), 'edit-clear-all',
         lambda w, n, o, c: o.player.queue.clear()))
     
     def _saveas_playlist_cb(widget, name, page, context):
@@ -50,10 +50,10 @@ def __create_queue_tab_context_menu():
             exaile.playlists.save_playlist(pl)
             page.container.create_tab_from_playlist(pl)
     
-    items.append(smi('saveas', ['clear'], None, 'gtk-save-as',
+    items.append(smi('saveas', ['clear'], _("_Save as Playlist"), 'document-save-as',
         _saveas_playlist_cb))
     items.append(sep('tab-close-sep', ['saveas']))
-    items.append(smi('tab-close', ['tab-close-sep'], None, 'gtk-close',
+    items.append(smi('tab-close', ['tab-close-sep'], _("C_lose Tab"), 'window-close',
         lambda w, n, o, c: o.tab.close()))
     for item in items:
         providers.register('queue-tab-context', item)

--- a/xlgui/widgets/queue.py
+++ b/xlgui/widgets/queue.py
@@ -53,7 +53,7 @@ def __create_queue_tab_context_menu():
     items.append(smi('saveas', ['clear'], _("_Save as Playlist"), 'document-save-as',
         _saveas_playlist_cb))
     items.append(sep('tab-close-sep', ['saveas']))
-    items.append(smi('tab-close', ['tab-close-sep'], _("C_lose Tab"), 'window-close',
+    items.append(smi('tab-close', ['tab-close-sep'], _("Close _Tab"), 'window-close',
         lambda w, n, o, c: o.tab.close()))
     for item in items:
         providers.register('queue-tab-context', item)


### PR DESCRIPTION
This is the simple part of removing GtkStock. In most cases I could just use another icon exactly replacing the old one. Also changes the "Device manager" icon from 'harddisk' to 'multimedia-player'.
Added an image to "Covers".
What is left of GtkStock usage? Mostly dialog buttons plus some API in progress.py, icons.py, guiutil.py and some minor ones. I don't want to break API since I am not experienced in python programming.