### PR TITLE
Travis: Build everything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,9 +234,8 @@ check-doc: clean
 BUILD_DIR		= /tmp/exaile-test-build
 test_compile:
 	mkdir -p $(BUILD_DIR)
-	cp --recursive xl xlgui plugins $(BUILD_DIR)
-	$(PYTHON2_CMD) -m compileall -q $(BUILD_DIR)
-	$(PYTHON2_CMD) -O -m compileall -q $(BUILD_DIR)
+	cp --recursive xl xlgui plugins tools Makefile $(BUILD_DIR)
+	$(MAKE) -C $(BUILD_DIR) all
 
 test:
 	EXAILE_DIR=$(shell pwd) PYTHONPATH=$(shell pwd) $(PYTEST) tests


### PR DESCRIPTION
This could have prevented a build error in debian stretch where the target "pot"
failed to make (#454).

I'll merge this as soon as it succeeds to build.