### PR TITLE
Main window transparency: Fixes and improvement

### DIFF
--- a/data/ui/preferences/appearance.ui
+++ b/data/ui/preferences/appearance.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkImage" id="image1">
@@ -34,7 +34,8 @@
     </data>
   </object>
   <object class="GtkAdjustment" id="transparency_adjustment">
-    <property name="upper">1</property>
+    <property name="lower">0.01</property>
+    <property name="upper">0.81000000000000005</property>
     <property name="step_increment">0.10000000000000001</property>
     <property name="page_increment">0.20000000000000001</property>
   </object>
@@ -140,7 +141,6 @@
         <child>
           <object class="GtkButton" id="gui/playlist_font_reset_button">
             <property name="label">_Revert</property>
-            <property name="use_action_appearance">False</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
@@ -159,7 +159,6 @@
         </child>
         <child>
           <object class="GtkFontButton" id="gui/playlist_font">
-            <property name="use_action_appearance">False</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>

--- a/xlgui/main.py
+++ b/xlgui/main.py
@@ -212,18 +212,11 @@ class MainWindow(GObject.GObject):
         self.volume_control = playback.VolumeControl(player.PLAYER)
         self.info_area.get_action_area().pack_end(self.volume_control, False, False, 0)
 
-        self.alpha_style = None
-
         if settings.get_option('gui/use_alpha', False):
-
             screen = self.window.get_screen()
             visual = screen.get_rgba_visual()
             self.window.set_visual(visual)
             self.window.connect('screen-changed', self.on_screen_changed)
-
-            self.alpha_style = Gtk.CssProvider.new()
-            self.window.get_style_context().add_provider(self.alpha_style,
-                                                         Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
             self._update_alpha()
 
         playlist_area = self.builder.get_object('playlist_area')
@@ -390,16 +383,8 @@ class MainWindow(GObject.GObject):
         #panel = panels['files']
 
     def _update_alpha(self):
-        if self.alpha_style is None:
-            return
-
-        opac = 1.0 - float(settings.get_option('gui/transparency'))
-
-        self.alpha_style.load_from_data(
-            '.background { ' +
-            ('background-color: alpha(@theme_bg_color, %s);' % opac) +
-            '}'
-        )
+        opac = 1.0 - float(settings.get_option('gui/transparency', 0.3))
+        Gtk.Widget.set_opacity(self.window, opac)
 
     def do_get_property(self, prop):
         if prop.name == 'is-fullscreen':

--- a/xlgui/preferences/appearance.py
+++ b/xlgui/preferences/appearance.py
@@ -77,7 +77,7 @@ class UseAlphaTransparencyPreference(widgets.CheckPreference):
     restart_required = True
 
 
-class TransparencyPreferfence(widgets.ScalePreference, widgets.CheckConditional):
+class TransparencyPreference(widgets.ScalePreference, widgets.CheckConditional):
     default = 0.3
     name = 'gui/transparency'
     condition_preference_name = 'gui/use_alpha'


### PR DESCRIPTION
Bug fixes:
* Initialize with a sane value, otherwise `float(None)` will raise.
* As long as transparency is enabled, opacity must be less than 1.0, otherwise you'll have to expect artifacts
* Limit transparency so that users don't accidentially break their Exaile installation by fading it away

Improvement:
* Fix typo in preferences
* Remove deprecated widget properties