### PR TITLE
xlgui/panel: Allow panels without a parent window

### DIFF
--- a/data/ui/panel/collection.ui
+++ b/data/ui/panel/collection.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkListStore" id="collection_combo_model">
@@ -13,58 +13,101 @@
     <property name="can_focus">False</property>
     <property name="icon_name">list-add</property>
   </object>
-  <object class="GtkWindow" id="CollectionPanelWindow">
+  <object class="GtkStack" id="CollectionPanel">
+    <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Collection</property>
     <child>
-      <object class="GtkBox" id="CollectionTopContainer">
+      <object class="GtkGrid" id="CollectionPanelEmpty">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="row_spacing">6</property>
         <child>
-          <object class="GtkBox" id="EmptyCollectionPanel">
+          <object class="GtkButton" id="add_music_button">
+            <property name="label" translatable="yes">_Add Music</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="image">image2</property>
+            <property name="use_underline">True</property>
+            <property name="always_show_image">True</property>
+            <signal name="clicked" handler="on_add_music_button_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="empty_collection_label">
+            <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="no_show_all">True</property>
-            <property name="valign">center</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">12</property>
+            <property name="label" translatable="yes">&lt;b&gt;Collection is empty.&lt;/b&gt;</property>
+            <property name="use_markup">True</property>
+            <property name="justify">center</property>
+            <property name="wrap">True</property>
+            <property name="width_chars">20</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="name">page0</property>
+        <property name="title" translatable="yes">page0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox" id="CollectionPanelContent">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">3</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">3</property>
+        <child>
+          <object class="GtkBox" id="collection_top_hbox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <child>
-              <object class="GtkLabel" id="empty_collection_label">
+              <object class="GtkComboBox" id="collection_combo_box">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">&lt;b&gt;Collection is empty.&lt;/b&gt;</property>
-                <property name="use_markup">True</property>
-                <property name="justify">center</property>
-                <property name="wrap">True</property>
-                <property name="width_chars">20</property>
+                <property name="can_focus">True</property>
+                <property name="model">collection_combo_model</property>
+                <signal name="changed" handler="on_collection_combo_box_changed" swapped="no"/>
+                <child>
+                  <object class="GtkCellRendererText" id="renderer1"/>
+                  <attributes>
+                    <attribute name="text">0</attribute>
+                  </attributes>
+                </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkButtonBox" id="hbuttonbox1">
+              <object class="GtkButton" id="refresh_button">
+                <property name="width_request">34</property>
+                <property name="height_request">34</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Refresh collection view
+(Hold Shift key to rescan the collection)</property>
+                <property name="relief">none</property>
+                <signal name="button-press-event" handler="on_refresh_button_press_event" swapped="no"/>
+                <signal name="key-press-event" handler="on_refresh_button_key_press_event" swapped="no"/>
                 <child>
-                  <object class="GtkButton" id="add_music_button">
-                    <property name="label" translatable="yes">_Add Music</property>
-                    <property name="use_action_appearance">False</property>
+                  <object class="GtkImage" id="image3">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="image">image2</property>
-                    <property name="use_underline">True</property>
-                    <property name="always_show_image">True</property>
-                    <signal name="clicked" handler="on_add_music_button_clicked" swapped="no"/>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">view-refresh</property>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
               </object>
               <packing>
@@ -75,103 +118,37 @@
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="CollectionPanel">
+          <object class="GtkEntry" id="collection_search_entry">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="border_width">3</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">3</property>
-            <child>
-              <object class="GtkBox" id="collection_top_hbox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkComboBox" id="collection_combo_box">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="model">collection_combo_model</property>
-                    <signal name="changed" handler="on_collection_combo_box_changed" swapped="no"/>
-                    <child>
-                      <object class="GtkCellRendererText" id="renderer1"/>
-                      <attributes>
-                        <attribute name="text">0</attribute>
-                      </attributes>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="refresh_button">
-                    <property name="use_action_appearance">False</property>
-                    <property name="width_request">34</property>
-                    <property name="height_request">34</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Refresh collection view
-(Hold Shift key to rescan the collection)</property>
-                    <property name="relief">none</property>
-                    <signal name="button-press-event" handler="on_refresh_button_press_event" swapped="no"/>
-                    <signal name="key-press-event" handler="on_refresh_button_key_press_event" swapped="no"/>
-                    <child>
-                      <object class="GtkImage" id="image3">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">view-refresh</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="collection_search_entry">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="primary_icon_name">edit-find</property>
-                <property name="secondary_icon_name">edit-clear</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_sensitive">False</property>
-                <property name="secondary_icon_tooltip_text" translatable="yes">Clear search field</property>
-                <signal name="activate" handler="on_collection_search_entry_activate" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
+            <property name="can_focus">True</property>
+            <property name="primary_icon_name">edit-find</property>
+            <property name="secondary_icon_name">edit-clear</property>
+            <property name="primary_icon_activatable">False</property>
+            <property name="secondary_icon_sensitive">False</property>
+            <property name="secondary_icon_tooltip_text" translatable="yes">Clear search field</property>
+            <signal name="activate" handler="on_collection_search_entry_activate" swapped="no"/>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="position">1</property>
           </packing>
         </child>
