### PR TITLE
Fix Export Files playlist dialog (#299)

### DIFF
--- a/xlgui/widgets/dialogs.py
+++ b/xlgui/widgets/dialogs.py
@@ -1602,8 +1602,10 @@ def export_playlist_files(playlist, parent=None):
     
     def _on_uri(uri):
         if hasattr(playlist, 'get_playlist'):
-            playlist = playlist.get_playlist()
-        pl_files = [track.get_loc_for_io() for track in playlist]
+            pl = playlist.get_playlist()
+        else:
+            pl = playlist
+        pl_files = [track.get_loc_for_io() for track in pl]
         dialog = FileCopyDialog( pl_files, uri, 
             _('Exporting %s') % playlist.name, parent=parent)
         dialog.do_copy()


### PR DESCRIPTION
The dialog to export files from a playlist (launched with the 'Export
Files' context menu option over such playlist tab) fails because it
tries to assign a value to a free variable in a closure (which are
read-only in Python).

This patch modifies the logic in the closure so the free variable is
only used as an R-value.