### PR TITLE
Cover window: Fix dialog being too wide

### DIFF
--- a/xlgui/properties.py
+++ b/xlgui/properties.py
@@ -714,6 +714,7 @@ class TagTextField(Gtk.Box):
         self.buffer = Gtk.TextBuffer()
         self.field = Gtk.TextView.new_with_buffer(self.buffer)
         self.field.set_size_request(200, 150) # XXX
+        self.field.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
         scrollwindow = Gtk.ScrolledWindow()
         scrollwindow.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrollwindow.set_shadow_type(Gtk.ShadowType.IN)


### PR DESCRIPTION
Fixes a bug where the track properties window would become too wide for the
screen so user experience would suffer due to unreachable buttons.

Steps to reprodce the original bug:
1. have a file with comment containing some thousand characters in one line
2. open exaile's track properties dialog on it

What happens:
Dialog is very wide to fit the longest comment line without breaking it.

What should happen:
Either wrap the line (realized solution) or scroll horizontally (worse user experience because more user interaction needed for reading the text).

Additional info:
This solution has a downside: Shrinking the track properties dialog is very CPU intensive due to recalculation of text inside the GtkTextView.