+        <child>
+          <placeholder/>
+        </child>
       </object>
+      <packing>
+        <property name="name">page1</property>
+        <property name="title" translatable="yes">page1</property>
+        <property name="position">1</property>
+      </packing>
     </child>
   </object>
 </interface>

--- a/data/ui/panel/device.ui
+++ b/data/ui/panel/device.ui
@@ -1,29 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
-  <object class="GtkWindow" id="DevicePanelWindow">
+  <object class="GtkBox" id="DevicePanel">
+    <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Collection</property>
+    <property name="border_width">3</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">3</property>
     <child>
-      <object class="GtkBox" id="DevicePanel">
+      <object class="GtkNotebook" id="device_notebook">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="border_width">3</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">3</property>
-        <child>
-          <object class="GtkNotebook" id="device_notebook">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
+        <property name="can_focus">True</property>
       </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
     </child>
   </object>
 </interface>

--- a/data/ui/panel/files.ui
+++ b/data/ui/panel/files.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkListStore" id="liststore_libraries_location">
@@ -8,192 +8,174 @@
       <column type="gchararray"/>
     </columns>
   </object>
-  <object class="GtkWindow" id="FilesPanelWindow">
+  <object class="GtkBox" id="FilesPanel">
+    <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Files</property>
+    <property name="border_width">3</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">3</property>
     <child>
-      <object class="GtkBox" id="FilesPanel">
+      <object class="GtkBox" id="hbox20">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox" id="files_box">
+          <object class="GtkButton" id="files_back_button">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="border_width">3</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">3</property>
+            <property name="sensitive">False</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Previous visited directory</property>
+            <property name="relief">none</property>
             <child>
-              <object class="GtkBox" id="hbox20">
+              <object class="GtkImage" id="image44">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkButton" id="files_back_button">
-                    <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Previous visited directory</property>
-                    <property name="relief">none</property>
-                    <child>
-                      <object class="GtkImage" id="image44">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">go-previous</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="files_forward_button">
-                    <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Next visited directory</property>
-                    <property name="relief">none</property>
-                    <child>
-                      <object class="GtkImage" id="image45">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">go-next</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="files_up_button">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Up one directory</property>
-                    <property name="relief">none</property>
-                    <child>
-                      <object class="GtkImage" id="image46">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">go-up</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="files_refresh_button">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Refresh directory listing</property>
-                    <property name="relief">none</property>
-                    <child>
-                      <object class="GtkImage" id="image43">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">view-refresh</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="files_home_button">
-                    <property name="width_request">36</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Home directory</property>
-                    <property name="relief">none</property>
-                    <child>
-                      <object class="GtkImage" id="image47">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">user-home</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">4</property>
-                  </packing>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
+                <property name="icon_name">go-previous</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkComboBox" id="files_entry">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="model">liststore_libraries_location</property>
-                <property name="has_entry">True</property>
-                <property name="entry_text_column">0</property>
-                <child internal-child="entry">
-                  <object class="GtkEntry" id="combobox-entry1">
-                    <property name="can_focus">True</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="files_search_entry">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="primary_icon_name">edit-find</property>
-                <property name="secondary_icon_name">edit-clear</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_sensitive">False</property>
-                <property name="secondary_icon_tooltip_text" translatable="yes">Clear search field</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="position">0</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkButton" id="files_forward_button">
+            <property name="visible">True</property>
+            <property name="sensitive">False</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Next visited directory</property>
+            <property name="relief">none</property>
+            <child>
+              <object class="GtkImage" id="image45">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">go-next</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="files_up_button">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Up one directory</property>
+            <property name="relief">none</property>
+            <child>
+              <object class="GtkImage" id="image46">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">go-up</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="files_refresh_button">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Refresh directory listing</property>
+            <property name="relief">none</property>
+            <child>
+              <object class="GtkImage" id="image43">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">view-refresh</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="files_home_button">
+            <property name="width_request">36</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Home directory</property>
+            <property name="relief">none</property>
+            <child>
+              <object class="GtkImage" id="image47">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">user-home</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
       </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkComboBox" id="files_entry">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="model">liststore_libraries_location</property>
