### PR TITLE
Add support for MATE and Cinnamon screensavers to Pause on Screensaver plugin

### DIFF
--- a/plugins/screensaverpause/PLUGININFO
+++ b/plugins/screensaverpause/PLUGININFO
@@ -1,6 +1,6 @@
 Version='4.0.0'
 Authors=['Johannes Sasongko <sasongko@gmail.com>']
 Name=_('Pause on Screensaver')
-Description=_('Pauses (and optionally resumes) playback based on screensaver status.\n\nRequires: GNOME Screensaver or KDE Screensaver (does not support XScreenSaver nor XLockMore)')
+Description=_('Pauses (and optionally resumes) playback based on screensaver status.\n\nRequires: GNOME, MATE, Cinnamon, or KDE Screensaver (does not support XScreenSaver nor XLockMore)')
 Category=_('Utility')
 RequiredModules=['dbus']

--- a/plugins/screensaverpause/__init__.py
+++ b/plugins/screensaverpause/__init__.py
@@ -35,6 +35,16 @@ SERVICES = [
         path='/org/gnome/ScreenSaver',
         dbus_interface='org.gnome.ScreenSaver',
     ),
+    dict(  # MATE
+        bus_name='org.mate.ScreenSaver',
+        path='/org/mate/ScreenSaver',
+        dbus_interface='org.mate.ScreenSaver',
+    ),
+    dict(  # CINNAMON
+        bus_name='org.cinnamon.ScreenSaver',
+        path='/org/cinnamon/ScreenSaver',
+        dbus_interface='org.cinnamon.ScreenSaver',
+    ),
     dict(  # KDE
         bus_name='org.freedesktop.ScreenSaver',
         path='/',


### PR DESCRIPTION
The plugin currently only supports GNOME and KDE screensavers, but can support MATE and Cinnamon screensavers.