### PR TITLE
repeat+shuffle: prevent recursion on playlist length of 1

### DIFF
--- a/xl/playlist.py
+++ b/xl/playlist.py
@@ -1128,8 +1128,12 @@ class Playlist(object):
                 next = None
 
         if next is None:
-            if repeat_mode == 'all' and len(self) > 0:
-                return self.__get_next(-1)
+            if repeat_mode == 'all':
+                if len(self) == 1:
+                    next = self[current_position]
+                    next_index = current_position
+                if len(self) > 1:
+                    return self.__get_next(-1)
 
         self.__next_data = (None, next_index, next)
         return next


### PR DESCRIPTION
Fix #37 RuntimeError: maximum recursion depth exceeded

Original reproducer lead to an infinite recursion in `__get_next()`
1. Create a new playlist
2. set shuffle mode to "shuffle tracks" and repeat mode to "repeat all"
3. Add one single song to the playlist
4. Press play
5. Press next