### PR TITLE
Fix panel popup menu

### DIFF
--- a/xlgui/panel/collection.py
+++ b/xlgui/panel/collection.py
@@ -455,6 +455,7 @@ class CollectionPanel(panel.Panel):
                 return True
             else:
                 return False
+        return True
 
     def on_expanded(self, tree, iter, path):
         """

--- a/xlgui/widgets/common.py
+++ b/xlgui/widgets/common.py
@@ -419,6 +419,7 @@ class DragTreeView(AutoScrollTreeView):
             return self.container.button_press(button, event)
         except AttributeError:
             pass
+        return True
 
     def on_button_release(self, button, event):
         """


### PR DESCRIPTION
This is reported as bug #156:
You couldn't right-click open a popup menu on multiple files or items. Exaile always deselected all but one elements.

Cause: handlers for signal button-press-event must return true in some cases. See [1] for this tip.
The change in DragTreeView reflects the fact that users might move their mouse a bit between pressing and releasing their right mouse button. In this case selection should not break either.

This issue would not have happened if python were enforcing explicit returns instead of assuming that returning nothing is returning False. Blame you, python!

[1] http://mailman.daa.com.au/cgi-bin/pipermail/pygtk/2005-June/010465.html