### PR TITLE
event: add first-class support for UI callbacks

### DIFF
--- a/tests/xl/test_event.py
+++ b/tests/xl/test_event.py
@@ -1,0 +1,97 @@
+
+from gi.repository import GLib
+import threading
+
+# nasty globals
+on_ui_thread = [False]
+calls = [0]
+
+# TODO: monkeypatch instead
+def glib_idle_add(fn, *args):
+    was_ui_thread = on_ui_thread[0]
+    on_ui_thread[0] = True
+    
+    try:
+        fn(*args)
+    finally:
+        on_ui_thread[0] = was_ui_thread
+
+GLib.idle_add = glib_idle_add
+
+from xl import event
+
+class NormalCallback(object):
+    
+    def __init__(self):
+        self.called = False
+        event.add_callback(self.on_cb, 'test')
+        
+    def destroy(self):
+        event.remove_callback(self.on_cb, 'test')
+        
+    def on_cb(self, type, obj, data):
+        self.called = True
+        self.on_ui_thread = on_ui_thread[0]
+    
+class UiCallback(object):
+    
+    def __init__(self):
+        self.called = False
+        event.add_ui_callback(self.on_cb, 'test')
+        
+    def destroy(self):
+        event.remove_callback(self.on_cb, 'test')
+    
+    def on_cb(self, type, obj, data):
+        if on_ui_thread[0]:
+            self.called = True
+
+def _init_events():
+    event.EVENT_MANAGER = event.EventManager()
+
+def _finish_events():
+    assert len(event.EVENT_MANAGER.callbacks) == 0
+    assert len(event.EVENT_MANAGER.all_callbacks) == 0
+    assert len(event.EVENT_MANAGER.ui_callbacks) == 0
+
+def test_ui_events():
+    _init_events()
+    ucb = UiCallback()
+    ncb = NormalCallback()
+    
+    on_ui_thread[0] = True
+    event.log_event('test', ucb, None)
+    
+    assert ncb.called == True
+    assert ncb.on_ui_thread == True
+    assert ucb.called == True
+    
+    ucb.destroy()
+    ncb.destroy()
+    
+    _finish_events()
+    
+def test_thread_events():
+    
+    _init_events()
+    ucb = UiCallback()
+    ncb = NormalCallback()
+    
+    def _run():
+        on_ui_thread[0] = False
+        event.log_event('test', ucb, None)
+    
+    t = threading.Thread(target=_run)
+    t.start()
+    t.join()
+    
+    assert ncb.called == True
+    assert ncb.on_ui_thread == False
+    assert ucb.called == True
+    
+    ucb.destroy()
+    ncb.destroy()
+    
+    _finish_events()
+    
+    


### PR DESCRIPTION
* Add add_ui_callback function to event to signify that you only want to receive events on the UI thread
* No more idle_add required, easier to audit

This is a first step towards fixing #83. I'd love feedback for making this more efficient, this was the first implementation that popped into my head. In particular, I wonder if there's a way that this could be implemented without using three separate dictionaries... I didn't want to keep checking to see if a callback was 'ui' or not, though, perhaps it's not that big of a deal. 

Fixed some correctness stuff in the weakref usage also.

@sjohannes , @genodeftest , thoughts?

Once this gets in, then I think the next step is to convert most of the UI classes to use add_ui_callback instead of add_callback... maybe plugins too. Then will need to audit each usage of common.threaded to ensure that they aren't touching GTK widgets.