### PR TITLE
Require GIRepository

### DIFF
--- a/xl/main.py
+++ b/xl/main.py
@@ -49,6 +49,7 @@ def _do_heavy_imports():
     gi.require_version('Gdk', '3.0')
     gi.require_version('Gtk', '3.0')
     gi.require_version('Gst', '1.0')
+    gi.require_version('GIRepository', '2.0')
     
     from gi.repository import Gio
     from xl import common, xdg


### PR DESCRIPTION
Prevent warning when opening preferences page "Plugins" for the first time. Since all the other essential `gi.require_version()` calls are here, I put it here too, which might be wrong.