### PR TITLE
Fix shuffle playback missing last track in playlist

### DIFF
--- a/xl/playlist.py
+++ b/xl/playlist.py
@@ -1125,7 +1125,7 @@ class Playlist(object):
         next_index = -1
 
         if shuffle_mode != 'disabled':
-            if self.current is not None:
+            if current_position != -1:
                 self.__tracks.set_meta_key(current_position,
                                            "playlist_shuffle_history", self.__shuffle_history_counter)
                 self.__shuffle_history_counter += 1


### PR DESCRIPTION
Prior to this commit, when a playlist had "shuffle tracks" and "repeat all"
enabled, it would not play the last track any more after playing all tracks once.

Thanks to @sbrubes for the hint!

Fixes #247


Please check for unknown side-effects before merging.