### PR TITLE
xlgui/widgets/playback.py: replace deprecated Gdk.Color

### DIFF
--- a/xlgui/widgets/playback.py
+++ b/xlgui/widgets/playback.py
@@ -197,7 +197,7 @@ class Marker(GObject.GObject):
             GObject.PARAM_READWRITE
         ),
         'color': (
-            Gdk.Color,
+            Gdk.RGBA,
             'marker color',
             'Override color of the marker',
             GObject.PARAM_READWRITE


### PR DESCRIPTION
`Gdk.Color` is deprecated in favor of `Gdk.RGBA`.
The drawing code already supports `Gdk.RGBA`, no more changes required.