### PR TITLE
Replace deprecated Gtk.Alignment (fix warnings)

### DIFF
--- a/data/ui/coverchooser.ui
+++ b/data/ui/coverchooser.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkListStore" id="covers_model">
@@ -12,13 +12,23 @@
       <column type="GdkPixbuf"/>
     </columns>
   </object>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">document-save</property>
+  </object>
+  <object class="GtkImage" id="image2">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">window-close</property>
+  </object>
   <object class="GtkWindow" id="CoverChooser">
     <property name="can_focus">False</property>
     <property name="border_width">3</property>
     <property name="title" translatable="yes">Cover Finder</property>
     <property name="resizable">False</property>
     <property name="window_position">center-on-parent</property>
-    <property name="type-hint">dialog</property>
+    <property name="type_hint">dialog</property>
     <child>
       <object class="GtkBox" id="main_container">
         <property name="visible">True</property>
@@ -26,90 +36,110 @@
         <property name="orientation">vertical</property>
         <property name="spacing">3</property>
         <child>
-          <object class="GtkBox" id="info_box">
+          <object class="GtkStack" id="stack">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="border_width">3</property>
             <child>
-              <object class="GtkLabel" id="size_label">
+              <object class="GtkSpinner">
+                <property name="width_request">350</property>
+                <property name="height_request">350</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <attributes>
-                  <attribute name="size" value="8000"/>
-                </attributes>
+                <property name="active">True</property>
               </object>
               <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
+                <property name="name">spinner</property>
+                <property name="title" translatable="yes">page0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="source_label">
+              <object class="GtkGrid" id="stack_ready">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">The origin of this cover</property>
-                <property name="halign">end</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="8000"/>
-                </attributes>
+                <property name="row_spacing">3</property>
+                <child>
+                  <object class="GtkIconView" id="previews_box">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="margin">0</property>
+                    <property name="item_orientation">horizontal</property>
+                    <property name="model">covers_model</property>
+                    <property name="row_spacing">0</property>
+                    <property name="column_spacing">0</property>
+                    <property name="item_padding">0</property>
+                    <signal name="item-activated" handler="on_previews_box_item_activated" swapped="no"/>
+                    <signal name="selection-changed" handler="on_previews_box_selection_changed" swapped="no"/>
+                    <child>
+                      <object class="GtkCellRendererPixbuf" id="cellrendererpixbuf1"/>
+                      <attributes>
+                        <attribute name="pixbuf">2</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">2</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="cover_image_box">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="size_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <attributes>
+                      <attribute name="size" value="8000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="source_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="tooltip_text" translatable="yes">The origin of this cover</property>
+                    <property name="halign">end</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="8000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
               </object>
               <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
+                <property name="title" translatable="yes">page1</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="cover_image_box">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkIconView" id="previews_box">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="margin">0</property>
-            <property name="item_orientation">horizontal</property>
-            <property name="model">covers_model</property>
-            <property name="row_spacing">0</property>
-            <property name="column_spacing">0</property>
-            <property name="item_padding">0</property>
-            <signal name="item-activated" handler="on_previews_box_item_activated" swapped="no"/>
-            <signal name="selection-changed" handler="on_previews_box_selection_changed" swapped="no"/>
-            <child>
-              <object class="GtkCellRendererPixbuf" id="cellrendererpixbuf1"/>
-              <attributes>
-                <attribute name="pixbuf">2</attribute>
-              </attributes>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <placeholder/>
         </child>
         <child>
           <object class="GtkButtonBox" id="actions_box">
@@ -161,15 +191,5 @@
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkImage" id="image1">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">document-save</property>
-  </object>
-  <object class="GtkImage" id="image2">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">window-close</property>
   </object>
 </interface>

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -106,7 +106,7 @@ class SecondaryOutputPlugin(object):
         # stolen from main
         self.info_area = main.MainWindowTrackInfoPane(self.player)
         self.info_area.set_auto_update(True)
-        self.info_area.set_padding(3, 3, 3, 3)
+        self.info_area.set_border_width(3)
         self.info_area.hide()
         self.info_area.set_no_show_all(True)
 

--- a/xlgui/cover.py
+++ b/xlgui/cover.py
@@ -1046,19 +1046,8 @@ class CoverChooser(GObject.GObject):
 
         self.cover_image_box = self.builder.get_object('cover_image_box')
 
-        self.loading_indicator = Gtk.Alignment()
-        self.loading_indicator.props.xalign = 0.5
-        self.loading_indicator.props.yalign = 0.5
-        self.loading_indicator.set_size_request(350, 350)
-        self.cover_image_box.pack_start(self.loading_indicator, True, True, 0)
-
-        try:
-            spinner = Gtk.Spinner()
-            spinner.set_size_request(100, 100)
-            spinner.start()
-            self.loading_indicator.add(spinner)
-        except AttributeError: # Older than GTK 2.20 and PyGTK 2.22
-            self.loading_indicator.add(Gtk.Label(label=_('Loading...')))
+        self.stack = self.builder.get_object('stack')
+        self.stack_ready = self.builder.get_object('stack_ready')
 
         self.size_label = self.builder.get_object('size_label')
         self.source_label = self.builder.get_object('source_label')
@@ -1109,7 +1098,7 @@ class CoverChooser(GObject.GObject):
         if self.stopper.is_set():
             return
 
-        self.cover_image_box.remove(self.loading_indicator)
+        self.stack.set_visible_child(self.stack_ready)
         self.previews_box.set_model(self.covers_model)
 
         if db_strings:

--- a/xlgui/main.py
+++ b/xlgui/main.py
@@ -214,7 +214,7 @@ class MainWindow(GObject.GObject):
 
         self.info_area = MainWindowTrackInfoPane(player.PLAYER)
         self.info_area.set_auto_update(True)
-        self.info_area.set_padding(3, 3, 3, 3)
+        self.info_area.set_border_width(3)
         self.info_area.hide()
         self.info_area.set_no_show_all(True)
         guiutil.gtk_widget_replace(self.builder.get_object('info_area'), self.info_area)

--- a/xlgui/widgets/info.py
+++ b/xlgui/widgets/info.py
@@ -48,12 +48,12 @@ from xlgui import (
 from xlgui.widgets import playlist
 from xlgui.widgets.playback import PlaybackProgressBar
 
-class TrackInfoPane(Gtk.Alignment):
+class TrackInfoPane(Gtk.Bin):
     """
         Displays cover art and track data
     """
     def __init__(self, player):
-        Gtk.Alignment.__init__(self, xscale=1, yscale=1)
+        Gtk.Bin.__init__(self)
         self.__player = player
         
         builder = Gtk.Builder()
@@ -98,7 +98,7 @@ class TrackInfoPane(Gtk.Alignment):
         # Make sure to disconnect callbacks
         self.set_auto_update(False)
 
-        Gtk.Alignment.destroy(self)
+        Gtk.Bin.destroy(self)
 
     def get_auto_update(self):
         """
@@ -387,7 +387,7 @@ class TrackToolTip(TrackInfoPane, ToolTip):
         TrackInfoPane.__init__(self, player)
         ToolTip.__init__(self, parent, self)
 
-        self.set_padding(6, 6, 6, 6)
+        self.set_border_width(6)
         self.info_label.set_ellipsize(Pango.EllipsizeMode.NONE)
         self.cover.set_no_show_all(False)
         self.cover.show_all()


### PR DESCRIPTION
Replace or remove all remaining usages of Gtk.Alignment, which has been deprecated in Gtk+ 3.14.