### PR TITLE
splash.ui: Splash screen is no popup window

### DIFF
--- a/data/ui/splash.ui
+++ b/data/ui/splash.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <!--*- mode: xml -*-->
 <interface>
   <requires lib="gtk+" version="3.10"/>
@@ -7,10 +7,8 @@
     <property name="width_request">413</property>
     <property name="height_request">163</property>
     <property name="can_focus">False</property>
-    <property name="type">popup</property>
     <property name="resizable">False</property>
     <property name="window_position">center</property>
-    <property name="destroy_with_parent">True</property>
     <property name="type_hint">splashscreen</property>
     <property name="skip_taskbar_hint">True</property>
     <property name="skip_pager_hint">True</property>


### PR DESCRIPTION
This change should fix #342 or at least get around the warnings.

@virtuald : Can you please test under OS X, if this fixes #342?