### PR TITLE
Fix column width saving and glib_wait

### DIFF
--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -697,9 +697,6 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
 
         self.dragging = False
         self.pending_event = None
-        self.button_pressed = False  # used by columns to determine whether
-        # a notify::width event was initiated
-        # by the user.
         self._insert_focusing = False
 
         self._hack_is_osx = sys.platform == 'darwin'
@@ -1022,7 +1019,6 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
             * thunar_details_view_button_press_event() of thunar-details-view.c
             * MultiDragTreeView.__button_press/__button.release of quodlibet/qltk/views.py
         """
-        self.button_pressed = True
         self.grab_focus()
 
         # need this to workaround bug in GTK+ on OSX when dragging/dropping
@@ -1073,7 +1069,6 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
         """
             Unsets the internal state for button press
         """
-        self.button_pressed = False
         self._hack_osx_control_mask = False
 
         # Restore regular selection behavior in any case


### PR DESCRIPTION
* Fix glib_wait to work correctly with instance methods (and now, only with instance methods)
* Fix playlist column width saving... seems like the button release callback it depended on wasn't always called, so use glib_wait instead to reduce the number of potential computations

One annoying side effect is that if you have multiple playlists showing, the other playlist will only update its position after a delay. But... I'm fine with that for now.