### PR TITLE
Disable tray icon on wayland

### DIFF
--- a/xlgui/__init__.py
+++ b/xlgui/__init__.py
@@ -147,7 +147,11 @@ class Main(object):
             .child_set_property(self.panel_notebook, 'shrink', False)
 
         if settings.get_option('gui/use_tray', False):
-            self.tray_icon = tray.TrayIcon(self.main)
+            if tray.is_supported():
+                self.tray_icon = tray.TrayIcon(self.main)
+            else:
+                settings.set_option('gui/use_tray', False)
+                logger.warn("Tray icons are not supported on your platform. Disabling tray icon.")
             
         from xl import event
         event.add_ui_callback(self.add_device_panel, 'device_connected')

--- a/xlgui/preferences/appearance.py
+++ b/xlgui/preferences/appearance.py
@@ -29,6 +29,7 @@ from gi.repository import Gtk
 from xl import xdg
 from xl.nls import gettext as _
 from xlgui.preferences import widgets
+from xlgui import tray
 
 name = _('Appearance')
 icon = 'preferences-desktop-theme'
@@ -89,9 +90,19 @@ class TrackCountsPreference(widgets.CheckPreference):
         return return_value
         
 
-class UseTrayPreference(widgets.CheckPreference):
+class UseTrayPreference(widgets.CheckPreference, widgets.Conditional):
     default = False
     name = 'gui/use_tray'
+
+    def __init__(self, preferences, widget):
+        widgets.CheckPreference.__init__(self, preferences, widget)
+        widgets.Conditional.__init__(self)
+        if not tray.is_supported():
+            self.widget.set_tooltip_text(_("Tray icons are not supported on your platform"))
+    
+    def on_check_condition(self):
+        return tray.is_supported()
+
 
 class MinimizeToTrayPreference(widgets.CheckPreference, widgets.CheckConditional):
     default = False

--- a/xlgui/tray.py
+++ b/xlgui/tray.py
@@ -24,6 +24,8 @@
 # do so. If you do not wish to do so, delete this exception statement
 # from your version.
 
+import logging
+
 from gi.repository import Gdk
 from gi.repository import Gtk
 
@@ -36,6 +38,25 @@ from xl import (
 from xl.nls import gettext as _
 from xlgui.widgets.info import TrackToolTip
 from xlgui.widgets import rating, menu, menuitems, playlist, playback
+
+logger = logging.getLogger(__name__)
+
+
+def is_supported():
+    """
+    On some platforms (e.g. Linux+Wayland) tray icons are not supported.
+    """
+    supported = not __platform_is_wayland()
+    
+    if not supported:
+        logger.debug("No tray icon support on this platform")
+    
+    return supported
+
+
+def __platform_is_wayland():
+    display_name = Gdk.Display.get_default().get_name()
+    return display_name == 'Wayland'
 
 
 def __create_tray_context_menu():


### PR DESCRIPTION
This change does:
* prevent exaile from starting minimized to tray on Wayland
* disable the `gui/use_tray` preference when started on Wayland
* not interfere with exaile running on anything but Wayland except for the point above
* fix #181

What I noticed is that with and without this change applied the `--start-minimized` option is ignored and exaile will never start to tray. Can someone confirm that? Is this probably specific to gnome sessions? If yes, can someone please test that my change doesn't break the `--start-minimized` option on some other desktop?