### PR TITLE
Fix #287: 0 gets sorted as the largest playcount value

### DIFF
--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -590,7 +590,7 @@ class Track(object):
         else:
             value = self.__tags.get(tag)
 
-        if not value:
+        if value is None:
             value = u"\uffff\uffff\uffff\uffff"  # unknown
             if tag == 'title':
                 basename = self.get_basename_display()


### PR DESCRIPTION
Because `0` has been interpreted as `None`, sort order broke on numeric columns

Fixes #287.