+        <property name="has_entry">True</property>
+        <property name="entry_text_column">0</property>
+        <child internal-child="entry">
+          <object class="GtkEntry" id="combobox-entry1">
+            <property name="can_focus">True</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="files_search_entry">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="primary_icon_name">edit-find</property>
+        <property name="secondary_icon_name">edit-clear</property>
+        <property name="primary_icon_activatable">False</property>
+        <property name="secondary_icon_sensitive">False</property>
+        <property name="secondary_icon_tooltip_text" translatable="yes">Clear search field</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">3</property>
+      </packing>
+    </child>
+    <child>
+      <placeholder/>
     </child>
   </object>
 </interface>

--- a/data/ui/panel/flatplaylist.ui
+++ b/data/ui/panel/flatplaylist.ui
@@ -1,84 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
-  <object class="GtkWindow" id="FlatPlaylistPanelWindow">
+  <object class="GtkBox" id="FlatPlaylistPanel">
+    <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Radio</property>
+    <property name="border_width">3</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">3</property>
     <child>
-      <object class="GtkBox" id="FlatPlaylistPanel">
+      <object class="GtkBox" id="hbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="border_width">3</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">3</property>
         <child>
-          <object class="GtkBox" id="hbox1">
+          <object class="GtkButton" id="add_button">
+            <property name="width_request">36</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Append All Tracks to Playlist</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="on_add_button_clicked" swapped="no"/>
             <child>
-              <object class="GtkButton" id="add_button">
-                <property name="width_request">36</property>
+              <object class="GtkImage" id="image2">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Append All Tracks to Playlist</property>
-                <property name="relief">none</property>
-                <signal name="clicked" handler="on_add_button_clicked" swapped="no"/>
-                <child>
-                  <object class="GtkImage" id="image2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">list-add</property>
-                  </object>
-                </child>
+                <property name="can_focus">False</property>
+                <property name="icon_name">list-add</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="import_button">
-                <property name="width_request">36</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Import CD</property>
-                <property name="relief">none</property>
-                <signal name="clicked" handler="on_import_button_clicked" swapped="no"/>
-                <child>
-                  <object class="GtkImage" id="image1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">document-open</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="import_button">
+            <property name="width_request">36</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Import CD</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="on_import_button_clicked" swapped="no"/>
+            <child>
+              <object class="GtkImage" id="image1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">document-open</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
           <placeholder/>
         </child>
-        <child>
-          <placeholder/>
-        </child>
       </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
     </child>
   </object>
 </interface>

--- a/data/ui/panel/playlists.ui
+++ b/data/ui/panel/playlists.ui
@@ -1,23 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <!--*- mode: xml -*-->
 <interface>
   <requires lib="gtk+" version="3.10"/>
-  <object class="GtkWindow" id="PlaylistsPanelWindow">
+  <object class="GtkBox" id="PlaylistsPanel">
+    <property name="width_request">85</property>
+    <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Playlists</property>
+    <property name="border_width">3</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">3</property>
     <child>
-      <object class="GtkBox" id="playlists_box">
-        <property name="width_request">85</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="border_width">3</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">3</property>
-        <child>
-          <placeholder/>
-        </child>
-      </object>
+      <placeholder/>
     </child>
   </object>
 </interface>

--- a/data/ui/panel/radio.ui
+++ b/data/ui/panel/radio.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkImage" id="image1">
@@ -7,64 +7,45 @@
     <property name="can_focus">False</property>
     <property name="icon_name">list-add</property>
   </object>
-  <object class="GtkWindow" id="RadioPanelWindow">
+  <object class="GtkBox" id="RadioPanel">
+    <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Radio</property>
+    <property name="border_width">3</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">3</property>
     <child>
