### PR TITLE
remove deprecated xalign from builder XML files

### DIFF
--- a/data/ui/panel/radio.ui
+++ b/data/ui/panel/radio.ui
@@ -52,7 +52,7 @@
           <object class="GtkLabel" id="status_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="xalign">0</property>
+            <property name="halign">start</property>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/data/ui/preferences/collection.ui
+++ b/data/ui/preferences/collection.ui
@@ -45,7 +45,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/data/ui/preferences/playback.ui
+++ b/data/ui/preferences/playback.ui
@@ -145,7 +145,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="use_underline">True</property>
-        <property name="xalign">0.5</property>
         <property name="active">True</property>
         <property name="draw_indicator">True</property>
       </object>
@@ -162,7 +161,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="use_underline">True</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -178,7 +176,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="use_underline">True</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -194,7 +191,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="use_underline">True</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -211,7 +207,6 @@
         <property name="receives_default">False</property>
         <property name="tooltip_text" translatable="yes">If a track is currently playing, do not allow new tracks to be started, except when clicking the playback controls</property>
         <property name="hexpand">True</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -226,7 +221,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -294,7 +288,6 @@
         <property name="receives_default">False</property>
         <property name="tooltip_text" translatable="yes">Forces automatically advancing to the next track</property>
         <property name="use_underline">True</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -335,7 +328,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="use_underline">True</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -382,7 +374,6 @@
         <property name="receives_default">False</property>
         <property name="tooltip_text" translatable="yes">Gapless playback means to play tracks without inserting silence between them.</property>
         <property name="hexpand">True</property>
-        <property name="xalign">0</property>
         <property name="active">True</property>
         <property name="draw_indicator">True</property>
       </object>

--- a/data/ui/preferences/plugin.ui
+++ b/data/ui/preferences/plugin.ui
@@ -140,7 +140,6 @@
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
                 <property name="halign">start</property>
-                <property name="xalign">0.5</property>
                 <property name="draw_indicator">True</property>
                 <signal name="toggled" handler="on_show_incompatible_cb_toggled" swapped="no"/>
               </object>
@@ -156,7 +155,6 @@
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
                 <property name="halign">start</property>
-                <property name="xalign">0.5</property>
                 <property name="draw_indicator">True</property>
                 <signal name="toggled" handler="on_show_broken_cb_toggled" swapped="no"/>
               </object>

--- a/plugins/alarmclock/acprefs_pane.ui
+++ b/plugins/alarmclock/acprefs_pane.ui
@@ -128,7 +128,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -144,7 +143,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -160,7 +158,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -176,7 +173,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -192,7 +188,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -208,7 +203,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -224,7 +218,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -240,7 +233,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/plugins/audioscrobbler/asprefs_pane.ui
+++ b/plugins/audioscrobbler/asprefs_pane.ui
@@ -21,7 +21,6 @@
         <property name="receives_default">False</property>
         <property name="halign">start</property>
         <property name="use_underline">True</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -39,7 +38,6 @@
         <property name="receives_default">False</property>
         <property name="halign">start</property>
         <property name="use_underline">True</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -56,7 +54,6 @@
         <property name="receives_default">False</property>
         <property name="halign">start</property>
         <property name="use_underline">True</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/plugins/awn/awn_prefs_pane.ui
+++ b/plugins/awn/awn_prefs_pane.ui
@@ -68,7 +68,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/plugins/bookmarks/bookmarks_pane.ui
+++ b/plugins/bookmarks/bookmarks_pane.ui
@@ -14,7 +14,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/plugins/daapclient/daapclient_prefs.ui
+++ b/plugins/daapclient/daapclient_prefs.ui
@@ -15,7 +15,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -31,7 +30,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="active">True</property>
         <property name="draw_indicator">True</property>
       </object>

--- a/plugins/daapserver/daapserver_prefs.ui
+++ b/plugins/daapserver/daapserver_prefs.ui
@@ -92,7 +92,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/plugins/desktopcover/desktopcover_preferences.ui
+++ b/plugins/desktopcover/desktopcover_preferences.ui
@@ -174,7 +174,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -230,7 +229,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/plugins/equalizer/equalizer.ui
+++ b/plugins/equalizer/equalizer.ui
@@ -145,7 +145,6 @@
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
             <property name="hexpand">True</property>
