### PR TITLE
[WIP] Improve build: Makefile and more tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 
 script:
 - docker run --rm -it -e HOME=/home -v $(pwd):/app -w /app exaile/exaile-testimg:${IMGTAG} make test
+- docker run --rm -it -e HOME=/home -v $(pwd):/app -w /app exaile/exaile-testimg:${IMGTAG} make check-doc
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ before_install:
 - docker pull exaile/exaile-testimg:${IMGTAG}
 
 script:
-- docker run --rm -it -e HOME=/home -v $(pwd):/app -w /app exaile/exaile-testimg:${IMGTAG} make test
-- docker run --rm -it -e HOME=/home -v $(pwd):/app -w /app exaile/exaile-testimg:${IMGTAG} make check-doc
+- docker run --rm -it -e HOME=/home -v $(pwd):/app -w /app exaile/exaile-testimg:${IMGTAG} make BUILDDIR=/tmp test check-doc
 
 notifications:
   irc:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,10 @@ EXAILESHAREDIR = $(DESTDIR)$(DATADIR)/exaile
 EXAILECONFDIR  = $(DESTDIR)$(XDGCONFDIR)/exaile
 EXAILEMANDIR   = $(DESTDIR)$(MANPREFIX)/man
 
-.PHONY: dist test completion coverage clean sanitycheck builddir
+.PHONY: all all_no_locale builddir compile make-install-dirs uninstall \
+	install install_no_locale install-target locale install-locale \
+	plugins-dist manpage completion clean pot potball dist test test_coverage \
+	lint_errors sanitycheck
 
 all: compile completion locale manpage
 	@echo "Ready to install..."

--- a/Makefile
+++ b/Makefile
@@ -226,9 +226,10 @@ dist:
 	./tools/dist.sh
 	rm -rf dist/copy
 
+# See .travis.yml for details on how tests are ran by Travis CI
 check-doc: clean
 	$(MAKE) -C doc html
-	$(MAKE) -C doc linkcheck
+
 
 test:
 	EXAILE_DIR=$(shell pwd) PYTHONPATH=$(shell pwd) $(PYTEST) tests

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ EXAILEMANDIR   = $(DESTDIR)$(MANPREFIX)/man
 
 .PHONY: all all_no_locale builddir compile make-install-dirs uninstall \
 	install install_no_locale install-target locale install-locale \
-	plugins-dist manpage completion clean pot potball dist test test_coverage \
-	lint_errors sanitycheck
+	plugins-dist manpage completion clean pot potball dist check-doc test \
+	test_coverage lint_errors sanitycheck
 
 all: compile completion locale manpage
 	@echo "Ready to install..."
@@ -225,6 +225,10 @@ dist:
 	git archive HEAD --prefix=copy/ | tar -x -C dist
 	./tools/dist.sh
 	rm -rf dist/copy
+
+check-doc: clean
+	$(MAKE) -C doc html
+	$(MAKE) -C doc linkcheck
 
 test:
 	EXAILE_DIR=$(shell pwd) PYTHONPATH=$(shell pwd) $(PYTEST) tests

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,7 +6,7 @@ SPHINXOPTS    ?=
 SPHINXBUILD   = python2 -msphinx
 SPHINXPROJ    = Exaile
 SOURCEDIR     = .
-BUILDDIR      = _build
+BUILDDIR      ?= _build
 
 # Put it first so that "make" without argument is like "make help".
 help:


### PR DESCRIPTION
Missing items:
- [ ] (optional) Run documentation and style checks only on one machine, preferably a separate one
- [ ] build all the code to check whether it compiles
- [ ] add sphinx to docker images (see exaile/exaile-testimg#2)
- [ ] build sphinx documentation during tests
- [ ] add pychecker to docker images (see exaile/exaile-testimg#2)
- [ ] check code style using pychecker
- [ ] put built .pyc / .pyo files where we can write them.

Code style:
```
$ pycodestyle --exclude=plugins/daapserver/spydaap/*.py --max-line-length=160 --statistics --count --ignore=E203,E241,E265,E266,E305,E402,E722,E731,E741,W293,W503 .
```

Deferred:
- [ ] add pytest-flakes to docker images (through `pip install`, see exaile/exaile-testimg#2