-      <object class="GtkBox" id="RadioPanel">
+      <object class="GtkButton" id="add_button">
+        <property name="label" translatable="yes">_Add Station</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">True</property>
+        <property name="halign">start</property>
+        <property name="image">image1</property>
+        <property name="use_underline">True</property>
+        <property name="always_show_image">True</property>
+        <signal name="clicked" handler="on_add_button_clicked" swapped="no"/>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="status_label">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="border_width">3</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">3</property>
-        <child>
-          <object class="GtkBox" id="hbox1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <child>
-              <object class="GtkButton" id="add_button">
-                <property name="label" translatable="yes">_Add Station</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">image1</property>
-                <property name="use_underline">True</property>
-                <property name="always_show_image">True</property>
-                <signal name="clicked" handler="on_add_button_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="status_label">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">start</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
+        <property name="halign">start</property>
       </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="pack_type">end</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <placeholder/>
     </child>
   </object>
 </interface>

--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -632,10 +632,10 @@ class NetworkPanel(CollectionPanel):
         self.net_collection = collection.Collection(self.name)
         self.net_collection.add_library(library)
         CollectionPanel.__init__(self, parent, self.net_collection,
-                                 self.name, _show_collection_empty_message=False)
+                                 self.name, _show_collection_empty_message=False,
+                                 label=self.name)
 
         self.all = []
-        self.label = self.name
 
         self.connect_id = None
 

--- a/plugins/jamendo/__init__.py
+++ b/plugins/jamendo/__init__.py
@@ -87,7 +87,7 @@ class JamendoPanel(panel.Panel):
         'download-items': (GObject.SignalFlags.RUN_LAST, None, (object,)),
     }
 
-    ui_info = (os.path.dirname(__file__) + "/ui/jamendo_panel.ui", 'JamendoPanelWindow')
+    ui_info = (os.path.dirname(__file__) + "/ui/jamendo_panel.ui", 'JamendoPanel')
 
     def __init__(self, parent, exaile):
         panel.Panel.__init__(self, parent, 'jamendo', "Jamendo")

--- a/plugins/jamendo/ui/jamendo_panel.ui
+++ b/plugins/jamendo/ui/jamendo_panel.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkAdjustment" id="num_results_adjustment">
@@ -99,215 +99,210 @@
       </row>
     </data>
   </object>
-  <object class="GtkWindow" id="JamendoPanelWindow">
+  <object class="GtkGrid" id="JamendoPanel">
+    <property name="visible">True</property>
     <property name="can_focus">False</property>
+    <property name="row_spacing">4</property>
+    <property name="column_spacing">2</property>
     <child>
