### PR TITLE
Don't emit track_tags_changed when adding new files to the collection

### DIFF
--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -235,9 +235,10 @@ class Track(object):
             self._unpickles(_unpickles)
             self.__register()
         elif uri:
-            self.set_loc(uri)
+            # notify isn't needed here because this is a new track
+            self.set_loc(uri, notify_changed=False)
             if scan:
-                self.read_tags()
+                self.read_tags(notify_changed=False)
         else:
             raise ValueError("Cannot create a Track from nothing")
 
@@ -258,7 +259,7 @@ class Track(object):
         except KeyError:
             pass
 
-    def set_loc(self, loc):
+    def set_loc(self, loc, notify_changed=True):
         """
             Sets the location.
 
@@ -268,7 +269,8 @@ class Track(object):
         gloc = Gio.File.new_for_commandline_arg(loc)
         self.__tags['__loc'] = gloc.get_uri()
         self.__register()
-        event.log_event('track_tags_changed', self, {'__loc'})
+        if notify_changed:
+            event.log_event('track_tags_changed', self, {'__loc'})
 
     def exists(self):
         """
@@ -366,7 +368,7 @@ class Track(object):
             logger.exception("Unknown exception: Could not write tags to file")
             return False
 
-    def read_tags(self, force=True):
+    def read_tags(self, force=True, notify_changed=True):
         """
             Reads tags from the file for this Track.
             
@@ -415,7 +417,7 @@ class Track(object):
             for tag in to_del:
                 ntags[tag] = None
 
-            self.set_tags(**ntags)
+            self.set_tags(notify_changed=notify_changed, **ntags)
 
             self._scan_valid = True
             return f


### PR DESCRIPTION
Note: This contains #457 , so only look at the last commit for this PR when reviewing it.

I'm less certain about this change... it does what is asked for by #357, but now that I'm thinking about it... should all notifications be suppressed when reading in a new file? Which means any reading done in `__new__` or `__init__` would not generate track_tags_changed notifications.

I'm fairly certain that suppressing them in `__init__` when url=something is desired behavior -- the only time `__init__` is going to be used with a URI object is to create a new track (otherwise `__new__` would return the old track). And if it's a brand new track, probably nobody cares about such notifications, right?

However, I think in `__new__`, the set_tags there should emit notifications, because the track will have existed previously.

* Fixes #357