### PR TITLE
plugins/ipconsole: fix colors, replace deprecated code, clean up

### DIFF
--- a/plugins/ipconsole/ipconsole_prefs.ui
+++ b/plugins/ipconsole/ipconsole_prefs.ui
@@ -1,30 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkAdjustment" id="adjustment1">
+    <property name="lower">30</property>
     <property name="upper">110</property>
     <property name="value">80</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
     <property name="page_size">10</property>
-  </object>
-  <object class="GtkListStore" id="liststore1">
-    <columns>
-      <!-- column-name Theme -->
-      <column type="gchararray"/>
-    </columns>
-    <data>
-      <row>
-        <col id="0">Linux</col>
-      </row>
-      <row>
-        <col id="0">LightBG</col>
-      </row>
-      <row>
-        <col id="0">NoColor</col>
-      </row>
-    </data>
   </object>
   <object class="GtkGrid" id="preferences_pane">
     <property name="visible">True</property>
@@ -74,7 +58,8 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">True</property>
-        <property name="font">Sans 12</property>
+        <property name="use_font">True</property>
+        <property name="use_size">True</property>
       </object>
       <packing>
         <property name="left_attach">1</property>
@@ -132,36 +117,6 @@
       </packing>
     </child>
     <child>
-      <object class="GtkLabel" id="label6">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="halign">start</property>
-        <property name="label" translatable="yes">IPython Color Theme:</property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">4</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkComboBox" id="plugin/ipconsole/iptheme">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="model">liststore1</property>
-        <property name="active">0</property>
-        <child>
-          <object class="GtkCellRendererText" id="cellrenderertext1"/>
-          <attributes>
-            <attribute name="text">0</attribute>
-          </attributes>
-        </child>
-      </object>
-      <packing>
-        <property name="left_attach">1</property>
-        <property name="top_attach">4</property>
-      </packing>
-    </child>
-    <child>
       <object class="GtkCheckButton" id="plugin/ipconsole/autostart">
         <property name="label" translatable="yes">Launch IPython console when Exaile starts</property>
         <property name="visible">True</property>
@@ -172,7 +127,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">5</property>
+        <property name="top_attach">4</property>
         <property name="width">2</property>
       </packing>
     </child>

--- a/plugins/ipconsole/ipconsoleprefs.py
+++ b/plugins/ipconsole/ipconsoleprefs.py
@@ -14,34 +14,45 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import os
+import sys
+
 from xlgui.preferences import widgets
 from xl.nls import gettext as _
-import os
 
 name = _('IPython Console')
 basedir = os.path.dirname(os.path.realpath(__file__))
 ui = os.path.join(basedir, 'ipconsole_prefs.ui')
 icon = 'utilities-terminal'
 
+
 class OpacityPreference(widgets.ScalePreference):
     default = 80.0
     name = 'plugin/ipconsole/opacity'
 
+    def __init__(self, preferences, widget):
+        widgets.ScalePreference.__init__(self, preferences, widget)
+        if sys.platform.startswith("win32"):
+            self.set_widget_sensitive(False)
+            # Setting opacity on Windows crashes with segfault,
+            # see https://bugzilla.gnome.org/show_bug.cgi?id=674449
+            self.widget.set_tooltip(_("Opacity cannot be set on Windows due to a bug in Gtk+"))
+
+
 class FontPreference(widgets.FontButtonPreference):
     default = 'Monospace 10'
     name = 'plugin/ipconsole/font'
-    
-class TextColor(widgets.ColorButtonPreference):
+
+
+class TextColor(widgets.RGBAButtonPreference):
     default = 'lavender'
     name = 'plugin/ipconsole/text_color'
-    
-class BgColor(widgets.ColorButtonPreference):
+
+
+class BgColor(widgets.RGBAButtonPreference):
     default = 'black'
     name = 'plugin/ipconsole/background_color'
-    
-class Theme(widgets.ComboPreference):
-    default = 'Linux'
-    name = 'plugin/ipconsole/iptheme'
+
 
 class AutoStart(widgets.CheckPreference):
     default = False

--- a/xlgui/preferences/widgets.py
+++ b/xlgui/preferences/widgets.py
@@ -878,48 +878,6 @@ class IntPreference(FloatPreference):
     def _get_value(self):
         return int(self.widget.get_text())
 
-class ColorButtonPreference(Preference):
-    """
-        A class to represent the color button
-        
-        Gdk.Color is deprecated, please use RGBAButtonPreference instead.
-    """
-    def __init__(self, preferences, widget):
-        Preference.__init__(self, preferences, widget)
-
-    def _setup_change(self):
-        self.widget.connect('color-set', self.change)
-
-    def _set_value(self):
-        value = self.preferences.settings.get_option(
-            self.name, self.default)
-
-        # Extract alpha value in any case
-        if len(value) == 9 and value[0] == '#':
-            alpha = int(value[-2:], 16) * 255
-            value = value[:-2]
-        else:
-            alpha = 1
-
-        if self.widget.get_use_alpha():
-            self.widget.set_alpha(alpha)
-
-        self.widget.set_color(Gdk.color_parse(value))
-
-    def _get_value(self):
-        color = self.widget.get_color()
-        value = '#%.2x%.2x%.2x' % (
-            color.red / 256,
-            color.green / 256,
-            color.blue / 256
-        )
-
-        if self.widget.get_use_alpha():
-            alpha = self.widget.get_alpha()
-            value += '%.2x' % (alpha / 256)
-
-        return value
-
 class RGBAButtonPreference(Preference):
     """
         A class to represent the color button
@@ -943,12 +901,12 @@ class RGBAButtonPreference(Preference):
     def _get_value(self):
         return self.widget.get_rgba().to_string()
 
-class FontButtonPreference(ColorButtonPreference):
+class FontButtonPreference(Preference):
     """
         Font button
     """
     def __init__(self, preferences, widget):
-        ColorButtonPreference.__init__(self, preferences, widget)
+        Preference.__init__(self, preferences, widget)
 
     def _setup_change(self):
         self.widget.connect('font-set', self.change)


### PR DESCRIPTION
* ipthemes did not work, so they were removed
* disable opacity on Win32 because it could cause a segfault
* utilize the new RGBAButtonPreference instead of ColorButtonPreference
  * get rid of the deprecated Gdk.Color
* `ipython_view.py`: replace deprecated `os.popen4()`
  * improves compatibility with python 3 where `os.popen4()` has been removed
* code cleanup and imports resorted
* `__init__.py` is not being loaded from terminal
  * it does not need an import hack
* add logging
* put preferences methods into plugin class
* utilize Gtk.StyleContext with CSS replacing deprecated methods from Gtk.Widget
  * `modify_font()`, `modify_base()`, `modify_text()`
  * this fixes coloring for font
* `xlgui/guiutil.py`: add function to convert font description from Pango to CSS
* utilize new css functions in `xlgui/guiutil.py`
* use `__future__` division for python 3 compatibility

`xlgui/preferences/widgets.py`: remove unused ColorButtonPreference
* After ipconsole is merged, there is no use of the ColorButtonPreference any more.
* FontButtonPreference inherited from ColorButtonPreference, but there is no reason to do so any more.