### PR TITLE
Fix: tags not read for opus files

### DIFF
--- a/xl/metadata/__init__.py
+++ b/xl/metadata/__init__.py
@@ -64,7 +64,7 @@ formats = {
         'ogg'   : ogg.OggFormat,
         'ogx'   : ogg.OggFormat,
         'okt'   : mod.ModFormat,
-        'opus'  : None,
+        'opus'  : ogg.OggOpusFormat,
         'ra'    : None,
         'ram'   : None,
         's3m'   : mod.ModFormat,

--- a/xl/metadata/ogg.py
+++ b/xl/metadata/ogg.py
@@ -56,7 +56,6 @@ class OggFormat(BaseFormat):
                 picture = mutagen.flac.Picture(base64.standard_b64decode(d))
                 td['cover'] += [CoverImage(type=picture.type, desc=picture.desc, mime=picture.mime, data=picture.data)]
         return td
-# vim: et sts=4 sw=4
 
 
 class OggOpusFormat(OggFormat):

--- a/xl/metadata/ogg.py
+++ b/xl/metadata/ogg.py
@@ -29,9 +29,10 @@ from xl.metadata._base import (
     BaseFormat,
     CoverImage
 )
-from mutagen import oggvorbis
+from mutagen import oggvorbis, oggopus
 import mutagen.flac
 import base64
+
 
 class OggFormat(BaseFormat):
     MutagenType = oggvorbis.OggVorbis
@@ -57,3 +58,6 @@ class OggFormat(BaseFormat):
         return td
 # vim: et sts=4 sw=4
 
+
+class OggOpusFormat(OggFormat):
+    MutagenType = oggopus.OggOpus


### PR DESCRIPTION
Tags of opus files could not be read.
This small changes fix it (at least my manual tests where successful, but my python knowledge is limited, so please review thoroughly)

An example file could be found here:
http://xiph.org/~giles/2012/opus/detodos.opus

thx