### PR TITLE
Remove deprecated Gtk.Table in plugins and replace with Gtk.Grid

### DIFF
--- a/data/ui/widgets/.#tracklist_info.ui
+++ b/data/ui/widgets/.#tracklist_info.ui
@@ -1,0 +1,1 @@
+thomas@constellation.7019:1464175836

--- a/data/ui/widgets/.#tracklist_info.ui
+++ b/data/ui/widgets/.#tracklist_info.ui
@@ -1,1 +1,0 @@
-thomas@constellation.7019:1464175836

--- a/data/ui/widgets/tracklist_info.ui
+++ b/data/ui/widgets/tracklist_info.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.19.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkWindow" id="window1">
@@ -51,11 +51,10 @@
           </packing>
         </child>
         <child>
-          <object class="GtkTable" id="tracklist_table">
+          <object class="GtkGrid" id="tracklist_table">
             <property name="can_focus">False</property>
             <property name="no_show_all">True</property>
             <property name="hexpand">True</property>
-            <property name="n_columns">3</property>
             <property name="column_spacing">6</property>
             <child>
               <placeholder/>
@@ -68,8 +67,8 @@
             </child>
           </object>
           <packing>
-            <property name="left_attach">1</property>
-            <property name="top_attach">2</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
           </packing>
         </child>
         <child>

--- a/plugins/grouptagger/gt_widgets.py
+++ b/plugins/grouptagger/gt_widgets.py
@@ -748,10 +748,10 @@ class GroupTaggerQueryDialog(Gtk.Dialog):
             self.combo_model.append( [choice] )
         
         # setup table
-        self.table = Gtk.Table(rows=len(groups)+1, columns=2)
+        self.table = Gtk.Grid()
         
-        self.table.attach(Gtk.Label(label=_('Group')), 0, 1, 0, 1, ypadding=5)
-        self.table.attach(Gtk.Label(label=_('Selected Tracks')), 1, 2, 0, 1, ypadding=5)
+        self.table.attach(Gtk.Label(label=_('Group')), 0, 0, 1, 1)
+        self.table.attach(Gtk.Label(label=_('Selected Tracks')), 1, 0, 1, 1)
         
         # TODO: Scrolled window
         self.combos = []
@@ -763,12 +763,12 @@ class GroupTaggerQueryDialog(Gtk.Dialog):
             # label
             gcombo = self._init_combo(self.group_model)
             gcombo.set_active(self._get_group_index(group))
-            self.table.attach(gcombo, 0, 1, i+1, i+2, xpadding=3)
+            self.table.attach(gcombo, 0, i+1, 1, 1)
             
             # combo
             combo = self._init_combo(self.combo_model)
             combo.set_active(0)
-            self.table.attach(combo, 1, 2, i+1, i+2)
+            self.table.attach(combo, 1, i+1, 1,1)
             
             self.combos.append( (gcombo, combo) )
             

--- a/plugins/playlistanalyzer/analyzer.ui
+++ b/plugins/playlistanalyzer/analyzer.ui
@@ -206,10 +206,9 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkTable" id="tags_table">
+                      <object class="GtkGrid" id="tags_table">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="n_columns">3</property>
                         <property name="column_spacing">4</property>
                         <property name="row_spacing">2</property>
                         <child>

--- a/plugins/playlistanalyzer/analyzer_dialog.py
+++ b/plugins/playlistanalyzer/analyzer_dialog.py
@@ -209,17 +209,15 @@ class AnalyzerDialog(object):
         if tmpl is None:
             return
         
-        self.tags_table.resize(tmpl['maxtags'], 3)
-        
         for i in xrange(0, tmpl['maxtags']):
             
             label = Gtk.Label(label=_('Tag %s') % (i + 1))
             combo = self.__build_tag_combo(i)
             spin = self.__build_spin(i)
             
-            self.tags_table.attach(label, 0, 1, i, i+1, xoptions=0, yoptions=0)
-            self.tags_table.attach(combo, 1, 2, i, i+1, xoptions=0, yoptions=0)
-            self.tags_table.attach(spin, 2, 3, i, i+1, xoptions=0, yoptions=0)
+            self.tags_table.attach(label, 0, i, 1, 1)
+            self.tags_table.attach(combo, 1, i, 1, 1)
+            self.tags_table.attach(spin, 2, i, 1, 1)
             
             self.__tag_widgets.append((combo, spin))
             


### PR DESCRIPTION
I was looking to see if there were any remaining uses of the deprecated `Gtk.Table` and I found the following which I replaced with a `Gtk.Grid` instance. This should make any future transition to Gtk4 easier.

I had to rename some functions due to the name clash of 'Gtk.Grid.remove_rows()` with the some class methods.