### PR TITLE
ignore __pycache__ dir when searching for plugins

### DIFF
--- a/xl/plugins.py
+++ b/xl/plugins.py
@@ -176,7 +176,8 @@ class PluginsManager(object):
             if os.path.exists(dir):
                 for file in os.listdir(dir):
                     if file not in pluginlist and \
-                            os.path.isdir(os.path.join(dir, file)):
+                            os.path.isdir(os.path.join(dir, file)) and \
+                            file != '__pycache__':
                         pluginlist.append(file)
         return pluginlist
 


### PR DESCRIPTION
In current development versions exaile would display an error message due to a folder named `__pycache__` in plugins dir. With this commit this folder will be ignored.

Tested from a git installation:
* list plugins
* enable, disable random plugins

__Edit:__ fixed markdown interpretion of underscores