### PR TITLE
Installer using MSYS2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,11 +24,12 @@ dist
 doc/_build
 doc/_static
 
+tools/installer/src
 tools/installer/_bin
 tools/installer/_build
 tools/installer/_build_osx
 tools/installer/_build_env
-tools/installer/_build_env_installer
+tools/installer/_build_root
 tools/installer/_copy
 tools/installer/_dist
 tools/installer/_dist_osx

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ install-target: make-install-dirs
 		$(DESTDIR)$(DATADIR)/applications/
 	install -m 644 data/exaile.appdata.xml \
 		$(DESTDIR)$(DATADIR)/appdata/
-	install -m 644 exaile.1.gz $(EXAILEMANDIR)/man1/
+	-install -m 644 exaile.1.gz $(EXAILEMANDIR)/man1/
 	-install -m 644 exaile.bash-completion $(DESTDIR)$(BASHCOMPDIR)/exaile
 	install -m 644 data/config/settings.ini $(EXAILECONFDIR)
 	tools/generate-launcher "$(DESTDIR)" "$(PREFIX)" "$(EPREFIX)" "$(LIBINSTALLDIR)" \

--- a/tools/generate-launcher
+++ b/tools/generate-launcher
@@ -10,18 +10,6 @@ EPREFIX=${3:-${PREFIX}}
 LIBDIR=${4:-${EPREFIX}/lib}
 PYTHON2_CMD=${5:-python2}
 
-# realpath/readlink misbehave on OSX
-#if (command -v realpath > /dev/null); then
-#  PREFIX=`realpath $PREFIX`
-#elif (command -v readlink > /dev/null); then
-#  PREFIX=`readlink -f $PREFIX`
-#elif test "${PREFIX:0:1}" != "/"; then
-#  echo "Please use an absolute path for PREFIX, or install either realpath or readlink"
-#  exit 1
-#fi
-
-EPREFIX=`$PYTHON2_CMD -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' $EPREFIX`
-
 cd ${DESTDIR}${EPREFIX}/bin && \
 cat <<EOF > exaile
 #!/bin/sh

--- a/tools/installer/_build.bat
+++ b/tools/installer/_build.bat
@@ -1,6 +1,0 @@
-set PATH=%PATH%;C:\Python27\
-
-set GI_TYPELIB_PATH=%~dp0\_build_env_installer\deps\lib\girepository-1.0
-set PATH=%PATH%;%~dp0\_build_env_installer\deps;
-
-python -m PyInstaller --clean --distpath _dist --workpath _build --paths %~dp0\_inst\usr\lib\exaile exaile.spec

--- a/tools/installer/_build.sh
+++ b/tools/installer/_build.sh
@@ -1,3 +1,9 @@
+set -e
+
+# We add the bin dirs from the build root to the PATH, because there
+# are a lot of instances in the legacy code where we make assumptions
+# about where the programs are (e.g. help2man)
+init_env
 
 if [ "$TARGET" == "" ]; then
   TARGET=`pwd`
@@ -11,6 +17,18 @@ else
   DIST=_dist
 fi
 
+function build_git {
+  "${BUILD_ROOT}"/usr/bin/git.exe "$@"
+}
+
+function build_tar {
+  "${BUILD_ROOT}"/usr/bin/tar.exe "$@"
+}
+
+function build_make {
+  "${BUILD_ROOT}"/usr/bin/make.exe "$@"
+}
+
 EXAILE_DIR="$TARGET"/../..
 COPYDIR="$TARGET"/_copy
 DESTDIR="$TARGET"/_inst
@@ -22,12 +40,16 @@ for d in _copy _inst _build _build_osx $DIST; do
 done
 
 pushd "$EXAILE_DIR"
-git archive HEAD --prefix=_copy/ | tar -x -C tools/installer/
+build_git archive HEAD --prefix=_copy/ | build_tar -x -C tools/installer/
 popd
 
 pushd "$COPYDIR"
-make
-PREFIX=/usr DESTDIR="$DESTDIR" make install
+# Our Makefile relies on $PYTHON2_CMD to run Python commands
+export PYTHON2_CMD="${BUILD_ROOT}"/"${MINGW}"/bin/"${PYTHON_ID}".exe
+# help2man relies on perl-Locale-gettext, which lives in this directory
+export PERL5LIB="${BUILD_ROOT}"/usr/lib/perl5/vendor_perl
+build_make
+PREFIX=/usr DESTDIR="$DESTDIR" build_make install
 
 # Copy things that the unix install doesn't require..
 if [ "$SDK_PLATFORM" == "darwin" ]; then
