### PR TITLE
pylint: cleanup main, doc, tests, tools

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys
+import os
 
 from os.path import abspath, join, dirname
 
@@ -34,11 +35,12 @@ import mocks
 sys.path.pop()
 
 
-# -- General configuration -----------------------------------------------------
+# -- General configuration ----------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autosummary', 'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.coverage']
+extensions = ['sphinx.ext.autosummary', 'sphinx.ext.autodoc',
+              'sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.coverage']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -105,7 +107,8 @@ pygments_style = 'sphinx'
 
 # -- Options for HTML output ---------------------------------------------------
 
-# on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
+# on_rtd is whether we are on readthedocs.org, this line of code grabbed from
+# docs.readthedocs.org
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if not on_rtd:  # only import and set the theme if we're building docs locally

--- a/doc/mocks.py
+++ b/doc/mocks.py
@@ -1,11 +1,12 @@
 '''
     Provided so that we can build docs without needing to have any
-    dependencies installed (such as for RTFD). 
-    
+    dependencies installed (such as for RTFD).
+
     Derived from http://read-the-docs.readthedocs.org/en/latest/faq.html
 '''
 
 import sys
+
 
 class Mock(object):
 
@@ -16,34 +17,34 @@ class Mock(object):
 
     def __call__(self, *args, **kwargs):
         return Mock()
-    
+
     @classmethod
     def __getattr__(cls, name):
         if name in ('__file__', '__path__'):
             return '/dev/null'
         else:
             return Mock()
-    
+
     # glib mocks
-    
+
     @classmethod
     def get_user_data_dir(cls):
         return '/tmp'
-    
+
     @classmethod
     def get_user_config_dir(cls):
         return '/tmp'
-    
+
     @classmethod
     def get_user_cache_dir(cls):
         return '/tmp'
 
 MOCK_MODULES = [
     'cairo',
-    
+
     'dbus',
     'dbus.service',
-    
+
     'gi',
     'gi.repository',
     'gi.repository.Gio',
@@ -51,7 +52,7 @@ MOCK_MODULES = [
     'gi.repository.GObject',
     'gi.repository.Gst',
     'gi.repository.Gtk',
-    
+
     'mutagen',
     'mutagen.apev2',
     'mutagen.ogg',
@@ -60,17 +61,18 @@ MOCK_MODULES = [
 
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()
-    
-    
+
+
 # player hack
 import xl.settings
 
 orig_get_option = xl.settings.get_option
+
 
 def option_hack(name, default):
     if name == 'player/engine':
         return 'rtfd_hack'
     else:
         return orig_get_option(name, default)
-    
+
 xl.settings.get_option = option_hack

--- a/exaile.py
+++ b/exaile.py
@@ -14,7 +14,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import os
 import os.path
 import sys
 
@@ -38,7 +37,7 @@ if sys.platform == 'linux2':
     try:
         import ctypes
         libc = ctypes.CDLL('libc.so.6')
-        libc.prctl(15, 'exaile', 0, 0, 0) # 15 = PR_SET_NAME
+        libc.prctl(15, 'exaile', 0, 0, 0)  # 15 = PR_SET_NAME
     except Exception:
         pass
 
@@ -49,7 +48,7 @@ try:
 except ImportError:
     pass
 
-# Find out the location of exaile's working directory, and insert it to sys.path
+# Find the location of exaile's working directory and insert it to sys.path
 basedir = os.path.dirname(os.path.realpath(__file__))
 if not os.path.exists(os.path.join(basedir, "exaile.py")):
     cwd = os.getcwd()

--- a/exaile_osx.py
+++ b/exaile_osx.py
@@ -2,6 +2,7 @@
 
 import sys
 
+
 def main():
     sys.argv[1:1] = ['--startgui', '--no-dbus', '--no-hal']
     import exaile

--- a/exaile_win.py
+++ b/exaile_win.py
@@ -7,28 +7,29 @@ from __future__ import division, print_function, unicode_literals
 # Make file handles not inheritable, that way we can restart on the fly
 # -> From http://www.virtualroadside.com/blog/index.php/2013/02/06/problems-with-file-descriptors-being-inherited-by-default-in-python/
 import __builtin__
-import msvcrt, sys
+import msvcrt
+import sys
 from ctypes import windll
 
-    
+
 __builtin__open = __builtins__.open
+
 
 def __open_inheritance_hack(*args, **kwargs):
     result = __builtin__open(*args, **kwargs)
     handle = msvcrt.get_osfhandle(result.fileno())
     windll.kernel32.SetHandleInformation(handle, 1, 0)
     return result
-    
+
 __builtin__.open = __open_inheritance_hack
 
 
-
 def error(message1, message2=None, die=True):
-    
+
     import logging
-    
+
     """Show error message and exit.
-    
+
     If two message arguments are supplied, the first one will be used as title.
     If `die` is true, exit after showing the message.
     """
@@ -45,29 +46,31 @@ def error(message1, message2=None, die=True):
     if die:
         sys.exit(1)
 
+
 def main():
-    
+
     import logging
     logging.basicConfig(level=logging.INFO, datefmt="%H:%M:%S",
-        format="%(levelname)-8s: %(message)s")
-    
-    aio_message = "\r\n\r\nPlease run the 'All-In-One PyGI/PyGObject for Windows Installer' and ensure that the following are selected:" + \
+                        format="%(levelname)-8s: %(message)s")
+
+    aio_message = "\r\n\r\nPlease run the 'All-In-One PyGI/PyGObject for " + \
+        "Windows Installer' and ensure that the following are selected:" + \
                   "\r\n\r\n" + \
                   "* GTK+ 3.x\r\n" + \
                   "* GStreamer 1.x and the gst-plugins package(s)\r\n" + \
                   "\r\n" + \
-                  "The 'All-In-One PyGI/PyGObject for Windows Installer' can be downloaded at\r\nhttp://sourceforge.net/projects/pygobjectwin32/\r\n\r\n" + \
+                  "The 'All-In-One PyGI/PyGObject for Windows Installer' " + \
+                  "can be downloaded at\r\n" + \
+                  "http://sourceforge.net/projects/pygobjectwin32/\r\n\r\n" + \
                   "See README.Windows for more information."
-    
+
     try:
         import gi
     except Exception:
         error("PyGObject not found",
-                "PyGObject could not be imported. " + aio_message)
+              "PyGObject could not be imported. " + aio_message)
     else:
         logging.info("PyGObject works")
-    
-    
     try:
         gi.require_version('Gtk', '3.0')
         from gi.repository import Gtk
@@ -76,7 +79,7 @@ def main():
               "GTK+ could not be imported. " + aio_message)
     else:
         logging.info("GTK+ works")