-      <object class="GtkGrid" id="grid1">
+      <object class="GtkComboBox" id="searchComboBox">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="hexpand">True</property>
+        <property name="model">search_categories</property>
+        <signal name="changed" handler="search_combobox_changed" swapped="no"/>
+        <child>
+          <object class="GtkCellRendererText" id="renderer1"/>
+          <attributes>
+            <attribute name="text">1</attribute>
+          </attributes>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkButton" id="refreshButton">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">True</property>
+        <signal name="clicked" handler="refresh_button_clicked" swapped="no"/>
+        <child>
+          <object class="GtkImage" id="image1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="icon_name">view-refresh</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">2</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="searchEntry">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="invisible_char">●</property>
+        <property name="secondary_icon_name">edit-clear</property>
+        <signal name="activate" handler="search_entry_activated" swapped="no"/>
+        <signal name="icon-release" handler="search_entry_icon_release" swapped="no"/>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">1</property>
+        <property name="width">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkExpander" id="expander1">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <child>
+          <object class="GtkGrid" id="grid2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="row_spacing">4</property>
+            <property name="column_spacing">2</property>
+            <child>
+              <object class="GtkLabel" id="label2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Order by:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="orderTypeComboBox">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="model">order_types</property>
+                <signal name="changed" handler="ordertype_combobox_changed" swapped="no"/>
+                <child>
+                  <object class="GtkCellRendererText" id="order_type_renderer"/>
+                  <attributes>
+                    <attribute name="text">1</attribute>
+                  </attributes>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Order direction:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="orderDirectionComboBox">
+                <property name="width_request">60</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="model">order_directions</property>
+                <signal name="changed" handler="orderdirection_combobox_changed" swapped="no"/>
+                <child>
+                  <object class="GtkCellRendererText" id="order_direction_renderer"/>
+                  <attributes>
+                    <attribute name="text">1</attribute>
+                  </attributes>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Results:</property>
+                <property name="justify">right</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSpinButton" id="numResultsSpinButton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="invisible_char">●</property>
+                <property name="adjustment">num_results_adjustment</property>
+                <property name="climb_rate">10</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+        <child type="label">
+          <object class="GtkLabel" id="label1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Advanced</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">2</property>
+        <property name="width">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox" id="treeview_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="row_spacing">4</property>
-        <property name="column_spacing">2</property>
-        <child>
-          <object class="GtkComboBox" id="searchComboBox">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="hexpand">True</property>
-            <property name="model">search_categories</property>
-            <signal name="changed" handler="search_combobox_changed" swapped="no"/>
-            <child>
-              <object class="GtkCellRendererText" id="renderer1"/>
-              <attributes>
-                <attribute name="text">1</attribute>
-              </attributes>
-            </child>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">0</property>
-            <property name="width">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButton" id="refreshButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <signal name="clicked" handler="refresh_button_clicked" swapped="no"/>
-            <child>
-              <object class="GtkImage" id="image1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="icon_name">view-refresh</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="left_attach">2</property>
-            <property name="top_attach">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkEntry" id="searchEntry">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="invisible_char">●</property>
-            <property name="secondary_icon_name">edit-clear</property>
-            <signal name="activate" handler="search_entry_activated" swapped="no"/>
-            <signal name="icon-release" handler="search_entry_icon_release" swapped="no"/>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">1</property>
-            <property name="width">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkExpander" id="expander1">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <child>
-              <object class="GtkGrid" id="grid2">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="row_spacing">4</property>
-                <property name="column_spacing">2</property>
-                <child>
-                  <object class="GtkLabel" id="label2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="label" translatable="yes">Order by:</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkComboBox" id="orderTypeComboBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="model">order_types</property>
-                    <signal name="changed" handler="ordertype_combobox_changed" swapped="no"/>
-                    <child>
-                      <object class="GtkCellRendererText" id="order_type_renderer"/>
-                      <attributes>
-                        <attribute name="text">1</attribute>
-                      </attributes>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="label4">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="label" translatable="yes">Order direction:</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkComboBox" id="orderDirectionComboBox">
-                    <property name="width_request">60</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="model">order_directions</property>
-                    <signal name="changed" handler="orderdirection_combobox_changed" swapped="no"/>
-                    <child>
-                      <object class="GtkCellRendererText" id="order_direction_renderer"/>
-                      <attributes>
-                        <attribute name="text">1</attribute>
-                      </attributes>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="label3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="label" translatable="yes">Results:</property>
-                    <property name="justify">right</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSpinButton" id="numResultsSpinButton">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="invisible_char">●</property>
-                    <property name="adjustment">num_results_adjustment</property>
-                    <property name="climb_rate">10</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">2</property>
-                  </packing>
-                </child>
-              </object>
-            </child>
-            <child type="label">
-              <object class="GtkLabel" id="label1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Advanced</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">2</property>
-            <property name="width">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="treeview_box">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="vexpand">True</property>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">3</property>
-            <property name="width">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="statusLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">start</property>
-            <property name="label" translatable="yes">Ready</property>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">4</property>
-          </packing>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
+        <property name="vexpand">True</property>
         <child>
           <placeholder/>
         </child>
       </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">3</property>
+        <property name="width">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="statusLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Ready</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">4</property>
+      </packing>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
     </child>
   </object>
 </interface>

--- a/plugins/podcasts/__init__.py
+++ b/plugins/podcasts/__init__.py
@@ -51,7 +51,7 @@ def disable(exaile):
 
 
 class PodcastPanel(panel.Panel):
-    ui_info = (os.path.join(BASEDIR, 'podcasts.ui'), 'PodcastPanelWindow')
+    ui_info = (os.path.join(BASEDIR, 'podcasts.ui'), 'PodcastPanel')
 
     def __init__(self, parent):
         panel.Panel.__init__(self, parent, 'podcasts', _('Podcasts'))

--- a/plugins/podcasts/podcasts.ui
+++ b/plugins/podcasts/podcasts.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkImage" id="image2">
@@ -7,72 +7,62 @@
     <property name="can_focus">False</property>
     <property name="icon_name">list-add</property>
   </object>