@@ -48,22 +70,18 @@ find "$DESTDIR" -name '*.pyo' -delete
 if [ "$SDK_PLATFORM" == "darwin" ]; then
   pyinstaller -w --clean --distpath $DIST --workpath _build_osx exaile.spec
 else
-  (wine cmd /c _build.bat)
+  build_python -m PyInstaller --clean --distpath _dist --workpath _build --paths ./_inst/usr/lib/exaile exaile.spec
 fi
 
 # Copy extra data
-
 cp "$COPYDIR"/COPYING "$DISTDIR"
 prune_translations "$DESTDIR"/usr/share/locale "$DISTDIR"
+
 
 # Run the installer
 if [ "$SDK_PLATFORM" == "darwin" ]; then
   prune_translations "$DESTDIR"/usr/share/locale $DIST/Exaile.app/Contents/Resources
   misc/create_dmg.sh $DIST/Exaile.app
 else
-  package_installer ../exaile_installer.nsi
+  package_installer "$TARGET"/exaile_installer.nsi
 fi
-
-for d in _copy _inst; do
-  [ -d "$d" ] && rm -rf "$d"
-done

--- a/tools/installer/_build.sh
+++ b/tools/installer/_build.sh
@@ -46,9 +46,7 @@ popd
 pushd "$COPYDIR"
 # Our Makefile relies on $PYTHON2_CMD to run Python commands
 export PYTHON2_CMD="${BUILD_ROOT}"/"${MINGW}"/bin/"${PYTHON_ID}".exe
-# help2man relies on perl-Locale-gettext, which lives in this directory
-export PERL5LIB="${BUILD_ROOT}"/usr/lib/perl5/vendor_perl
-build_make
+build_make compile locale
 PREFIX=/usr DESTDIR="$DESTDIR" build_make install
 
 # Copy things that the unix install doesn't require..

--- a/tools/installer/_clean.sh
+++ b/tools/installer/_clean.sh
@@ -5,4 +5,4 @@ rm -rf _copy
 rm -rf _dist
 rm -rf _dist_osx
 rm -rf _inst
-
+rm -rf src

--- a/tools/installer/project.config
+++ b/tools/installer/project.config
@@ -2,7 +2,6 @@
 # Packages to download
 #
 TARGET_DOWNLOAD_PKGS="\
-help2man \
 make \
 git \
 tar"

--- a/tools/installer/project.config
+++ b/tools/installer/project.config
@@ -1,11 +1,8 @@
 #
-# SDK Configuration
+# Packages to download
 #
-
-DOWNLOAD_FILES_NOT_SET=1
-
-DOWNLOAD_HASHES="\
-0aa011707785fe30935d8655380052a20ba8b972aa738d4f144c457b35b4d699  mutagen-1.31.tar.gz\
-"
-
-GIT_CLONE_URL="https://github.com/exaile/exaile.git"
+TARGET_DOWNLOAD_PKGS="\
+help2man \
+make \
+git \
+tar"

--- a/tools/installer/requirements.txt
+++ b/tools/installer/requirements.txt
@@ -1,5 +1,5 @@
 git+git://github.com/exaile/pywin32-ctypes.git@pyinstaller#egg=pywin32-ctypes
-git+git://github.com/dangmai/pyinstaller.git@msys2#egg=PyInstaller
+git+git://github.com/pyinstaller/pyinstaller.git@5b6288#egg=PyInstaller
 musicbrainzngs==0.6
 mutagen==1.37
 pylast==1.8.0

--- a/tools/installer/requirements.txt
+++ b/tools/installer/requirements.txt
@@ -1,3 +1,5 @@
-musicbrainzngs
-mutagen==1.31
-pylast
+git+git://github.com/exaile/pywin32-ctypes.git@pyinstaller#egg=pywin32-ctypes
+git+git://github.com/dangmai/pyinstaller.git@msys2#egg=PyInstaller
+musicbrainzngs==0.6
+mutagen==1.37
+pylast==1.8.0


### PR DESCRIPTION
Updated Exaile to use with the new `python-gtk3-gst-sdk`. The installer is created fine, however it is a bit large since it contains all the Gst plugins (~30mb out of the ~50mb generated installer). I'm not 100% sure which plugins we use, so I'll leave all of them in for now, but we can delete them before release if needed. Also, right now PyInstaller is pointing to my fork, we'll need to change that once they merge it in.