### PR TITLE
gstreamer windows: Call AvSetMmThreadCharacteristics to boot thread priority

### DIFF
--- a/xl/player/gst/engine.py
+++ b/xl/player/gst/engine.py
@@ -39,7 +39,7 @@ from xl.nls import gettext as _
 
 from . import gst_utils
 from .dynamic_sink import DynamicAudioSink
-from .sink import create_device
+from .sink import create_device, priority_boost
 
 from xl.player.engine import ExaileEngine
 from xl.player.track_fader import TrackFader
@@ -354,6 +354,9 @@ class AudioStream(object):
         bus = self.playbin.get_bus()
         bus.add_signal_watch()
         bus.connect('message', self.on_message)
+        
+        # priority boost hack if needed
+        priority_boost(self.playbin)
         
         # Pulsesink changes volume behind our back, track it
         self.playbin.connect('notify::volume', self.on_volume_change)

--- a/xl/player/gst/sink.py
+++ b/xl/player/gst/sink.py
@@ -212,3 +212,12 @@ if sys.platform == 'win32':
     import sink_windows
     dev_fn = sink_windows.load_directsoundsink(SINK_PRESETS)
     _autodetect_devices.append(dev_fn)
+    
+    priority_boost = sink_windows.get_priority_booster()
+    
+else:
+    
+    def priority_boost(player):
+        # only needed on windows
+        pass
+    


### PR DESCRIPTION
@sjohannes what do you think... I can't think of a better way to inject this functionality. This seems to work on my Windows 7 VM. The only question I have is whether there should be a setting to enable/disable it... or maybe an exception handler in case it fails? But... it shouldn't really fail as far as I can see. Only available on Windows Vista and above, but I think GST requires Win7 anyways..

@dangmai you mentioned you were able to get stutter to happen on your machine at some point? Can you see if you can stimulate your machine to stutter with GST 1.x? I didn't have much luck with my machine. It would be interesting to know whether this branch makes a difference.

It's worth noting that for this to be even more effective, you really need a directsoundsink built with the patches in https://bugzilla.gnome.org/show_bug.cgi?id=773681 applied. I can post a binary somewhere if you want.