### PR TITLE
Fix Gio.File.replace() error when using Playlist Analyzer

### DIFF
--- a/plugins/playlistanalyzer/__init__.py
+++ b/plugins/playlistanalyzer/__init__.py
@@ -179,7 +179,7 @@ class PlaylistAnalyzerPlugin(object):
             parent_dir = parent_dir.get_child("d3.min.js")
         
         with closing(outfile.replace(None, False, Gio.FileCreateFlags.NONE, None)) as fp:
-            fp.write(bytes(contents))
+            fp.write(str(contents))
             
         # copy d3 to the destination
         # -> TODO: add checkbox to indicate whether it should write d3 there or not

--- a/plugins/playlistanalyzer/__init__.py
+++ b/plugins/playlistanalyzer/__init__.py
@@ -178,14 +178,14 @@ class PlaylistAnalyzerPlugin(object):
         if parent_dir:
             parent_dir = parent_dir.get_child("d3.min.js")
         
-        with closing(outfile.replace('', False)) as fp:
-            fp.write(contents)
+        with closing(outfile.replace(None, False, Gio.FileCreateFlags.NONE, None)) as fp:
+            fp.write(bytes(contents))
             
         # copy d3 to the destination
         # -> TODO: add checkbox to indicate whether it should write d3 there or not
         if parent_dir:
             with open(self.d3_loc, 'rb') as d3fp:
-                with closing(parent_dir.replace('', False)) as pfp:
+                with closing(parent_dir.replace(None, False, Gio.FileCreateFlags.NONE, None)) as pfp:
                     pfp.write(d3fp.read())
 
 


### PR DESCRIPTION
When saving an HTML file from the Playlist Analyzer the following traceback occurs:

`Gio.File.replace() takes exactly 5 arguments (3 given)`

Apparently in `Gio.File.replace()` all the arguments are now required. This pull request simply supplies those arguments and passes the file content as a string so that the file can be written by`fp.write()`