### PR TITLE
[gi] inhibitsuspend plugin: fix for wayland, make more robust

### DIFF
--- a/plugins/inhibitsuspend/__init__.py
+++ b/plugins/inhibitsuspend/__init__.py
@@ -272,4 +272,4 @@ class XfceAdapter(PowerManagerAdapter):
             PowerManagerAdapter.__init__(self)
         except EnvironmentError:
             # Fall back to other bus name
-            PowerManager.__init(self, bus_name='org.xfce.PowerManager')
+            PowerManagerAdapter.__init(self, bus_name='org.xfce.PowerManager')

--- a/plugins/inhibitsuspend/__init__.py
+++ b/plugins/inhibitsuspend/__init__.py
@@ -32,8 +32,10 @@ def enable(exaile):
             SUSPEND_PLUGIN = SuspendInhibit()  
         except EnvironmentError:
             logger.error('Failed to Acquire Suspend Bus')
+            raise
         except NotImplementedError:
             logger.error('Desktop Session not implemented')
+            raise
 
         # allow plugin to finished enabling so that if user returns
         # to gnome plugin will not have to be re-enabled


### PR DESCRIPTION
 Re-raise Errors to disable Plugin on failure …
> Don't make plugin seem to work if it doesn't.

Make session detection more robust …
> On gnome 3.18+Wayland, DESKTOP_SESSION defaults to 'gnome-wayland', this is fixed by this commit.
> XDG_CURRENT_SESSION is going to replace DESKTOP_SESSION, so add it to session detection.
> Since XDG_CURRENT_SESSION is not very old (see [1]) keep DESKTOP_SESSION.
> 
> A more elegant way to solve this would be using Gtk.Application.inhibit(), then we could get rid of most of this code.
> To do that Exaile would need to get ported to Gtk.Application first (much work included).
> 
> [1] https://askubuntu.com/questions/72549/how-to-determine-which-window-manager-is-running

I didn't test this plugin under KDE or xfce, just under gnome (both wayland and X11, both if my session suspends correctly and if this plugin inhibits suspend correctly).