-            <property name="xalign">0.5</property>
             <property name="draw_indicator">True</property>
             <signal name="toggled" handler="on_chk-enabled_toggled" swapped="no"/>
           </object>

--- a/plugins/grouptagger/gt_import.ui
+++ b/plugins/grouptagger/gt_import.ui
@@ -130,7 +130,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="xalign">0.5</property>
                         <property name="active">True</property>
                         <property name="draw_indicator">True</property>
                       </object>
@@ -146,7 +145,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw_indicator">True</property>
                         <property name="group">radio_merge</property>
                       </object>

--- a/plugins/history/history_preferences.ui
+++ b/plugins/history/history_preferences.ui
@@ -20,7 +20,6 @@
         <property name="receives_default">False</property>
         <property name="halign">start</property>
         <property name="use_underline">True</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/plugins/ipconsole/ipconsole_prefs.ui
+++ b/plugins/ipconsole/ipconsole_prefs.ui
@@ -168,7 +168,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/plugins/minimode/minimode_preferences.ui
+++ b/plugins/minimode/minimode_preferences.ui
@@ -166,7 +166,6 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="xalign">0.5</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -181,7 +180,6 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="xalign">0.5</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -196,7 +194,6 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="xalign">0.5</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -211,7 +208,6 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="xalign">0.5</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -242,7 +238,6 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="xalign">0.5</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -269,7 +264,6 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="xalign">0.5</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>

--- a/plugins/multialarmclock/malrmclk.ui
+++ b/plugins/multialarmclock/malrmclk.ui
@@ -148,7 +148,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -163,7 +162,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/plugins/notify/notifyprefs_pane.ui
+++ b/plugins/notify/notifyprefs_pane.ui
@@ -14,7 +14,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="halign">start</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/plugins/notifyosd/notifyosdprefs_pane.ui
+++ b/plugins/notifyosd/notifyosdprefs_pane.ui
@@ -27,7 +27,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="active">True</property>
         <property name="draw_indicator">True</property>
       </object>
@@ -43,7 +42,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="active">True</property>
         <property name="draw_indicator">True</property>
       </object>
@@ -59,7 +57,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="active">True</property>
         <property name="draw_indicator">True</property>
       </object>
@@ -75,7 +72,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="active">True</property>
         <property name="draw_indicator">True</property>
       </object>
@@ -91,7 +87,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -120,7 +115,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="active">True</property>
         <property name="draw_indicator">True</property>
       </object>
@@ -136,7 +130,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="active">True</property>
         <property name="draw_indicator">True</property>
       </object>

--- a/plugins/osd/osd_preferences.ui
+++ b/plugins/osd/osd_preferences.ui
@@ -188,7 +188,6 @@
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
             <property name="halign">start</property>
-            <property name="xalign">0.5</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>

--- a/plugins/previewdevice/previewprefs.ui
+++ b/plugins/previewdevice/previewprefs.ui
@@ -87,7 +87,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="use_underline">True</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -128,7 +127,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="use_underline">True</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/plugins/replaygain/replaygainprefs_pane.ui
+++ b/plugins/replaygain/replaygainprefs_pane.ui
@@ -26,7 +26,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="tooltip_text" translatable="yes">Prefer ReplayGain's per-album correction over per-track correction.</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -42,7 +41,6 @@
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="tooltip_text" translatable="yes">Protect against noise caused by over-amplification</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/plugins/screensaverpause/prefs.ui
+++ b/plugins/screensaverpause/prefs.ui
@@ -13,7 +13,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/plugins/streamripper/streamripper.ui
+++ b/plugins/streamripper/streamripper.ui
@@ -61,7 +61,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
@@ -76,7 +75,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
-        <property name="xalign">0.5</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>


### PR DESCRIPTION
xalign property is deprecated since Gtk+ 3.14.
Removing it has no side-effects in recent versions of Gtk+.

No side effects to be expected. This stuff was just hold back by Glade always re-adding the field on save [(see this GNOME bug)](https://bugzilla.gnome.org/show_bug.cgi?id=750985)