### PR TITLE
Improve python code quality using pycodestyle

### DIFF
--- a/xl/collection.py
+++ b/xl/collection.py
@@ -715,7 +715,7 @@ class Library(object):
                 tr.set_tag_raw('__modified', mtime)
         else:
             tr = trax.Track(uri)
-            if tr._scan_valid == True:
+            if tr._scan_valid:
                 tr.set_tag_raw('__date_added', time.time())
                 self.collection.add(tr)
                 tr.set_tag_raw('__modified', mtime)

--- a/xl/collection.py
+++ b/xl/collection.py
@@ -202,7 +202,7 @@ class Collection(trax.TrackDB):
                 break
 
         to_rem = []
-        if not "://" in library.location:
+        if "://" not in library.location:
             location = u"file://" + library.location
         else:
             location = library.location
@@ -674,10 +674,10 @@ class Library(object):
         album = album.lower()
         artist = artist.lower()
         try:
-            if not basedir in ccheck:
+            if basedir not in ccheck:
                 ccheck[basedir] = {}
 
-            if not album in ccheck[basedir]:
+            if album not in ccheck[basedir]:
                 ccheck[basedir][album] = deque()
         except TypeError:
             logger.exception("Error adding to compilation")

--- a/xl/common.py
+++ b/xl/common.py
@@ -451,7 +451,7 @@ def walk(root):
                 # FIXME: recursive symlinks could cause an infinite loop
                 if fileinfo.get_is_symlink():
                     target = fileinfo.get_symlink_target()
-                    if not "://" in target and not os.path.isabs(target):
+                    if "://" not in target and not os.path.isabs(target):
                         fil2 = dir.get_child(target)
                     else:
                         fil2 = Gio.File.new_for_uri(target)

--- a/xl/migrations/settings/osd.py
+++ b/xl/migrations/settings/osd.py
@@ -22,7 +22,7 @@ def migrate():
     """
     plugins = settings.get_option('plugins/enabled', [])
 
-    if settings.get_option('osd/enabled', False) and not 'osd' in plugins:
+    if settings.get_option('osd/enabled', False) and 'osd' not in plugins:
         settings.set_option('plugins/enabled', plugins + ['osd'])
 
     settings.set_option('osd/enabled', False)

--- a/xl/playlist.py
+++ b/xl/playlist.py
@@ -1985,7 +1985,7 @@ class PlaylistManager(object):
             pl.save_to_location(os.path.join(self.playlist_dir,
                 encode_filename(name)))
 
-            if not name in self.playlists:
+            if name not in self.playlists:
                 self.playlists.append(name)
             #self.playlists.sort()
             self.save_order()

--- a/xl/radio.py
+++ b/xl/radio.py
@@ -56,7 +56,7 @@ class RadioManager(providers.ProviderHandler):
         providers.register(self.servicename, station)
 
     def on_provider_added(self, station):
-        if not station.name in self.stations:
+        if station.name not in self.stations:
             self.stations[station.name] = station
             event.log_event('station_added', self, station)
 

--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -219,7 +219,7 @@ class Track(object):
                 state. not for normal use.
         """
         # don't re-init if its a reused track. see __new__
-        if self._init == False:
+        if self._init is False:
             return
 
         self.__tags = {}

--- a/xlgui/main.py
+++ b/xlgui/main.py
@@ -1072,7 +1072,7 @@ class MainWindow(GObject.GObject):
             #else
             #    destroy tray
             
-            if self.minimized != prev_minimized and self.minimized == True:
+            if self.minimized != prev_minimized and self.minimized is True:
                 if not settings.get_option('gui/use_tray', False) and \
                         self.controller.tray_icon is None:
                     self.controller.tray_icon = tray.TrayIcon(self)

--- a/xlgui/panel/playlists.py
+++ b/xlgui/panel/playlists.py
@@ -633,7 +633,7 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
                     # If we want to go after we have to append 1
                     insert_index = drop_target_index + 1
             else:
-                current_playlist = drop_target;
+                current_playlist = drop_target
 
             # Since the playlist do not have very good support for
             # duplicate tracks we have to perform some trickery

--- a/xlgui/panel/playlists.py
+++ b/xlgui/panel/playlists.py
@@ -328,7 +328,7 @@ class BasePlaylistPanelMixin(GObject.GObject):
         """
             Loads the playlist tracks into the node for the specified playlist
         """
-        if not playlist in self.playlist_nodes: return
+        if playlist not in self.playlist_nodes: return
 
         expanded = self.tree.row_expanded(
             self.model.get_path(self.playlist_nodes[playlist]))

--- a/xlgui/panel/playlists.py
+++ b/xlgui/panel/playlists.py
@@ -782,7 +782,7 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
                 # tracks within our widget
                 # We do a copy if we are draggin from another playlist
                 if Gtk.drag_get_source_widget(context) == tv and \
-                    dragging_playlist == False:
+                    dragging_playlist is False:
                     Gdk.drag_status(context, Gdk.DragAction.MOVE, time)
                 else:
                     Gdk.drag_status(context, Gdk.DragAction.COPY, time)

--- a/xlgui/preferences/__init__.py
+++ b/xlgui/preferences/__init__.py
@@ -215,7 +215,7 @@ class PreferencesDialog(object):
             self.panes[page] = child
             self.builders[page] = builder
 
-        if not page in self.fields:
+        if page not in self.fields:
             self._populate_fields(page, self.builders[page])
 
         if hasattr(page, 'page_enter'):

--- a/xlgui/properties.py
+++ b/xlgui/properties.py
@@ -1043,7 +1043,7 @@ class TagImageField(Gtk.Box):
                 self.batch_update = False
                 self.call_update_func()
 
-        if not None in (all_vals, self.all_button):
+        if None not in (all_vals, self.all_button):
             self.all_button.set_active(all(val == v for v in all_vals))
 
     def get_value(self):

--- a/xlgui/widgets/menuitems.py
+++ b/xlgui/widgets/menuitems.py
@@ -217,7 +217,7 @@ class ShowCurrentTrackMenuItem(menu.MenuItem):
             if callback is not None:
                 item.connect('activate', callback, name, parent, context, *callback_args)
 
-            from xl import player;
+            from xl import player
             item.set_sensitive(player.PLAYER.get_state()!='stopped')
 
             return item

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -1447,8 +1447,8 @@ class PlaylistModel(Gtk.ListStore):
     @guiutil.idle_add()   # sync this call to prevent race conditions
     def on_track_tags_changed(self, type, track, tag):
         if not track or not \
-            settings.get_option('gui/sync_on_tag_change', True) or not\
-            tag in self.columns:
+            settings.get_option('gui/sync_on_tag_change', True) or\
+            tag not in self.columns:
             return
             
         if self._redraw_timer:


### PR DESCRIPTION
Use pycodestyle's errors and warnings over the core source tree (`xl/` and `xlgui/` directories) to fix simple errors and improve the general code quality (#371). Only a sensible subset of the checks are used.