### PR TITLE
panel notebook: Do not show context menu everywhere

### DIFF
--- a/xlgui/widgets/notebook.py
+++ b/xlgui/widgets/notebook.py
@@ -31,7 +31,6 @@ from gi.repository import Pango
 
 from xl.nls import gettext as _
 from xl import providers
-from xlgui import guiutil
 from xlgui.widgets import menu
 
 # Custom tab style; fixes some Adwaita ugliness
@@ -72,7 +71,6 @@ class SmartNotebook(Gtk.Notebook):
         Gtk.Notebook.__init__(self)
         self.set_scrollable(True)
         self.connect('button-press-event', self.on_button_press)
-        self.connect('popup-menu', self.on_popup_menu)
         self._add_tab_on_empty = True
 
         sc = self.get_style_context()
@@ -147,14 +145,9 @@ class SmartNotebook(Gtk.Notebook):
     def on_button_press(self, widget, event):
         if event.type == Gdk.EventType.BUTTON_PRESS and event.button == 2:
             self.add_default_tab()
-            
-    def on_popup_menu(self, widget):
-        page = self.get_current_tab()
-        tab_label = self.get_tab_label(self.get_current_tab())
-        page.tab_menu.popup(None, None, guiutil.position_menu, tab_label,
-                            0, 0)
-        return True        
-        
+            return True
+        return False
+
 
 class NotebookTab(Gtk.EventBox):
     """


### PR DESCRIPTION
Before this commit, the context menu of the notebook panel would not only be
shown on notebook tab, but also inside any panel when pressing the "menu" key.

After this commit, the context menu of the notebook panel is not shown any more
when pressing the "menu" key.

Opening the context menu by secondary mouse click is not affected by this commit,
since the code for that is in NotebookTab.

This is an attempt to fix #291.
This change basically reverts 77ca3dcaf7dbf357bf92de8ab8f3dfd9313a51a9.
As a side effect, the menu key does not show the tab panel menu any more at all. The only accessible way to add and remove panels is the main menu now.