### PR TITLE
Python: Remove pre-2.5 compatibility for MD5

### DIFF
--- a/plugins/daapserver/spydaap/cache.py
+++ b/plugins/daapserver/spydaap/cache.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Spydaap. If not, see <http://www.gnu.org/licenses/>.
 
-import md5
+from hashlib import md5
 import os
 import sys
 
@@ -26,7 +26,7 @@ class Cache(object):
             os.mkdir(self.dir)
 
     def get(self, id, func):
-        id = md5.md5(id).hexdigest()
+        id = md5(id).hexdigest()
         fn = os.path.join(self.dir, id)
         if (not(os.path.exists(fn))):
             f = open(fn, 'w')

--- a/plugins/daapserver/spydaap/containers.py
+++ b/plugins/daapserver/spydaap/containers.py
@@ -15,7 +15,7 @@
 
 import os
 import struct
-import md5
+from hashlib import md5
 import spydaap.cache
 from spydaap.daap import do
 
@@ -51,7 +51,7 @@ class ContainerCache(spydaap.cache.OrderedCache):
                         [build_do(md, id) for (id, md) in enumerate(entries)])
                     ])
             ContainerCacheItem.write_entry(self.dir, pl.name, d, len(entries))
-            pid_list.append(md5.md5(pl.name).hexdigest())
+            pid_list.append(md5(pl.name).hexdigest())
         self.build_index(pid_list)
 
 
@@ -62,7 +62,7 @@ class ContainerCacheItem(spydaap.cache.OrderedCacheItem):
         data = struct.pack('!i', length)
         data = data + struct.pack('!i%ss' % len(name), len(name), name)
         data = data + d.encode()
-        cachefn = os.path.join(dir, md5.md5(name).hexdigest())
+        cachefn = os.path.join(dir, md5(name).hexdigest())
         f = open(cachefn, 'w')
         f.write(data)
         f.close()

--- a/plugins/daapserver/spydaap/metadata.py
+++ b/plugins/daapserver/spydaap/metadata.py
@@ -13,11 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Spydaap. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 import warnings
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    import md5
+from hashlib import md5
 
 import os
 import struct
@@ -42,7 +39,7 @@ class MetadataCache(spydaap.cache.OrderedCache):
                     self.build(os.path.join(path, d), marked, True)
             for fn in files:
                 ffn = os.path.join(path, fn)
-                digest = md5.md5(ffn).hexdigest()
+                digest = md5(ffn).hexdigest()
                 marked[digest] = True
                 md = self.get_item_by_pid(digest)
                 if (not(md.get_exists()) or
@@ -69,7 +66,7 @@ class MetadataCacheItem(spydaap.cache.OrderedCacheItem):
         data = "".join([d.encode() for d in daap])
         data = struct.pack('!i%ss' % len(name), len(name), name) + data
         data = struct.pack('!i%ss' % len(fn), len(fn), fn) + data
-        cachefn = os.path.join(dir, md5.md5(fn).hexdigest())
+        cachefn = os.path.join(dir, md5(fn).hexdigest())
         f = open(cachefn, 'w')
         f.write(data)
         f.close()

--- a/plugins/podcasts/__init__.py
+++ b/plugins/podcasts/__init__.py
@@ -1,4 +1,6 @@
 
+from hashlib import md5
+
 from gi.repository import GLib
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -22,13 +24,6 @@ logger = logging.getLogger(__name__)
 PODCASTS = None
 CURPATH = os.path.realpath(__file__)
 BASEDIR = os.path.dirname(CURPATH)
-
-try:
-    import hashlib
-    md5 = hashlib.md5
-except ImportError:
-    import md5
-    md5 = md5.new
 
 
 def enable(exaile):


### PR DESCRIPTION
hashlib.md5 was added in Python 2.5. We really don't need to support older python versions.