### PR TITLE
Fix searching when non-string tags are present

### DIFF
--- a/tests/xl/trax/test_search.py
+++ b/tests/xl/trax/test_search.py
@@ -411,3 +411,14 @@ class TestSearchTracks(object):
         assert gen.next().track == tracks[2]
         with pytest.raises(StopIteration):
             gen.next()
+            
+    def test_search_tracks_with_int_from_string(self):
+        # unlike mp3, mp4 will return integers for BPM.. make sure that works
+        tracks = [track.Track(x) for x in ('foo', 'bar', 'baz', 'quux')]
+        tracks[1].set_tag_raw('bpm', '2')
+        tracks[2].set_tag_raw('bpm', 2)
+        gen = search.search_tracks_from_string(tracks, '2', keyword_tags=['bpm'])
+        assert gen.next().track == tracks[1]
+        assert gen.next().track == tracks[2]
+        with pytest.raises(StopIteration):
+            gen.next()

--- a/xl/common.py
+++ b/xl/common.py
@@ -45,6 +45,8 @@ from UserDict import DictMixin
 
 logger = logging.getLogger(__name__)
 
+from .unicode import to_unicode, strxfrm
+
 #TODO: get rid of this. only plugins/cd/ uses it.
 VALID_TAGS = (
     # Ogg Vorbis spec tags
@@ -80,31 +82,6 @@ def log_exception(log=logger, message="Exception caught!"):
                 logger.exception("Some message: %s", param)
     """
     log.exception(message)
-
-def to_unicode(x, encoding=None, errors='strict'):
-    """Force getting a unicode string from any object."""
-    # unicode() only accepts "string or buffer", so check the type of x first.
-    if isinstance(x, unicode):
-        return x
-    elif isinstance(x, str):
-        if encoding:
-            return unicode(x, encoding, errors)
-        else:
-            return unicode(x, errors=errors)
-    else:
-        return unicode(x)
-
-def strxfrm(x):
-    """Like locale.strxfrm but also supports Unicode.
-
-    This works around a bug in Python 2 causing strxfrm to fail on unicode
-    objects that cannot be encoded with sys.getdefaultencoding (ASCII in most
-    cases): https://bugs.python.org/issue2481
-    """
-    import locale
-    if isinstance(x, unicode):
-        return locale.strxfrm(x.encode('utf-8', 'replace'))
-    return locale.strxfrm(x)
 
 def clamp(value, minimum, maximum):
     """

--- a/xl/trax/search.py
+++ b/xl/trax/search.py
@@ -58,21 +58,15 @@ class _Matcher(object):
         vals = srtrack.track.get_tag_search(self.tag, format=False)
         if vals == '__null__':
             vals = None
-        if self.tag.startswith("__"):
-            if self._matches(vals):
+        if not isinstance(vals, list):
+            vals = [vals]
+            
+        for item in vals:
+            if item is not None:
+                item = self.lower(item)
+            
+            if self._matches(item):
                 return True
-        else:
-            if type(vals) != list:
-                vals = [vals]
-            for item in vals:
-                if item is not None:
-                    try:
-                        item = item.decode('ascii')
-                    except:
-                        item = shave_marks(item)
-                    item = self.lower(item)
-                if self._matches(item):
-                    return True
         return False
 
     def _matches(self, value):

--- a/xl/trax/search.py
+++ b/xl/trax/search.py
@@ -26,8 +26,8 @@
 
 import time
 import re
-import unicodedata
-import string
+
+from xl.unicode import shave_marks
 
 __all__ = ['TracksMatcher', 'search_tracks']
 
@@ -544,19 +544,4 @@ def match_track_from_string(track, search_string,
     return matcher.match(SearchResultTrack(track))
 
 
-def shave_marks(text):
-    '''
-    Removes diacritics from Latin characters and replaces them with their base
-    characters
-    '''
-    decomposed_text = unicodedata.normalize('NFD', text)
-    latin_base = False
-    keepers = []
-    for character in decomposed_text:
-        if unicodedata.combining(character) and latin_base:
-            continue # Ignore diacritic on any Latin base character
-        keepers.append(character)
-        if not unicodedata.combining(character):
-            latin_base = character in string.ascii_letters
-    shaved = ''.join(keepers)
-    return unicodedata.normalize('NFC', shaved)
+

--- a/xl/trax/search.py
+++ b/xl/trax/search.py
@@ -227,10 +227,7 @@ class TracksMatcher(object):
         """
         self.case_sensitive = case_sensitive
         self.keyword_tags = keyword_tags or []
-        try:
-            search_string = search_string.decode('ascii')
-        except:
-            search_string = shave_marks(search_string)
+        search_string = shave_marks(search_string)
         tokens = self.__tokenize_query(search_string)
         tokens = self.__red(tokens)
         tokens = self.__optimize_tokens(tokens)

--- a/xl/unicode.py
+++ b/xl/unicode.py
@@ -1,0 +1,59 @@
+'''
+    Routines useful for dealing with unicode data
+'''
+
+import locale
+import unicodedata
+import string
+
+
+def shave_marks(text):
+    '''
+        Removes diacritics from Latin characters and replaces them with their
+        base characters
+        
+        :param text: Some input that will be converted to unicode string
+        :returns: unicode string
+    '''
+    text = unicode(text)
+    decomposed_text = unicodedata.normalize('NFD', text)
+    
+    # Don't look for decomposed characters if there aren't any..
+    if decomposed_text == text:
+        return text
+    
+    keepers = []
+    last = ' '
+    for character in decomposed_text:
+        if unicodedata.combining(character) and last in string.ascii_letters:
+            continue # Ignore diacritic on any Latin base character
+        keepers.append(character)
+        last = character
+    shaved = ''.join(keepers)
+    return unicodedata.normalize('NFC', shaved)
+
+def strxfrm(x):
+    """Like locale.strxfrm but also supports Unicode.
+
+    This works around a bug in Python 2 causing strxfrm to fail on unicode
+    objects that cannot be encoded with sys.getdefaultencoding (ASCII in most
+    cases): https://bugs.python.org/issue2481
+    """
+    
+    if isinstance(x, unicode):
+        return locale.strxfrm(x.encode('utf-8', 'replace'))
+    return locale.strxfrm(x)
+
+def to_unicode(x, encoding=None, errors='strict'):
+    """Force getting a unicode string from any object."""
+    # unicode() only accepts "string or buffer", so check the type of x first.
+    if isinstance(x, unicode):
+        return x
+    elif isinstance(x, str):
+        if encoding:
+            return unicode(x, encoding, errors)
+        else:
+            return unicode(x, errors=errors)
+    else:
+        return unicode(x)
+


### PR DESCRIPTION
The problem this resolves is that mp4 returns BPM as an integer, not a string like the other formats. 

@sjohannes does this seem sane, or are there searches that I'm going to accidentally break by converting everything to a string? I'm not really sure if the `str(item)` conversion should be here... really, it seems like get_tag_search() should already be returning the correct thing? But if that's true, then we probably should move the unicode conversion over to get_tag_search also... 

Fixes a bug introduced by #261, #275
