### PR TITLE
Fix: unicode lyrics not shown

### DIFF
--- a/xl/lyrics.py
+++ b/xl/lyrics.py
@@ -270,8 +270,12 @@ class LyricsManager(providers.ProviderHandler):
             if lyrics:
                 # update cache
                 time = datetime.now()
+
+                if isinstance(lyrics, unicode):
+                    lyrics = lyrics.encode('utf8')
+
                 self.cache[key] = (zlib.compress(lyrics), source, url, time)
-                
+
         if not lyrics:
             # no lyrcs were found, raise an exception
             raise LyricsNotFoundException()


### PR DESCRIPTION
It failed to show lyrics if they had unicode in them, because the caching failed. 
This fixes it, but I don't quite understand what pythons problem is with unicode ;).
So it may not be a good solution.

Feel free to reject or tell me in a short comment whats wrong with that solution.
Thanks.

For sake of completion, here is the stacktrace this pullrequest solves:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/martin/develop/git/exaile/plugins/lyricsviewer/__init__.py", line 265, in get_lyrics
    lyrics_found = lyrics.MANAGER.find_all_lyrics(track, refresh)
  File "/home/martin/develop/git/exaile/xl/lyrics.py", line 215, in find_all_lyrics
    (lyrics, source, url) = self._find_cached_lyrics(method, track, refresh)
  File "/home/martin/develop/git/exaile/xl/lyrics.py", line 273, in _find_cached_lyrics
    self.cache[key] = (zlib.compress(lyrics), source, url, time)
UnicodeEncodeError: 'ascii' codec can't encode character u'\x92' in position 5: ordinal not in range(128)
```