-    
+
     try:
         gi.require_version('Gst', '1.0')
         from gi.repository import Gst
@@ -85,17 +88,18 @@ def main():
               "GStreamer could not be imported. " + aio_message)
     else:
         logging.info("GStreamer works")
-    
+
     try:
         import mutagen
     except Exception:
         error("Mutagen not found",
-                "The Python module Mutagen could not be imported. It can be downloaded from http://code.google.com/p/mutagen\r\n\r\n" +
-                "See README.Windows for more information.")
+              "The Python module Mutagen could not be imported. It can be " +
+              "downloaded from http://code.google.com/p/mutagen\r\n\r\n" +
+              "See README.Windows for more information.")
     else:
         logging.info("Mutagen works")
 
-    # disable the logging before starting exaile.. otherwise it gets 
+    # disable the logging before starting exaile.. otherwise it gets
     # configured twice and we get double the log messages!
     logging = None
     del sys.modules['logging']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,27 +19,28 @@ def exaile_test_cleanup():
     '''
         Teardown/setup of various Exaile globals
     '''
-    
+
     yield
-    
+
     Track._Track__the_cuts = ['the', 'a']
-    
+
     for key in Track._Track__tracksdict.keys():
         del Track._Track__tracksdict[key]
 
 #
 # Fixtures for test track data
 #
-    
 