-  <object class="GtkWindow" id="PodcastPanelWindow">
+  <object class="GtkGrid" id="PodcastPanel">
+    <property name="visible">True</property>
     <property name="can_focus">False</property>
+    <property name="border_width">4</property>
+    <property name="row_spacing">4</property>
+    <property name="column_spacing">2</property>
     <child>
-      <object class="GtkGrid" id="grid1">
+      <object class="GtkButton" id="add_button">
+        <property name="label" translatable="yes">_Add Podcast</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="border_width">4</property>
-        <property name="row_spacing">4</property>
-        <property name="column_spacing">2</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="halign">start</property>
+        <property name="image">image2</property>
+        <property name="use_underline">True</property>
+        <property name="always_show_image">True</property>
+        <signal name="clicked" handler="on_add_button_clicked" swapped="no"/>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkScrolledWindow" id="scrolledwindow1">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="hexpand">True</property>
+        <property name="vexpand">True</property>
+        <property name="shadow_type">etched-in</property>
         <child>
-          <object class="GtkButton" id="add_button">
-            <property name="label" translatable="yes">_Add Podcast</property>
+          <object class="GtkTreeView" id="podcast_tree">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="halign">start</property>
-            <property name="image">image2</property>
-            <property name="use_underline">True</property>
-            <property name="always_show_image">True</property>
-            <signal name="clicked" handler="on_add_button_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkScrolledWindow" id="scrolledwindow1">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
-            <property name="shadow_type">etched-in</property>
-            <child>
-              <object class="GtkTreeView" id="podcast_tree">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="headers_visible">False</property>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection" id="treeview-selection1"/>
-                </child>
-              </object>
+            <property name="headers_visible">False</property>
+            <child internal-child="selection">
+              <object class="GtkTreeSelection" id="treeview-selection1"/>
             </child>
           </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">1</property>
-            <property name="width">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="podcast_statusbar">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">start</property>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">2</property>
-            <property name="width">2</property>
-          </packing>
-        </child>
-        <child>
-          <placeholder/>
         </child>
       </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="podcast_statusbar">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">2</property>
+      </packing>
     </child>
   </object>
 </interface>

--- a/plugins/wikipedia/__init__.py
+++ b/plugins/wikipedia/__init__.py
@@ -143,7 +143,7 @@ class BrowserPage(WebKit2.WebView):
 
 class WikiPanel(panel.Panel):
     # Specifies the path to the UI file and the name of the root element
-    ui_info = (os.path.dirname(__file__) + "/data/wikipanel.ui", 'wikipanel_window')
+    ui_info = (os.path.dirname(__file__) + "/data/wikipanel.ui", 'WikiPanel')
 
     def __init__(self, parent, user_agent):
         panel.Panel.__init__(self, parent, 'wikipedia', _('Wikipedia'))

--- a/plugins/wikipedia/data/wikipanel.ui
+++ b/plugins/wikipedia/data/wikipanel.ui
@@ -1,153 +1,141 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
-  <object class="GtkWindow" id="wikipanel_window">
+  <object class="GtkBox" id="WikiPanel">
+    <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Wikipedia</property>
-    <property name="default_width">100</property>
-    <property name="default_height">100</property>
+    <property name="border_width">3</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">3</property>
     <child>
-      <object class="GtkBox" id="wikipanel">
+      <object class="GtkBox" id="buttonbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="border_width">3</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">3</property>
         <child>
-          <object class="GtkBox" id="buttonbox1">
+          <object class="GtkButton" id="home_button">
+            <property name="width_request">32</property>
+            <property name="height_request">32</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">True</property>
+            <property name="focus_on_click">False</property>
+            <property name="receives_default">True</property>
+            <property name="has_tooltip">True</property>
+            <property name="tooltip_markup" translatable="yes">Home</property>
+            <property name="tooltip_text" translatable="yes">Home</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="on_home_button_clicked" swapped="no"/>
             <child>
