### PR TITLE
Main window: move ProgressManager into footer

### DIFF
--- a/data/ui/main.ui
+++ b/data/ui/main.ui
@@ -10,10 +10,9 @@
     <signal name="delete-event" handler="on_delete_event" after="yes" swapped="no"/>
     <signal name="window-state-event" handler="on_window_state_event" swapped="no"/>
     <child>
-      <object class="GtkBox" id="vbox1">
+      <object class="GtkGrid" id="grid1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
         <child>
           <object class="GtkMenuBar" id="mainmenu">
             <property name="visible">True</property>
@@ -75,55 +74,29 @@
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+            <property name="width">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkPaned" id="splitter">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
             <property name="position">129</property>
             <child>
-              <object class="GtkBox" id="panel_box">
+              <object class="GtkNotebook" id="panel_notebook">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
+                <property name="can_focus">True</property>
+                <property name="tab_pos">left</property>
+                <property name="scrollable">True</property>
                 <child>
-                  <object class="GtkNotebook" id="panel_notebook">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="tab_pos">left</property>
-                    <property name="scrollable">True</property>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child type="tab">
-                      <placeholder/>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
+                  <placeholder/>
                 </child>
-                <child>
-                  <object class="GtkBox" id="progress_box">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">3</property>
-                    <property name="orientation">vertical</property>
-                    <child>
-                      <placeholder/>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
+                <child type="tab">
+                  <placeholder/>
                 </child>
               </object>
               <packing>
@@ -290,27 +263,42 @@ Right Click for Stop After Track Feature</property>
               </object>
               <packing>
                 <property name="resize">True</property>
-                <property name="shrink">True</property>
+                <property name="shrink">False</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
+            <property name="width">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkStatusbar" id="status_bar">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="halign">end</property>
             <property name="spacing">3</property>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">2</property>
+            <property name="left_attach">1</property>
+            <property name="top_attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="progress_box">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="border_width">3</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">2</property>
           </packing>
         </child>
       </object>

--- a/data/ui/panel/playlists.ui
+++ b/data/ui/panel/playlists.ui
@@ -8,6 +8,7 @@
     <property name="title" translatable="yes">Playlists</property>
     <child>
       <object class="GtkBox" id="playlists_box">
+        <property name="width_request">85</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="border_width">3</property>

--- a/data/ui/widgets/progress.ui
+++ b/data/ui/widgets/progress.ui
@@ -7,23 +7,10 @@
     <property name="can_focus">False</property>
     <property name="icon_name">process-stop</property>
   </object>
-  <template class="ProgressMonitor" parent="GtkGrid">
+  <template class="ProgressMonitor" parent="GtkBox">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="column_spacing">3</property>
-    <child>
-      <object class="GtkProgressBar" id="progressbar">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="hexpand">True</property>
-        <property name="pulse_step">0.050000000000000003</property>
-        <property name="show_text">True</property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">1</property>
-      </packing>
-    </child>
+    <property name="spacing">3</property>
     <child>
       <object class="GtkButton" id="cancel_button">
         <property name="label">_Stop</property>
@@ -39,35 +26,40 @@
         <signal name="clicked" handler="on_cancel_button_clicked" swapped="no"/>
       </object>
       <packing>
-        <property name="left_attach">1</property>
-        <property name="top_attach">1</property>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="pack_type">end</property>
+        <property name="position">0</property>
       </packing>
     </child>
     <child>
-      <object class="GtkBox" id="box">
+      <object class="GtkProgressBar" id="progressbar">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">3</property>
-        <child>
-          <object class="GtkLabel" id="label">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">start</property>
-            <property name="hexpand">True</property>
-            <property name="label" translatable="yes">label</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
+        <property name="hexpand">True</property>
+        <property name="pulse_step">0.050000000000000003</property>
+        <property name="show_text">True</property>
       </object>
       <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">0</property>
-        <property name="width">2</property>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="pack_type">end</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="hexpand">True</property>
+        <property name="label" translatable="yes">label</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="pack_type">end</property>
+        <property name="position">2</property>
       </packing>
     </child>
   </template>

--- a/xlgui/__init__.py
+++ b/xlgui/__init__.py
@@ -143,6 +143,8 @@ class Main(object):
         
         guiutil.gtk_widget_replace(panel_notebook, 
                                    self.panel_notebook)
+        self.panel_notebook.get_parent()    \
+            .child_set_property(self.panel_notebook, 'shrink', False)
 
         if settings.get_option('gui/use_tray', False):
             self.tray_icon = tray.TrayIcon(self.main)

--- a/xlgui/main.py
+++ b/xlgui/main.py
@@ -350,8 +350,6 @@ class MainWindow(GObject.GObject):
             Sets up panel events
         """
         
-        self.panel_box = self.builder.get_object('panel_box')
-        
         # When there's nothing in the notebook, hide it
         self.controller.panel_notebook.connect('page-added', self.on_panel_notebook_add_page)
         self.controller.panel_notebook.connect('page-removed', self.on_panel_notebook_remove_page)
@@ -421,11 +419,13 @@ class MainWindow(GObject.GObject):
             
     def on_panel_notebook_add_page(self, notebook, page, page_num):
         if self.splitter.get_child1() is None:
-            self.splitter.pack1(self.panel_box)
+            self.splitter.pack1(self.controller.panel_notebook)
+            self.controller.panel_notebook.get_parent()    \
+                .child_set_property(self.controller.panel_notebook, 'shrink', False)
         
     def on_panel_notebook_remove_page(self, notebook, page, page_num):
         if notebook.get_n_pages() == 0:
-            self.splitter.remove(self.panel_box)
+            self.splitter.remove(self.controller.panel_notebook)
 
     def on_stop_button_motion_notify_event(self, widget, event):
         """

--- a/xlgui/progress.py
+++ b/xlgui/progress.py
@@ -33,7 +33,7 @@ from xl.nls import gettext as _
 from xlgui.guiutil import GtkTemplate
 
 @GtkTemplate('ui', 'widgets', 'progress.ui')
-class ProgressMonitor(Gtk.Grid):
+class ProgressMonitor(Gtk.Box):
     """
         A graphical progress monitor
     """
@@ -41,8 +41,7 @@ class ProgressMonitor(Gtk.Grid):
     __gtype_name__ = 'ProgressMonitor'
     
     label,          \
-    box,            \
-    progressbar     = GtkTemplate.Child.widgets(3)
+    progressbar     = GtkTemplate.Child.widgets(2)
     
     def __init__(self, manager, thread, description, image=None):
         """
@@ -63,7 +62,7 @@ class ProgressMonitor(Gtk.Grid):
         self._progress_updated = False
 
         if image is not None:
-            self.box.pack_start(image, False, True, 0)
+            self.pack_start(image, False, True, 0)
             
         self.label.set_text(description)
         


### PR DESCRIPTION
Move the ProgressManager into footer ("status bar") beside GtkStatusBar.

ProgressManager: Replace 2-line-design (grid) by one-line-design (box) to fit into footer

main window GtkPaned: force disable shrink of right and left child. Even after removing and re-adding left child. Note: this change effectively forces a minimum window size.

Playlists panel: force minimum size to match changes to main window GtkPaned.