### PR TITLE
Plugin moodbar: rework cache filenames, cleanups and fixes

### DIFF
--- a/plugins/moodbar/generator.py
+++ b/plugins/moodbar/generator.py
@@ -25,10 +25,11 @@ import tempfile
 from gi.repository import Gio
 
 
-class MoodbarGeneratorError(Exception): pass
+class MoodbarGeneratorError(Exception):
+    pass
 
 
-class MoodbarGenerator:
+class MoodbarGenerator(object):
     def check(self):
         """Check whether the generator works.
 
@@ -55,10 +56,10 @@ class MoodbarGenerator:
         :type uri: bytes
         :type callback: Callable[[bytes, bytes], None]
         """
-        t = threading.Thread(name=self.__class__.__name__,
-            target=self.generate, args=(uri, callback))
-        t.daemon = True
-        t.start()
+        thread = threading.Thread(name=self.__class__.__name__,
+                                  target=self.generate, args=(uri, callback))
+        thread.daemon = True
+        thread.start()
 
 
 class SpectrumMoodbarGenerator(MoodbarGenerator):
@@ -84,11 +85,12 @@ class SpectrumMoodbarGenerator(MoodbarGenerator):
                 f = open(tmppath, 'rb')
                 data = f.read()
             except Exception as e:
+                # TODO propagate this error to UI, make sure to install required GStreamer plugins
                 raise MoodbarGeneratorError(e)
             finally:
                 if f:
                     f.close()
-                if tmppath:
+                if tmppath and os.path.exists(tmppath):
                     os.remove(tmppath)
         if callback:
             callback(uri, data)

--- a/plugins/moodbar/painter.py
+++ b/plugins/moodbar/painter.py
@@ -17,30 +17,29 @@
 
 from __future__ import division, print_function, unicode_literals
 
+# It seems like cairo does not support GObject Introspection.
 import cairo
 
 
-class MoodbarPainter:
-    """Turn moodbar data into Cairo surface, ready to be drawn"""
+def paint(data):
+    """Paint moodbar to a surface.
 
-    def paint(self, data):
-        """Paint moodbar to a surface.
-
-        :param data: Moodbar data
-        :type data: bytes
-        :return: Cairo surface containing the image to be drawn
-        :rtype: cairo.ImageSurface
-        """
-        surf = cairo.ImageSurface(cairo.FORMAT_RGB24, 1000, 1)
-        arr = surf.get_data()
-        for p in xrange(0, 1000):
-            p4 = p * 4
-            p3 = p * 3
-            # Cairo RGB24 is BGRX
-            arr[p4 + 0] = data[p3 + 2]
-            arr[p4 + 1] = data[p3 + 1]
-            arr[p4 + 2] = data[p3 + 0]
-        return surf
+    :param data: Moodbar data
+    :type data: bytes
+    :return: Cairo surface containing the image to be drawn
+    :rtype: cairo.ImageSurface
+    """
+    width = len(data) // 3
+    surf = cairo.ImageSurface(cairo.FORMAT_RGB24, width, 1)
+    arr = surf.get_data()
+    for index in xrange(0, width):
+        index4 = index * 4
+        index3 = index * 3
+        # Cairo RGB24 is BGRX
+        arr[index4 + 0] = data[index3 + 2]
+        arr[index4 + 1] = data[index3 + 1]
+        arr[index4 + 2] = data[index3 + 0]
+    return surf
 
 
 # vi: et sts=4 sw=4 tw=99

--- a/plugins/moodbar/widget.py
+++ b/plugins/moodbar/widget.py
@@ -29,6 +29,8 @@ from gi.repository import (
     PangoCairo,
 )
 
+from plugins.moodbar import painter
+
 
 Extents = collections.namedtuple('Extents', 'x_bearing y_bearing width height x_advance y_advance')
 
@@ -37,9 +39,8 @@ class Moodbar(Gtk.DrawingArea):
     pos_size = 0.4  # Size of seek notch, in fraction of bar height
     pos_linesize = 2
 
-    def __init__(self, loader):
+    def __init__(self):
         super(Moodbar, self).__init__()
-        self.loader = loader
         # TODO: Handle screen-changed.
         # See https://developer.gnome.org/gtk3/stable/GtkWidget.html#gtk-widget-create-pango-layout
         self.pango_layout = self.create_pango_layout()
@@ -54,7 +55,7 @@ class Moodbar(Gtk.DrawingArea):
         :rtype: bool
         """
         if data:
-            self.surf = self.loader.paint(data)
+            self.surf = painter.paint(data)
             self._invalidate()
             return bool(self.surf)
         else:
@@ -117,7 +118,7 @@ class Moodbar(Gtk.DrawingArea):
         if self.surf:
             # Mood
             cr.save()
-            cr.scale(width / 1000, height)
+            cr.scale(width / self.surf.get_width(), height)
             cr.set_source_surface(self.surf, 0, 0)
             cr.paint()
             cr.restore()


### PR DESCRIPTION
Cache:
* replaced URI-based filenames by hash-based filenames. This fixes #297.
* clean up some code

Generator:
* fixed a traceback occurring if the .mood file could not be created and thus the tmpfile does not exist

Painter:
* Fix array indexing on short tracks, make array indexing more flexible to any kind of track size
* MoodbarPainter: had just one function without usage of self, so removed this class

Widget:
* Fallout from Painter

Formatting:
* made sure that variables are initialized until `__init__()` finishes
* renamed some variables to not overlap with builtin symbols (format)
* renamed some variables to make the name more readable (e.g. `f` for file, `t` for thread)
* replaced old-style classes by new-style classes

I am ready to merge this. Comments?