### PR TITLE
Migrate mox to mox3 for Python3 compatibility

### DIFF
--- a/tests/xl/trax/test_search.py
+++ b/tests/xl/trax/test_search.py
@@ -1,4 +1,4 @@
-import mox
+from mox3 import mox
 import unittest
 
 from xl.trax import search

--- a/tests/xl/trax/test_track.py
+++ b/tests/xl/trax/test_track.py
@@ -9,7 +9,7 @@ import logging
 import weakref
 import types
 
-import mox
+from mox3 import mox
 from gi.repository import Gio
 from gi.repository import GLib
 try:

--- a/tests/xl/trax/test_util.py
+++ b/tests/xl/trax/test_util.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mox
+from mox3 import mox
 from gi.repository import Gio
 try:
     from nose.plugins.skip import SkipTest


### PR DESCRIPTION
mox3 is drop in replacement for pymox that is compatible with Python 3.
As pymox is not updated since 2010, I think it's reasonable to replace this.