-              <object class="GtkButton" id="home_button">
-                <property name="use_action_appearance">False</property>
-                <property name="width_request">32</property>
-                <property name="height_request">32</property>
+              <object class="GtkImage" id="image2">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="has_tooltip">True</property>
-                <property name="tooltip_markup" translatable="yes">Home</property>
-                <property name="tooltip_text" translatable="yes">Home</property>
-                <property name="relief">none</property>
-                <property name="focus_on_click">False</property>
-                <signal name="clicked" handler="on_home_button_clicked" swapped="no"/>
-                <child>
-                  <object class="GtkImage" id="image2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">go-home</property>
-                  </object>
-                </child>
+                <property name="can_focus">False</property>
+                <property name="icon_name">go-home</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
             </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="back_button">
+            <property name="width_request">32</property>
+            <property name="height_request">32</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Back</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="on_back_button_clicked" swapped="no"/>
             <child>
-              <object class="GtkButton" id="back_button">
-                <property name="use_action_appearance">False</property>
-                <property name="width_request">32</property>
-                <property name="height_request">32</property>
+              <object class="GtkImage" id="image3">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Back</property>
-                <property name="relief">none</property>
-                <signal name="clicked" handler="on_back_button_clicked" swapped="no"/>
-                <child>
-                  <object class="GtkImage" id="image3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">go-previous</property>
-                  </object>
-                </child>
+                <property name="can_focus">False</property>
+                <property name="icon_name">go-previous</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="refresh_button">
-                <property name="use_action_appearance">False</property>
-                <property name="width_request">32</property>
-                <property name="height_request">32</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="has_tooltip">True</property>
-                <property name="tooltip_markup" translatable="yes">Refresh</property>
-                <property name="tooltip_text" translatable="yes">Refresh</property>
-                <property name="relief">none</property>
-                <property name="focus_on_click">False</property>
-                <signal name="clicked" handler="on_refresh_button_clicked" swapped="no"/>
-                <child>
-                  <object class="GtkImage" id="image1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">view-refresh</property>
-                    <property name="icon_size">2</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="forward_button">
-                <property name="use_action_appearance">False</property>
-                <property name="width_request">32</property>
-                <property name="height_request">32</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Forward</property>
-                <property name="relief">none</property>
-                <signal name="clicked" handler="on_forward_button_clicked" swapped="no"/>
-                <child>
-                  <object class="GtkImage" id="image4">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">go-next</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
-              </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkFrame" id="rendering_frame">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label_xalign">0</property>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkButton" id="refresh_button">
+            <property name="width_request">32</property>
+            <property name="height_request">32</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="focus_on_click">False</property>
+            <property name="receives_default">True</property>
+            <property name="has_tooltip">True</property>
+            <property name="tooltip_markup" translatable="yes">Refresh</property>
+            <property name="tooltip_text" translatable="yes">Refresh</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="on_refresh_button_clicked" swapped="no"/>
+            <child>
+              <object class="GtkImage" id="image1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">view-refresh</property>
+                <property name="icon_size">2</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="forward_button">
+            <property name="width_request">32</property>
+            <property name="height_request">32</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Forward</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="on_forward_button_clicked" swapped="no"/>
+            <child>
+              <object class="GtkImage" id="image4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">go-next</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
       </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkFrame" id="rendering_frame">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label_xalign">0</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
     </child>
   </object>
 </interface>

--- a/xlgui/panel/__init__.py
+++ b/xlgui/panel/__init__.py
@@ -31,6 +31,10 @@ from gi.repository import GObject
 
 from xl import xdg
 from xlgui.widgets.notebook import NotebookPage
