### PR TITLE
font css from pango font: Handle None argument

### DIFF
--- a/xlgui/guiutil.py
+++ b/xlgui/guiutil.py
@@ -642,6 +642,9 @@ def css_from_pango_font_description(pango_font_str):
     """
         Convert a Pango.FontDescription string to a CSS font string
     """
+    if pango_font_str is None:
+        return ""
+
     new_font = Pango.FontDescription.from_string(pango_font_str)
 
     # Gtk+ CSS and Pango are compatible except for the prefix and case


### PR DESCRIPTION
Handle the case that pango_font_str can be None.

Fixes #375