### PR TITLE
Don't write "WARNING" in an INFO level log message

### DIFF
--- a/plugins/podcasts/__init__.py
+++ b/plugins/podcasts/__init__.py
@@ -208,7 +208,7 @@ class PodcastPanel(panel.Panel):
                 (url, title) = line.split('\t')
                 self.podcasts.append((title, url))
         except (IOError, OSError):
-            logger.info('WARNING: could not open podcast file')
+            logger.warn('Could not open podcast file')
             self._set_status('')
             return
 


### PR DESCRIPTION
Using `WARNING: ` in an INFO level log message is inconsistent. 

A better solution would be to distinguish 2 cases:
1. no podcast file exists. This is a valid use case and no problem. Don't `warn()` or `info()` but ignore.
2. podcast file exists but cannot be opened. In this case something is wrong, this is an invalid use case. `warn()` or `error()`.