### PR TITLE
Clarify meaning of `__date_added` field

### DIFF
--- a/xl/metadata/tags.py
+++ b/xl/metadata/tags.py
@@ -70,7 +70,7 @@ tag_data = {
     
     '__bitrate':        _TD(N_('Bitrate'),      'bitrate', editable=False),
     '__basedir':        None,
-    '__date_added':     _TD(N_('Date added'),   'timestamp', editable=False),
+    '__date_added':     _TD(N_('Added to library'),   'timestamp', editable=False),
     '__last_played':    _TD(N_('Last played'),  'timestamp', editable=False),
     '__length':         _TD(N_('Length'),       'time', editable=False),
     '__loc':            _TD(N_('Location'),     'location', editable=False),


### PR DESCRIPTION
When a track has not been added to exaile's collection, it will show "Never" in the "Date added" column. It is unclear where the track has (never) been added to.

See https://github.com/exaile/exaile/issues/226#issuecomment-195025945 for more details.