### PR TITLE
Fix vorbis default quality

### DIFF
--- a/xl/transcoder.py
+++ b/xl/transcoder.py
@@ -138,8 +138,8 @@ class Transcoder(object):
     def __init__(self):
         self.src = None
         self.sink = None
-        self.dest_format = "Ogg Vorbis"
-        self.quality = 5
+        self.set_format("Ogg Vorbis")
+        self.set_quality(0.5)
         self.input = None
         self.output = None
         self.encoder = None


### PR DESCRIPTION
According to the GStreamer documentation, module `vorbisenc`, `quality` ranges from −0.1 to +1.0.

Use setter functions to make sure the issue is not being made again.