### PR TITLE
plugins/lyricsviewer: remove deprecations, clean up

### DIFF
--- a/plugins/lyricsviewer/lyricsviewer.ui
+++ b/plugins/lyricsviewer/lyricsviewer.ui
@@ -2,65 +2,100 @@
 <!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
-  <object class="GtkTextBuffer" id="LyricsTextBuffer"/>
-  <object class="GtkSpinner" id="RefreshSpinner">
+  <object class="GtkTextBuffer" id="lyrics_text_buffer"/>
+  <object class="GtkTextBuffer" id="track_text_buffer"/>
+  <template class="LyricsViewer" parent="GtkBox">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-  </object>
-  <object class="GtkTextBuffer" id="TrackTextBuffer"/>
-  <object class="GtkWindow" id="LyricsViewerWindow">
-    <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Lyrics</property>
-    <property name="default_width">100</property>
-    <property name="default_height">100</property>
+    <property name="border_width">3</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">3</property>
     <child>
-      <object class="GtkBox" id="LyricsPanel">
+      <object class="GtkBox" id="lyrics_top_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="border_width">3</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">3</property>
         <child>
-          <object class="GtkBox" id="LyricsTopBox">
+          <object class="GtkButton" id="refresh_button">
+            <property name="width_request">34</property>
+            <property name="height_request">34</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="has_tooltip">True</property>
+            <property name="tooltip_text" translatable="yes">Refresh Lyrics</property>
+            <signal name="clicked" handler="on_refresh_button_clicked" swapped="no"/>
             <child>
-              <object class="GtkButton" id="RefreshButton">
-                <property name="width_request">34</property>
-                <property name="height_request">34</property>
+              <object class="GtkStack" id="refresh_button_stack">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="has_tooltip">True</property>
-                <property name="tooltip_text" translatable="yes">Refresh Lyrics</property>
-                <signal name="clicked" handler="on_RefreshButton_clicked" swapped="no"/>
+                <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkImage" id="RefreshIcon">
+                  <object class="GtkImage" id="refresh_icon">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="icon_name">view-refresh</property>
                   </object>
+                  <packing>
+                    <property name="name">page0</property>
+                    <property name="title" translatable="yes">page0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinner" id="refresh_spinner">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="name">page1</property>
+                    <property name="title" translatable="yes">page1</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="pack_type">end</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
+            <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkTextView" id="TrackText">
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkTextView" id="track_text">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="editable">False</property>
+        <property name="wrap_mode">word</property>
+        <property name="justification">center</property>
+        <property name="left_margin">3</property>
+        <property name="right_margin">3</property>
+        <property name="cursor_visible">False</property>
+        <property name="buffer">track_text_buffer</property>
+        <property name="accepts_tab">False</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkScrolledWindow" id="scrolled_window">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <child>
+          <object class="GtkTextView" id="lyrics_text">
+            <property name="width_request">1</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="editable">False</property>
@@ -69,55 +104,29 @@
             <property name="left_margin">3</property>
             <property name="right_margin">3</property>
             <property name="cursor_visible">False</property>
-            <property name="buffer">TrackTextBuffer</property>
+            <property name="buffer">lyrics_text_buffer</property>
             <property name="accepts_tab">False</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkScrolledWindow" id="ScrolledWindow">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <child>
-              <object class="GtkTextView" id="LyricsText">
-                <property name="width_request">1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="editable">False</property>
-                <property name="wrap_mode">word</property>
-                <property name="justification">center</property>
-                <property name="left_margin">3</property>
-                <property name="right_margin">3</property>
-                <property name="cursor_visible">False</property>
-                <property name="buffer">LyricsTextBuffer</property>
-                <property name="accepts_tab">False</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="padding">5</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="LyricsSource">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="use_markup">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
         </child>
       </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="padding">5</property>
+        <property name="position">2</property>
+      </packing>
     </child>
-  </object>
+    <child>
+      <object class="GtkLabel" id="lyrics_source_label">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_markup">True</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">3</property>
+      </packing>
+    </child>
+  </template>
 </interface>

--- a/plugins/lyricsviewer/lyricsviewer_prefs.ui
+++ b/plugins/lyricsviewer/lyricsviewer_prefs.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkGrid" id="preferences_pane">
@@ -21,12 +21,12 @@
     </child>
     <child>
       <object class="GtkFontButton" id="plugin/lyricsviewer/lyrics_font">
-        <property name="use_action_appearance">False</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">True</property>
         <property name="hexpand">True</property>
-        <property name="font">Sans 12</property>
+        <property name="use_font">True</property>
+        <property name="use_size">True</property>
       </object>
       <packing>
         <property name="left_attach">1</property>
@@ -35,7 +35,6 @@
     </child>
     <child>
       <object class="GtkButton" id="plugin/lyricsviewer/reset_button">
-        <property name="use_action_appearance">False</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">True</property>

--- a/plugins/lyricsviewer/lyricsviewerprefs.py
+++ b/plugins/lyricsviewer/lyricsviewerprefs.py
@@ -12,23 +12,33 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import os
+
 from xlgui.preferences import widgets
 from xl.nls import gettext as _
-import os
-from gi.repository import Gtk
 
 name = _('Lyrics Viewer')
 basedir = os.path.dirname(os.path.realpath(__file__))
 ui = os.path.join(basedir, 'lyricsviewer_prefs.ui')
 
-def _get_system_default_font():
-    return Gtk.Widget.get_default_style().font_desc.to_string()
+
+DEFAULT_FONT = None
+
 
 class LyricsFontPreference(widgets.FontButtonPreference):
-    default = _get_system_default_font()
+    default = None
     name = 'plugin/lyricsviewer/lyrics_font'
 
+    def __init__(self, preferences, widget):
+        self.default = DEFAULT_FONT
+        widgets.FontButtonPreference.__init__(self, preferences, widget)
+
+
 class LyricsFontResetButtonPreference(widgets.FontResetButtonPreference):
-    default = _get_system_default_font()
+    default = None
     name = 'plugin/lyricsviewer/reset_button'
     condition_preference_name = 'plugin/lyricsviewer/lyrics_font'
+
+    def __init__(self, preferences, widget):
+        self.default = DEFAULT_FONT
+        widgets.FontResetButtonPreference.__init__(self, preferences, widget)


### PR DESCRIPTION
`lyricsviewer.ui`:
* Remove toplevel panel window
* toplevel box becomes a template
* utilize GtkStack to switch refresh_button child widgets

`lyricsviewer_prefs.ui`:
* Remove deprecated "use_action_appearance" property
* use font and size in GtkFontButton

`__init__.py`:
* clean up code, resort `import`s
* reflect changes in .ui file, including port to GtkTemplate
* create plugin class to utilize `on_gui_loaded()`
* remove unused function `modify_textview_look()`
* remove unused function `open_url()`
* integrate `update_source_text()` into `update_lyrics_text()`
* use GtkStyleContext with GtkCssProvider
  * replaces deprecated method `Gtk.Widget.modify_font()`
  * replaces deprecated method `Gtk.Widget.get_default_style()`

`lyricsviewer_prefs.py`:
* clean up code, resort `import`s