+import logging
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class Panel(GObject.GObject):
@@ -81,12 +85,19 @@ class Panel(GObject.GObject):
             :returns: NotebookPage object
         '''
         if not self._child:
-            window = self.builder.get_object(self.ui_info[1])
-            child = window.get_child()
-            window.remove(child)
-            if not self.label:
-                self.label = window.get_title()
-            window.destroy()
+            widget = self.builder.get_object(self.ui_info[1])
+            if isinstance(widget, Gtk.Window):
+                # the old way, for pre 4.0.0-compatibility
+                child = widget.get_child()
+                if not self.label:
+                    self.label = widget.get_title()
+                LOGGER.info(
+                    "Old style panel %s is creating unnecessary Gtk.Window.",
+                    self.label)
+                widget.remove(child)
+                widget.destroy()
+            else:
+                child = widget
 
             self._child = NotebookPage(child, self.label, 'panel-tab-context')
 

--- a/xlgui/panel/device.py
+++ b/xlgui/panel/device.py
@@ -107,7 +107,7 @@ class DevicePanel(panel.Panel):
         'collection-tree-loaded': (GObject.SignalFlags.RUN_LAST, None, ()),
     }
 
-    ui_info = ('device.ui', 'DevicePanelWindow')
+    ui_info = ('device.ui', 'DevicePanel')
 
     def __init__(self, parent, main, device, name):
 
@@ -156,7 +156,7 @@ class FlatPlaylistDevicePanel(panel.Panel):
         'queue-items': (GObject.SignalFlags.RUN_LAST, None, (object,)),
     }
 
-    ui_info = ('device.ui', 'DevicePanelWindow')
+    ui_info = ('device.ui', 'DevicePanel')
 
     def __init__(self, parent, main, device, name):
 

--- a/xlgui/panel/files.py
+++ b/xlgui/panel/files.py
@@ -71,16 +71,16 @@ class FilesPanel(panel.Panel):
         'queue-items': (GObject.SignalFlags.RUN_LAST, None, (object,)),
     }
 
-    ui_info = ('files.ui', 'FilesPanelWindow')
+    ui_info = ('files.ui', 'FilesPanel')
 
     def __init__(self, parent, collection, name):
         """
             Initializes the files panel
         """
-        panel.Panel.__init__(self, parent, name)
+        panel.Panel.__init__(self, parent, name, _('Files'))
         self.collection = collection
 
-        self.box = self.builder.get_object('files_box')
+        self.box = self.builder.get_object('FilesPanel')
 
         self.targets = [Gtk.TargetEntry.new('text/uri-list', 0, 0)]
 

--- a/xlgui/panel/flatplaylist.py
+++ b/xlgui/panel/flatplaylist.py
@@ -48,7 +48,7 @@ class FlatPlaylistPanel(panel.Panel):
         'queue-items': (GObject.SignalFlags.RUN_LAST, None, (object,)),
     }
 
-    ui_info = ('flatplaylist.ui', 'FlatPlaylistPanelWindow')
+    ui_info = ('flatplaylist.ui', 'FlatPlaylistPanel')
 
     def __init__(self, parent, name, label):
         panel.Panel.__init__(self, parent, name, label)

--- a/xlgui/panel/playlists.py
+++ b/xlgui/panel/playlists.py
@@ -370,7 +370,7 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
     """
     __gsignals__ = BasePlaylistPanelMixin._gsignals_
 
-    ui_info = ('playlists.ui', 'PlaylistsPanelWindow')
+    ui_info = ('playlists.ui', 'PlaylistsPanel')
 
     def __init__(self, parent, playlist_manager,
                  smart_manager, collection, name):
@@ -379,12 +379,12 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
 
             @param playlist_manager:  The playlist manager
         """
-        panel.Panel.__init__(self, parent, name)
+        panel.Panel.__init__(self, parent, name, _('Playlists'))
         BasePlaylistPanelMixin.__init__(self)
         self.playlist_manager = playlist_manager
         self.smart_manager = smart_manager
         self.collection = collection
-        self.box = self.builder.get_object('playlists_box')
+        self.box = self.builder.get_object('PlaylistsPanel')
 
         self.playlist_name_info = 500
         self.track_target = Gtk.TargetEntry.new("text/uri-list", 0, 0)

--- a/xlgui/panel/radio.py
+++ b/xlgui/panel/radio.py
@@ -71,7 +71,7 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
     }
     __gsignals__.update(playlistpanel.BasePlaylistPanelMixin._gsignals_)
 
-    ui_info = ('radio.ui', 'RadioPanelWindow')
+    ui_info = ('radio.ui', 'RadioPanel')
     _radiopanel = None
 
     def __init__(self, parent, collection,
@@ -79,7 +79,7 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
         """
             Initializes the radio panel
         """
-        panel.Panel.__init__(self, parent, name)
+        panel.Panel.__init__(self, parent, name, _('Radio'))
         playlistpanel.BasePlaylistPanelMixin.__init__(self)
 
         self.collection = collection


### PR DESCRIPTION
Commit message:

> Before this change, all panels are created with a parent window and are being reparented when loaded. This is unnecessary code.
> 
> This change introduces a simple way to allow panels being created without a window. All known panels have been ported to the new feature.
> 
> Also, some panels have been slightly redesigned, reducing the widget count.

This is part of #347.

