### PR TITLE
Fix GtkNotebook deprecation warnings for GTK 3.20+

### DIFF
--- a/xlgui/widgets/notebook.py
+++ b/xlgui/widgets/notebook.py
@@ -36,38 +36,41 @@ from xlgui.widgets import menu
 
 # Custom tab style; fixes some Adwaita ugliness
 TAB_CSS = Gtk.CssProvider()
-TAB_CSS.load_from_data(
-    # For GTK+ <3.20 (TODO: remove eventually)
+if (Gtk.MAJOR_VERSION, Gtk.MINOR_VERSION) < (3,20):
+    TAB_CSS.load_from_data(
+        # For GTK+ <3.20 (TODO: remove eventually)
 
-    '.notebook { ' +
-        # Remove gap before first tab
-        '-GtkNotebook-initial-gap: 0; ' +
+        '.notebook { ' +
+            # Remove gap before first tab
+            '-GtkNotebook-initial-gap: 0; ' +
+            # Remove gap between tabs
+            '-GtkNotebook-tab-overlap: 1; ' +
+        '} ' +
+        '.notebook tab { ' +
+            # Make tabs smaller (or bigger on some other themes, unfortunately)
+            'padding: 6px; ' +
+        '}')
+
+else:
+    TAB_CSS.load_from_data(
+        # For GTK+ >=3.20
+
+        # Work around weird Close button position on panel.
+        # Need to find out why the button is not centered.
+        'notebook.vertical tab { ' +
+            'padding-left: 6px; ' +
+            'padding-right: 3px; ' +
+        '} ' +
+
         # Remove gap between tabs
-        '-GtkNotebook-tab-overlap: 1; ' +
-    '} ' +
-    '.notebook tab { ' +
-        # Make tabs smaller (or bigger on some other themes, unfortunately)
-        'padding: 6px; ' +
-    '} ' +
-
-    # For GTK+ >=3.20
-
-    # Work around weird Close button position on panel.
-    # Need to find out why the button is not centered.
-    'notebook.vertical tab { ' +
-        'padding-left: 6px; ' +
-        'padding-right: 3px; ' +
-    '} ' +
-
-    # Remove gap between tabs
-    'header.top tab, header.bottom tab { ' +
-        'margin-left: -1px; ' +
-        'margin-right: -1px; ' +
-    '} ' +
-    'header.left tab, header.right tab { ' +
-        'margin-top: -1px; ' +
-        'margin-bottom: -1px; ' +
-    '}')
+        'header.top tab, header.bottom tab { ' +
+            'margin-left: -1px; ' +
+            'margin-right: -1px; ' +
+        '} ' +
+        'header.left tab, header.right tab { ' +
+            'margin-top: -1px; ' +
+            'margin-bottom: -1px; ' +
+        '}')
 
 class SmartNotebook(Gtk.Notebook):
     def __init__(self, vertical=False):


### PR DESCRIPTION
Load different GtkNotebook style properties for GTK versions < 3.20 and >= 3.20 in order to avoid the use of the deprecated `initial-gap` and `tab-overlap` with the most recent ones.

This fixes the warnings:
```
(exaile.py:11723): Gtk-WARNING **: Theme parsing error: <data>:1:38: The style property GtkNotebook:initial-gap is deprecated and shouldn't be used anymore. It will be removed in a future version
(exaile.py:11723): Gtk-WARNING **: Theme parsing error: <data>:1:67: The style property GtkNotebook:tab-overlap is deprecated and shouldn't be used anymore. It will be removed in a future version
```
when using GTK 3.20 or later.