### PR TITLE
Lyricwiki Plugin: Changed url to http://lyrics.wikia.com/wiki

### DIFF
--- a/plugins/lyricwiki/__init__.py
+++ b/plugins/lyricwiki/__init__.py
@@ -47,7 +47,7 @@ class LyricWiki(LyricSearchMethod):
         artist = urllib.quote(artist.replace(' ','_'))
         title = urllib.quote(title.replace(' ','_'))
 
-        url = 'http://lyrics.wikia.com/%s:%s' % (artist, title)
+        url = 'http://lyrics.wikia.com/wiki/%s:%s' % (artist, title)
 
         try:
             html = common.get_url_contents(url, self.user_agent)


### PR DESCRIPTION
Changed the url from http://lyrics.wikia.com/ to http://lyrics.wikia.com/wiki/ because there is a redirect from the first url to the second url anyway and new things take a while (multiple days) until the are available through the first url (but are available trough the second url immediately).

Note that there is also a bug in the lyrics viewer (the view with the actual text is not expanding, the lyrics cannot be seen).  A fix for that is not included because of https://github.com/exaile/exaile/pull/129 which also seems to addresses this.

It could also be fixed by changing 
```
    <property name="expand">False</property>
```
To
```
    <property name="expand">True</property>
```
in "plugins/lyricsviewer/lyricsviewer.ui" line 103

Thanks for your good work!