### PR TITLE
Fix #97: SEGVs in application menu

### DIFF
--- a/xlgui/widgets/menu.py
+++ b/xlgui/widgets/menu.py
@@ -24,7 +24,6 @@
 # do so. If you do not wish to do so, delete this exception statement
 # from your version.
 
-from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gtk
 
@@ -207,8 +206,7 @@ class Menu(Gtk.Menu):
         self._items = []
         self.context_func = context_func
         self.connect('show', lambda *e: self.regenerate_menu())
-        # GTK gets unhappy if we remove the menu items before it's done with them.
-        self.connect('hide', lambda *e: GLib.idle_add(self.clear_menu))
+        self.connect('hide', lambda *e: self.clear_menu())
         # Placeholder exists to make sure unity doesn't get confused (legacy?)
         self.placeholder = Gtk.MenuItem.new_with_mnemonic('')
         self._inherit_context = inherit_context


### PR DESCRIPTION
Fixes the random SEGVs caused by quickly jumping through application
menus (issue #97).

The crash is avoided by directly invoking self.clear_menu() when a
"hide" signal is emitted rather than delay it until the main loop is
idle.

This patch effectively undoes commit 040a5ca8 "Make GTK happy with
dynamic submenus"