### PR TITLE
Collection Panel: use GtkStack, center message

### DIFF
--- a/data/ui/panel/collection.ui
+++ b/data/ui/panel/collection.ui
@@ -17,15 +17,14 @@
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Collection</property>
     <child>
-      <object class="GtkBox" id="CollectionTopContainer">
+      <object class="GtkStack" id="CollectionPanel">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox" id="EmptyCollectionPanel">
+            <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="no_show_all">True</property>
             <property name="orientation">vertical</property>
+            <property name="valign">center</property>
             <property name="spacing">12</property>
             <child>
               <object class="GtkLabel" id="empty_collection_label">
@@ -74,13 +73,11 @@
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="CollectionPanel">
+          <object class="GtkBox" id="PopulatedCollectionPanel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">3</property>
@@ -166,8 +163,6 @@
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>

--- a/xlgui/panel/collection.py
+++ b/xlgui/panel/collection.py
@@ -179,7 +179,8 @@ class CollectionPanel(panel.Panel):
         self.collection = collection
         self.use_alphabet = settings.get_option('gui/use_alphabet', True)
         self.vbox = self.builder.get_object('CollectionPanel')
-        self.message = self.builder.get_object('EmptyCollectionPanel')
+        self.empty_collection_panel = self.builder.get_object('EmptyCollectionPanel')
+        self.populated_collection_panel = self.builder.get_object('PopulatedCollectionPanel')
         self.choice = self.builder.get_object('collection_combo_box')
         self.collection_empty_message = False
         self._search_num = 0
@@ -229,19 +230,18 @@ class CollectionPanel(panel.Panel):
         if not self._show_collection_empty_message or \
             (self.collection.libraries and self.collection_empty_message):
             self.collection_empty_message = False
-            GLib.idle_add(self.vbox.set_child_visible, True)
-            GLib.idle_add(self.message.set_child_visible, False)
-            GLib.idle_add(self.vbox.show_all)
-            GLib.idle_add(self.message.hide)
+            GLib.idle_add(self.populated_collection_panel.show_all)
+            GLib.idle_add(self.empty_collection_panel.hide)
+            GLib.idle_add(self.vbox.set_visible_child, \
+                self.populated_collection_panel)
 
         elif not self.collection.libraries and not \
             self.collection_empty_message:
             self.collection_empty_message = True
-            GLib.idle_add(self.vbox.set_child_visible, False)
-            GLib.idle_add(self.message.set_no_show_all, False)
-            GLib.idle_add(self.message.set_child_visible, True)
-            GLib.idle_add(self.vbox.hide)
-            GLib.idle_add(self.message.show_all)
+            GLib.idle_add(self.empty_collection_panel.show_all)
+            GLib.idle_add(self.populated_collection_panel.hide)
+            GLib.idle_add(self.vbox.set_visible_child, \
+                self.empty_collection_panel)
 
     def _connect_events(self):
         """
@@ -372,7 +372,7 @@ class CollectionPanel(panel.Panel):
         """
         self.tree = CollectionDragTreeView(self)
         self.tree.set_headers_visible(False)
-        container = self.builder.get_object('CollectionPanel')
+        container = self.populated_collection_panel
         scroll = Gtk.ScrolledWindow()
         scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scroll.add(self.tree)


### PR DESCRIPTION
Use a GtkStack instead of adding and removing widgets
Center the "empty collection" message

TODO: change wiki entry for "empty collection" message after this PR is merged.