-TrackData = collections.namedtuple('TrackData',
-                                   ['ext', 'filename', 'uri', 'size', 'writeable'])
+
+TrackData = collections.namedtuple(
+                'TrackData', ['ext', 'filename', 'uri', 'size', 'writeable'])
+
 
 def _fname(ext):
     local_path = os.path.abspath(
-        os.path.join(os.path.dirname(__file__),
-        'data', 'music', 'delerium', 'chimera', '05 - Truly') + os.extsep + ext)
-    
+        os.path.join(os.path.dirname(__file__), 'data', 'music', 'delerium',
+                     'chimera', '05 - Truly') + os.extsep + ext)
+
     return ext, local_path, Gio.File.new_for_path(local_path).get_uri()
 
 _all_tracks = [
@@ -60,10 +61,12 @@ _all_tracks = [
 
 _writeable_tracks = [t for t in _all_tracks if t.writeable]
 
+
 @pytest.fixture(params=_all_tracks)
 def test_track(request):
     '''Provides TrackData objects for each test track'''
     return request.param
+
 
 @pytest.fixture(params=_writeable_tracks)
 def writeable_track(request):
@@ -77,10 +80,11 @@ def test_track_fp(request):
     with tempfile.NamedTemporaryFile(suffix='.' + t.ext) as tfp:
         with open(t.filename, 'rb') as fp:
             shutil.copyfileobj(fp, tfp)
-            
+
         tfp.flush()
-        
+
         yield tfp
+
 
 @pytest.yield_fixture(params=_writeable_tracks)
 def writeable_track_name(request):
@@ -89,9 +93,9 @@ def writeable_track_name(request):
     with tempfile.NamedTemporaryFile(suffix='.' + t.ext) as tfp:
         with open(t.filename, 'rb') as fp:
             shutil.copyfileobj(fp, tfp)
-        
+
         tfp.flush()
-        
+
         yield tfp.name
 
 
@@ -103,6 +107,5 @@ def test_tracks():
     class _TestTracks:
         def get(self, ext):
             return [x for x in _all_tracks if x.filename.endswith(ext)][0]
-        
-    return _TestTracks()
 
+    return _TestTracks()

--- a/tests/xl/player/gst/test_fader.py
+++ b/tests/xl/player/gst/test_fader.py
@@ -3,74 +3,78 @@ from gi.repository import GLib
 
 from xl.player.track_fader import TrackFader, FadeState
 
-NoFade =    FadeState.NoFade
-FadingIn =  FadeState.FadingIn
-Normal =    FadeState.Normal
+NoFade = FadeState.NoFade
+FadingIn = FadeState.FadingIn
+Normal = FadeState.Normal
 FadingOut = FadeState.FadingOut
 
 
 class FakeStream(object):
-    
+
     def __init__(self):
         self.reset()
-    
+
     def reset(self):
         self.position = 0
         self.volume = 42
         self.fadeout_begin = False
         self.stopped = False
-    
+
     def get_position(self):
         return self.position
 
     def set_volume(self, value):
         self.volume = int(value*100)
-    
+
     def stop(self):
         self.stopped = True
-    
+
     def on_fade_out(self):
         self.fadeout_begin = True
-        
+
+
 class FakeTrack(object):
-    
+
     def __init__(self, start_off, stop_off, tracklen):
         self.tags = {
             '__startoffset': start_off,
             '__stopoffset': stop_off,
             '__length': tracklen
         }
-        
+
     def get_tag_raw(self, t):
         return self.tags[t]
 
 # TODO: monkeypatch instead
-timeout_args = [()] 
+timeout_args = [()]
+
 
 def glib_timeout_add(*args):
     timeout_args[0] = args[2:]
     return args[1]
 
+
 def glib_source_remove(src_id):
     pass
-        
+
 GLib.timeout_add = glib_timeout_add
 GLib.source_remove = glib_source_remove
 
 TmSt = 1
 TmEx = 2
 
+
 def test_fader():
-    
+
     #
     # TODO: These tests don't cover setup_track, et al
     #
-    
+
     # Test data:
     #   Position, Volume, State, TmSt/TmEx/None, [call, [arg1...]]
-    
+
     tests = []
-    
+
     # Test don't manage the volume
     tests.append([
         (0, 100, NoFade, None, 'play', None, None, None, None),
@@ -80,7 +84,7 @@ def test_fader():
         (4, 100, NoFade, None, 'stop'),
         (5, 100, NoFade, None),
     ])
-    
+
     # Test fading in
     tests.append([
         (0, 0,  FadingIn, TmEx, 'play', 0, 2, None, None),
@@ -90,7 +94,7 @@ def test_fader():
         (5, 100, NoFade,  None, 'stop'),
         (6, 100, NoFade,  None),
     ])
-    
+
     # Test fading in: pause in middle
     tests.append([
         (0, 0,  FadingIn, TmEx, 'play', 0, 2, None, None),
@@ -103,62 +107,61 @@ def test_fader():
         (5, 100, NoFade,  None, 'stop'),
         (6, 100, NoFade,  None),
     ])
-    
+
     # Test fading in past the fade point
     tests.append([
         (3, 100, NoFade, None, 'play', 0, 2, None, None),
-        (4, 100, NoFade,  None),
-        (5, 100, NoFade,  None, 'stop'),
-        (6, 100, NoFade,  None),
+        (4, 100, NoFade, None),
+        (5, 100, NoFade, None, 'stop'),
+        (6, 100, NoFade, None),
     ])
-    
+
     # Test fading out
     tests.append([
-        (3, 100, Normal,   TmSt, 'play', None, None, 4, 6),
-        (4, 100, FadingOut,TmEx, 'start'),
-        (5, 50,  FadingOut,TmEx, 'execute'),
-        (6, 0,   FadingOut,TmEx, 'execute'),
-        (6.1, 0, NoFade,   None, 'execute'),
-        (7,   0, NoFade,   None),
+        (3, 100, Normal,    TmSt, 'play', None, None, 4, 6),
+        (4, 100, FadingOut, TmEx, 'start'),
+        (5, 50,  FadingOut, TmEx, 'execute'),
+        (6, 0,   FadingOut, TmEx, 'execute'),
+        (6.1, 0, NoFade,    None, 'execute'),
+        (7,   0, NoFade,    None),
     ])
-    
+
     # Test all of them
     tests.append([
-        (0, 0,  FadingIn,  TmEx, 'play', 0, 2, 4, 6),
-        (1, 50, FadingIn,  TmEx, 'execute'),
-        (3, 100, Normal,   TmSt, 'execute'),
-        (4, 100, FadingOut,TmEx, 'start'),
-        (5, 50,  FadingOut,TmEx, 'execute'),
-        (6, 0,   FadingOut,TmEx, 'execute'),
-        (6.1, 0, NoFade,   None, 'execute'),
-        (7,   0, NoFade,   None),
+        (0, 0,  FadingIn,   TmEx, 'play', 0, 2, 4, 6),
+        (1, 50, FadingIn,   TmEx, 'execute'),
+        (3, 100, Normal,    TmSt, 'execute'),
+        (4, 100, FadingOut, TmEx, 'start'),
+        (5, 50,  FadingOut, TmEx, 'execute'),
+        (6, 0,   FadingOut, TmEx, 'execute'),
+        (6.1, 0, NoFade,    None, 'execute'),
+        (7,   0, NoFade,    None),
     ])
-    
+
     # Test fading in with startoffset
-    #tests.append([
-    #    (0, 0,  FadingIn,  TmEx, 'play', 60, 62, 64, 66),
-    #    (0, 0,  FadingIn,  TmEx, 'seek', 60),
-    #    (61, 50,  FadingIn,  TmEx, 'execute'),
-    #    
-    #])
-    
+    # tests.append([
+    #     (0, 0,  FadingIn,  TmEx, 'play', 60, 62, 64, 66),
+    #     (0, 0,  FadingIn,  TmEx, 'seek', 60),
+    #     (61, 50,  FadingIn,  TmEx, 'execute'),
+    # ])
+
     # Test fade_out_on_play
-    
+
     # Test setup_track
-    
+
     # Test setup_track is_update=True
-    
+
     # Test unexpected fading out
-    
-    
+
     for test in tests:
-        yield check_fader, test  
+        yield check_fader, test
+
 
 def check_fader(test):
 
     stream = FakeStream()
     fader = TrackFader(stream, stream.on_fade_out, 'test')
-    
+
     for data in test:
         print(data)
         now = data[0]
@@ -167,21 +170,21 @@ def check_fader(test):
         volume = data[1]
         state = data[2]
         timer_id = data[3]
-        
+
         if len(data) > 4:
             action = data[4]
             args = data[5:] if len(data) > 5 else ()
-            
+
             if action == 'start':
                 action = '_on_fade_start'
             elif action == 'execute':
                 action = '_execute_fade'
                 args = timeout_args[0]
                 fader.now = now - 0.010
-                        
+
             # Call the function
             getattr(fader, action)(*args)
-        
+
         # Check to see if timer id exists
         if timer_id is None:
             assert fader.timer_id is None
@@ -191,63 +194,56 @@ def check_fader(test):
             assert fader.timer_id == fader._execute_fade
         else:
             assert False
-                
+
         assert fader.state == state
         assert stream.volume == volume
 
 
 def test_calculate_fades():
     fader = TrackFader(None, None, None)
-    
-    # fin, fout, start_off, stop_off, tracklen; start, start+fade, end-fade, end
+
+    # fin, fout, start_off, stop_off, tracklen;
+    # start, start+fade, end-fade, end
     calcs = [
         # one is zero/none
         (0, 4, 0, 0, 10,        0, 0, 6, 10),
         (None, 4, 0, 0, 10,     0, 0, 6, 10),
-    
+
         # other is zero/none
         (4, 0, 0, 0, 10,        0, 4, 10, 10),
         (4, None, 0, 0, 10,     0, 4, 10, 10),
-        
+
         # both are equal
         (4, 4, 0, 0, 10,        0, 4, 6, 10),
-        
+
         # both are none
         (0, 0, 0, 0, 10,        0, 0, 10, 10),
         (None, None, 0, 0, 10,  0, 0, 10, 10),
-        
+
         # Bigger than playlen: all three cases
         (0, 4, 0, 0, 2,         0, 0, 0, 2),
         (4, 0, 0, 0, 2,         0, 2, 2, 2),
         (4, 4, 0, 0, 2,         0, 1, 1, 2),
-        
+
         # With start offset
         (4, 4, 1, 0, 10,        1, 5, 6, 10),
-        
+
         # With stop offset
         (4, 4, 0, 9, 10,        0, 4, 5, 9),
-        
+
         # With both
         (2, 2, 1, 9, 10,        1, 3, 7, 9),
-        
+
         # With both, constrained
         (4, 4, 4, 8, 10,        4, 6, 6, 8),
         (2, 4, 4, 7, 10,        4, 5, 5, 7),
         (4, 2, 4, 7, 10,        4, 6, 6, 7),
     ]
-    
+
     i = 0
     for fin, fout, start, stop, tlen, t0, t1, t2, t3 in calcs:
-        print('%2d: Fade In: %s; Fade Out: %s; start: %s; stop: %s; Len: %s' % (i, fin, fout, start, stop, tlen))
+        print('%2d: Fade In: %s; Fade Out: %s; start: %s; stop: %s; Len: %s' %
+              (i, fin, fout, start, stop, tlen))
         track = FakeTrack(start, stop, tlen)
         assert fader.calculate_fades(track, fin, fout) == (t0, t1, t2, t3)
         i += 1
-        
-        
-        
-    
-    
-
-    
-    
-    

--- a/tests/xl/test_event.py
+++ b/tests/xl/test_event.py
@@ -1,16 +1,18 @@
 
 from gi.repository import GLib
 import threading
+from xl import event
 
 # nasty globals
 on_ui_thread = [False]
 calls = [0]
 
+
 # TODO: monkeypatch instead
 def glib_idle_add(fn, *args):
     was_ui_thread = on_ui_thread[0]
     on_ui_thread[0] = True
-    
+
     try:
         fn(*args)
     finally:
@@ -18,80 +20,82 @@ def glib_idle_add(fn, *args):
 
 GLib.idle_add = glib_idle_add
 
-from xl import event
 
 class NormalCallback(object):
-    
+
     def __init__(self):
         self.called = False
         event.add_callback(self.on_cb, 'test')
-        
+
     def destroy(self):
         event.remove_callback(self.on_cb, 'test')
-        
+
     def on_cb(self, type, obj, data):
         self.called = True
         self.on_ui_thread = on_ui_thread[0]
-    
+
+
 class UiCallback(object):
-    
+
     def __init__(self):
         self.called = False
         event.add_ui_callback(self.on_cb, 'test')
-        
+
     def destroy(self):
         event.remove_callback(self.on_cb, 'test')
-    
+
     def on_cb(self, type, obj, data):
         if on_ui_thread[0]:
             self.called = True
 
+
 def _init_events():
     event.EVENT_MANAGER = event.EventManager()
+
 
 def _finish_events():
     assert len(event.EVENT_MANAGER.callbacks) == 0
     assert len(event.EVENT_MANAGER.all_callbacks) == 0
     assert len(event.EVENT_MANAGER.ui_callbacks) == 0
 
+
 def test_ui_events():
     _init_events()
     ucb = UiCallback()
     ncb = NormalCallback()
-    
+
     on_ui_thread[0] = True
     event.log_event('test', ucb, None)
-    
-    assert ncb.called == True
-    assert ncb.on_ui_thread == True
-    assert ucb.called == True
-    
+
+    assert ncb.called is True
+    assert ncb.on_ui_thread is True
+    assert ucb.called is True
+
     ucb.destroy()
     ncb.destroy()
-    
+
     _finish_events()
-    
+
+
 def test_thread_events():
-    
+
     _init_events()
     ucb = UiCallback()
     ncb = NormalCallback()
-    
+
     def _run():
         on_ui_thread[0] = False
         event.log_event('test', ucb, None)
-    
+
     t = threading.Thread(target=_run)
     t.start()
     t.join()
-    
-    assert ncb.called == True
-    assert ncb.on_ui_thread == False
-    assert ucb.called == True
-    
+
+    assert ncb.called is True
+    assert ncb.on_ui_thread is False
+    assert ucb.called is True
+
     ucb.destroy()
     ncb.destroy()
-    
+
     _finish_events()
-    
-    

--- a/tests/xl/trax/test_data.py
+++ b/tests/xl/trax/test_data.py
@@ -5,14 +5,16 @@ import os
 def test_mp3_exists(test_tracks):
     assert test_tracks.get('.mp3')
 
+
 def test_all_tracks(test_track):
     assert os.path.exists(test_track.filename), \
             "%s does not exist" % test_track.filename
-            
+
     assert test_track.uri.startswith('file:///')
+
 
 def test_writable_tracks(writeable_track):
     assert os.path.exists(writeable_track.filename), \
             "%s does not exist" % writeable_track.filename
-            
+
     assert writeable_track.uri.startswith('file:///')

--- a/tests/xl/trax/test_search.py
+++ b/tests/xl/trax/test_search.py
@@ -403,7 +403,7 @@ class TestSearchTracks(object):
         assert gen.next().track == tracks[2]
         with pytest.raises(StopIteration):
             gen.next()
-            
+
     @pytest.mark.parametrize("sstr", [
         "motley crue",
         u"mötley crüe",
@@ -416,28 +416,28 @@ class TestSearchTracks(object):
         tracks[0].set_tag_raw('artist', 'motley crue')
         tracks[1].set_tag_raw('artist', 'rubbish')
         tracks[2].set_tag_raw('artist', u'motley crüe')
-        
+
         gen = search.search_tracks_from_string(tracks, sstr,
                 keyword_tags=['artist'])
-        
+
         assert gen.next().track == tracks[0]
         assert gen.next().track == tracks[2]
         with pytest.raises(StopIteration):
             gen.next()
-    
+
     def test_search_tracks_with_unicodemark_from_string(self):
         tracks = [track.Track(x) for x in ('foo', 'bar', 'baz', 'quux')]
         tracks[0].set_tag_raw('artist', 'foooo')
         tracks[2].set_tag_raw('artist', u'中')
-        
+
         # the weird character is normalized, so you can't search based on that
         gen = search.search_tracks_from_string(tracks, u'中',
                 keyword_tags=['artist'])
-        
+
         assert gen.next().track == tracks[2]
         with pytest.raises(StopIteration):
             gen.next()
-            
+
     def test_search_tracks_with_int_from_string(self):
         # unlike mp3, mp4 will return integers for BPM.. make sure that works
         tracks = [track.Track(x) for x in ('foo', 'bar', 'baz', 'quux')]

--- a/tests/xl/trax/test_track.py
+++ b/tests/xl/trax/test_track.py
@@ -83,7 +83,7 @@ class TestTrack(object):
 
     def teardown(self):
         self.mox.UnsetStubs()
-        
+
     ## Creation
     def test_flyweight(self, test_track):
         """There can only be one object based on a url in args"""
@@ -123,16 +123,16 @@ class TestTrack(object):
 
     def test_takes_nonurl(self, test_track):
         tr = track.Track(test_track.filename)
-        
+
         assert tr.get_local_path()
         assert tr.exists()
-    
+
     def test_takes_url(self, test_track):
         tr = track.Track(test_track.uri)
-        
+
         assert tr.get_local_path()
         assert tr.exists()
-    
+
     ## Information
     def test_local_type(self, test_track):
         tr = track.Track(test_track.filename)
@@ -165,56 +165,56 @@ class TestTrack(object):
         assert str(tr) == "'title' from 'alb' by 'art'"
 
     def test_read_tags_no_perms(self, test_track_fp):
-        
+
         tr = track.Track(test_track_fp.name)
         # first, ensure that we can actually read the tags to begin with
         assert tr.read_tags()
-        
+
         os.chmod(test_track_fp.name, 0o000)
-        
+
         # opening the file should fail...
         with pytest.raises(IOError):
             with open(test_track_fp.name, 'rb'):
                 pass
-        
+
         # second, ensure that we can no longer read them
         assert not tr.read_tags()
-        
+
     def test_write_tags_no_perms(self, test_track_fp):
-        
+
         os.chmod(test_track_fp.name, 0o444)
-        
+
         tr = track.Track(test_track_fp.name)
         tr.set_tag_raw('artist', random_str())
         assert not tr.write_tags()
-        
+
     def test_write_tag(self, writeable_track_name):
-        
+
         artist = random_str()
         tr = track.Track(writeable_track_name)
         tr.set_tag_raw('artist', artist)
         tr.write_tags()
-        
+
         tr.set_tag_raw('artist', None)
         assert tr.get_tag_raw('artist') == None
-        
+
         tr.read_tags()
-        
+
         assert tr.get_tag_raw('artist') == [artist]
-        
+
     def test_delete_tag(self, writeable_track_name):
-        
+
         artist = random_str()
         tr = track.Track(writeable_track_name)
         assert tr.get_tag_raw('artist') is not None
-        
+
         tr.set_tag_raw('artist', None)
         tr.write_tags()
-        
+
         tr.set_tag_raw('artist', artist)
         tr.read_tags()
         assert tr.get_tag_raw('artist') == None
-    
+
     def test_write_tag_invalid_format(self):
         tr = track.Track('/tmp/foo.foo')
         assert tr.write_tags() == False
@@ -314,7 +314,7 @@ class TestTrack(object):
         settings.set_option('collection/strip_list', value)
         track.Track._the_cuts_cb(None, None, 'collection/strip_list')
         assert track.Track._Track__the_cuts == value
-    
+
     def test_strip_marks(self):
         value = u'The Hëllò Wóþλdâ'
         retval = u'The Hello Woþλda The Hëllò Wóþλdâ'
@@ -513,7 +513,7 @@ class TestTrack(object):
         tr = track.Track('/foo')
         tr.set_tag_raw('__bitrate', 48000)
         assert tr.get_tag_search('__bitrate') == '__bitrate=="48k" __bitrate=="48000"'
-    
+
     def test_get_disk_tag(self, test_tracks):
         td = test_tracks.get('.mp3')
         tr = track.Track(td.filename)

--- a/tests/xl/trax/test_util.py
+++ b/tests/xl/trax/test_util.py
@@ -34,7 +34,7 @@ class TestGetTracksFromUri(object):
 
     def setup(self):
         self.mox = mox.Mox()
-    
+
     def teardown(self):
         self.mox.UnsetStubs()
 

--- a/tools/db_explorer.py
+++ b/tools/db_explorer.py
@@ -32,13 +32,16 @@ import shelve
 import click
 
 
-exaile_db = os.path.join(os.path.expanduser('~'), '.local', 'share', 'exaile', 'music.db')
+exaile_db = os.path.join(os.path.expanduser('~'), '.local', 'share', 'exaile',
+                         'music.db')
+
 
 def tracks(data):
     for k, v in data.iteritems():
         if not k.startswith('tracks-'):
             continue
         yield k, v
+
 
 @click.group()
 @click.option('--db', default=exaile_db)
@@ -48,6 +51,7 @@ def cli(ctx, db):
         Tool that allows low-level exploration of an Exaile music database
     '''
     ctx.obj = shelve.open(db, flag='r', protocol=2)
+
 
 @cli.command()
 @click.pass_obj
@@ -62,6 +66,7 @@ def info(data):
     print()
     print('Location(s):')
     pprint.pprint(data.get('_serial_libraries'))
+
 
 @cli.command()
 @click.argument('search')
@@ -81,6 +86,7 @@ def search(data, tag, search):
             if search in val:
                 print('%10s: %s' % (k, val))
 
+
 def _date_fix(tags):
     tags = copy.deepcopy(tags)
     for t in ['__date_added', '__last_played', '__modified']:
@@ -90,8 +96,9 @@ def _date_fix(tags):
                 tags[t] = dt.strftime("%Y-%m-%d %H:%M:%S")
             except:
                 pass
-            
+
     return tags
+
 
 def _print_tr(tr):
     if tr is not None:
@@ -113,8 +120,7 @@ def track_by_idx(data, idx):
     key = str('tracks-%s' % idx)
     tr = data.get(key)
     _print_tr(tr)
-    
-    
+
 
 @cli.command()
 @click.pass_obj
@@ -122,17 +128,16 @@ def tags(data):
     '''
         Display summary information about tags present
     '''
-    
+
     tags = set()
-    
+
     for k, v in tracks(data):
-        
-        #print(v[0].keys())
+        # print(v[0].keys())
         tags.update(set(v[0].keys()))
-        
+
     print("All tags:")
     pprint.pprint(tags)
-    
+
 
 if __name__ == '__main__':
     cli()

--- a/tools/plugin_tool.py
+++ b/tools/plugin_tool.py
@@ -9,13 +9,14 @@ import sys
 v_re1 = re.compile(r"^Version='(.*)'$")
 v_re2 = re.compile(r'^Version="(.*)"$')
 
+
 def _find_bad_plugin_versions(plugins_dir):
     for pname in os.listdir(plugins_dir):
         p = join(plugins_dir, pname, 'PLUGININFO')
         if exists(p):
             with open(p) as fp:
                 contents = fp.read()
-                
+
             s = contents.splitlines()
             for i, l in enumerate(s):
                 m = v_re1.match(l) or v_re2.match(l)
@@ -23,18 +24,20 @@ def _find_bad_plugin_versions(plugins_dir):
                     vv = m.group(1)
                     if vv != v:
                         yield pname, p, vv, s[:i] + s[i+1:]
-                    
+
                     break
             else:
                 print("Warning: no version found in %s" % pname)
+
 
 def check(v, plugins):
     retval = 0
     for pname, _, vv, _ in plugins:
         print("ERROR: Plugin %s version is %s, not %s" % (pname, vv, v))
         retval = 1
-    
+
     return retval
+
 
 def fixversion(v, plugins):
     v = "Version='%s'" % v
@@ -47,17 +50,17 @@ def fixversion(v, plugins):
 if __name__ == '__main__':
     exaile_dir = abspath(join(dirname(__file__), '..'))
     plugins_dir = join(exaile_dir, 'plugins')
-    
+
     os.environ['EXAILE_DIR'] = exaile_dir
     sys.path.insert(0, exaile_dir)
-    
+
     import xl.xdg
     xl.xdg.local_hack = False
     import xl.version
     v = '%s.%s' % (xl.version.major, xl.version.minor)
-    
+
     arg = sys.argv[1] if len(sys.argv) > 1 else ''
-    
+
     if arg == 'check':
         retval = check(v, _find_bad_plugin_versions(plugins_dir))
     elif arg == 'fix':
@@ -65,5 +68,5 @@ if __name__ == '__main__':
     else:
         print('Usage: %s check|fix' % sys.argv[0])
         retval = 1
-        
+
     exit(retval)


### PR DESCRIPTION
Use pylint to clean up the exaile{,_osx,_win}.py and all python files in doc/, tests/ and tools/

Those changes are just cosmetic, but I intend to continue cleaning up all of exaile's code to ease reading code and finding bugs.

I'm doing this pull request now asking you whether you are interested in such work. It'll probably take a day or two where other commits are not welcome at the same time because rebasing is ugly.