### PR TITLE
splash.ui: Splash screen is no popup window

### DIFF
--- a/data/ui/splash.ui
+++ b/data/ui/splash.ui
@@ -9,7 +9,6 @@
     <property name="can_focus">False</property>
     <property name="resizable">False</property>
     <property name="window_position">center</property>
-    <property name="destroy_with_parent">True</property>
     <property name="type_hint">splashscreen</property>
     <property name="skip_taskbar_hint">True</property>
     <property name="skip_pager_hint">True</property>

--- a/data/ui/splash.ui
+++ b/data/ui/splash.ui
@@ -7,7 +7,6 @@
     <property name="width_request">413</property>
     <property name="height_request">163</property>
     <property name="can_focus">False</property>
-    <property name="type">popup</property>
     <property name="resizable">False</property>
     <property name="window_position">center</property>
     <property name="destroy_with_parent">True</property>


### PR DESCRIPTION
This change should fix #342 or at least get around the warnings.

@virtuald : Can you please test under OS X, if this fixes #342?