### PR TITLE
Massive speedup

### DIFF
--- a/plugins/minimode/controls.py
+++ b/plugins/minimode/controls.py
@@ -798,7 +798,7 @@ class PlaylistButtonControl(Gtk.ToggleButton, BaseControl, QueueAdapter):
         """
             Updates the internally stored playlist
         """
-        columns = self.view.get_model().columns
+        columns = self.view.get_model().column_names
         model = PlaylistModel(playlist, columns, player.PLAYER, self.view)
         self.view.set_model(model)
 

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -927,6 +927,7 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
             columns = self.get_columns()
             for col in columns:
                 self.remove_column(col)
+                col.destroyed = True
 
             self._setup_columns()
         

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -590,7 +590,7 @@ class PlaylistPage(PlaylistPageBase):
             self.playlist.repeat_mode = mode
 
     def on_mode_changed(self, evtype, playlist, mode, button):
-        GLib.idle_add(button.set_active, mode != 'disabled')
+        button.set_active(mode != 'disabled')
 
     def on_dynamic_playlists_provider_changed(self, evtype, manager, provider):
         """
@@ -604,8 +604,8 @@ class PlaylistPage(PlaylistPageBase):
             sensitive = True
             tooltip_text = _('Dynamically add similar tracks to the playlist')
 
-        GLib.idle_add(self.dynamic_button.set_sensitive, sensitive)
-        GLib.idle_add(self.dynamic_button.set_tooltip_text, tooltip_text)
+        self.dynamic_button.set_sensitive(sensitive)
+        self.dynamic_button.set_tooltip_text(tooltip_text)
 
     def on_option_set(self, evtype, settings, option):
         """
@@ -613,9 +613,9 @@ class PlaylistPage(PlaylistPageBase):
         """
         if option == 'gui/playlist_utilities_bar_visible':
             visible = settings.get_option(option, True)
-            GLib.idle_add(self.playlist_utilities_bar.set_visible, visible)
-            GLib.idle_add(self.playlist_utilities_bar.set_sensitive, visible)
-            GLib.idle_add(self.playlist_utilities_bar.set_no_show_all, not visible)
+            self.playlist_utilities_bar.set_visible(visible)
+            self.playlist_utilities_bar.set_sensitive(visible)
+            self.playlist_utilities_bar.set_no_show_all(not visible)
 
     def on_row_changed(self, model, path, iter):
         """
@@ -966,13 +966,13 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
 
     def on_option_set(self, typ, obj, data):
         if data == "gui/columns" or data == 'gui/playlist_font':
-            GLib.idle_add(self._refresh_columns, priority=GLib.PRIORITY_DEFAULT)
+            self._refresh_columns()
 
     def on_playback_start(self, type, player, track):
         if player.queue.current_playlist == self.playlist and \
                 player.current == self.playlist.current and \
                 settings.get_option('gui/ensure_visible', True):
-            GLib.idle_add(self.scroll_to_current)
+            self.scroll_to_current()
 
     def scroll_to_current(self):
         position = self.playlist.current_position
@@ -1425,7 +1425,7 @@ class PlaylistModel(Gtk.ListStore):
 
     def on_option_set(self, typ, obj, data):
         if data == "gui/playlist_font":
-            GLib.idle_add(self._refresh_icons)
+            self._refresh_icons()
 
     def icon_for_row(self, row):
         # TODO: we really need some sort of global way to say "is this playlist/pos the current one?
@@ -1467,18 +1467,18 @@ class PlaylistModel(Gtk.ListStore):
         for position in positions:
             if position < 0:
                 continue
-            GLib.idle_add(self.update_icon, position)
+            self.update_icon(position)
 
     def on_spat_position_changed(self, event_type, playlist, positions):
         spat_position = min(positions)
         for position in xrange(spat_position, len(self)):
-            GLib.idle_add(self.update_icon, position)
+            self.update_icon(position)
 
     def on_playback_state_change(self, event_type, player_obj, track):
         position = self.playlist.current_position
         if position < 0 or position >= len(self):
             return
-        GLib.idle_add(self.update_icon, position)
+        self.update_icon(position)
 
     def on_track_tags_changed(self, type, track, tags):
         if not track or not \

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -921,14 +921,13 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
         if firstpath:
             topindex = firstpath[0][0]
 
-        self.disconnect(self.columns_changed_id)
-        columns = self.get_columns()
-        for col in columns:
-            self.remove_column(col)
+        with self.handler_block(self.columns_changed_id):
+            columns = self.get_columns()
+            for col in columns:
+                self.remove_column(col)
 
-        self._setup_columns()
-        self.columns_changed_id = self.connect("columns-changed",
-                                               self.on_columns_changed)
+            self._setup_columns()
+        
         self.queue_draw()
 
         if firstpath:

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -733,7 +733,7 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
         event.add_ui_callback(self.on_playback_start,
                               "playback_track_start", self.player,
                               destroy_with=self)
-        self.connect("cursor-changed", self.on_cursor_changed)
+        self._cursor_changed = self.connect("cursor-changed", self.on_cursor_changed)
         self.connect("row-activated", self.on_row_activated)
         self.connect("key-press-event", self.on_key_press_event)
 
@@ -962,7 +962,8 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
                 col.set_sort_indicator(False)
                 col.set_sort_order(Gtk.SortType.DESCENDING)
         reverse = order == Gtk.SortType.DESCENDING
-        self.playlist.sort([column.name] + list(common.BASE_SORT_TAGS), reverse=reverse)
+        with self.handler_block(self._cursor_changed):
+            self.playlist.sort([column.name] + list(common.BASE_SORT_TAGS), reverse=reverse)
 
     def on_option_set(self, typ, obj, data):
         if data == "gui/columns" or data == 'gui/playlist_font':

--- a/xlgui/widgets/playlist_columns.py
+++ b/xlgui/widgets/playlist_columns.py
@@ -72,6 +72,7 @@ class Column(Gtk.TreeViewColumn):
         self.settings_width_name = "gui/col_width_%s" % self.name
         self.cellrenderer = self.renderer()
         self.extrasize = 0
+        self.destroyed = False
 
         self._setup_font(font)
 
@@ -123,7 +124,8 @@ class Column(Gtk.TreeViewColumn):
     @common.glib_wait(100)
     def on_width_changed(self, column, wid):
         width = self.get_width()
-        if width != settings.get_option(self.settings_width_name, -1):
+        if not self.destroyed and \
+           width != settings.get_option(self.settings_width_name, -1):
             settings.set_option(self.settings_width_name, width)
 
     def _setup_font(self, font):

--- a/xlgui/widgets/playlist_columns.py
+++ b/xlgui/widgets/playlist_columns.py
@@ -62,36 +62,28 @@ class Column(Gtk.TreeViewColumn):
     dataproperty = 'text'
     cellproperties = {}
 
-    def __init__(self, container, index, player, font):
+    def __init__(self, container, player, font, size_ratio):
         if self.__class__ == Column:
             raise NotImplementedError("Can't instantiate "
                                       "abstract class %s" % repr(self.__class__))
-
+        
+        self._size_ratio = size_ratio
         self.container = container
         self.player = player
         self.settings_width_name = "gui/col_width_%s" % self.name
         self.cellrenderer = self.renderer()
-        self.extrasize = 0
         self.destroyed = False
-
-        self._setup_font(font)
-
-        if index == 2:
-            super(Column, self).__init__(self.display)
-            self.icon_cellr = Gtk.CellRendererPixbuf()
-            pbufsize = self.get_icon_height()
-            self.icon_cellr.set_fixed_size(pbufsize, pbufsize)
-            self.extrasize = pbufsize
-            self.icon_cellr.set_property('xalign', 0.0)
-            self.pack_start(self.icon_cellr, False)
-            self.set_attributes(self.icon_cellr, pixbuf=1)
-        else:
-            super(Column, self).__init__(self.display)
         
+        super(Column, self).__init__(self.display)
         self.props.min_width = 3
         
         self.pack_start(self.cellrenderer, True)
         self.set_cell_data_func(self.cellrenderer, self.data_func)
+        
+        try:
+            self.cellrenderer.set_property('font-desc', font)
+        except TypeError:
+            pass  # not all cells have a font
 
         try:
             self.cellrenderer.set_property('ellipsize', Pango.EllipsizeMode.END)
@@ -100,7 +92,7 @@ class Column(Gtk.TreeViewColumn):
 
         for name, val in self.cellproperties.iteritems():
             self.cellrenderer.set_property(name, val)
-
+        
         self.set_reorderable(True)
         self.set_clickable(True)
         self.set_sizing(Gtk.TreeViewColumnSizing.FIXED)  # needed for fixed-height mode
@@ -128,48 +120,13 @@ class Column(Gtk.TreeViewColumn):
            width != settings.get_option(self.settings_width_name, -1):
             settings.set_option(self.settings_width_name, width)
 
-    def _setup_font(self, font):
-        '''
-            This should be set even for non-text columns.
-
-            ::param font:: is None or a Pango.FontDescription
-        '''
-        default_font = Gtk.Widget.get_default_style().font_desc
-        if font is None:
-            font = default_font
-
-        def_font_sz = float(default_font.get_size())
-
-        try:
-            self.cellrenderer.set_property('font-desc', font)
-        except TypeError:
-            pass
-
-        # how much has the font deviated from normal?
-        self._font_ratio = font.get_size() / def_font_sz
-
-        try:
-            # adjust the display size of the column
-            ratio = self._font_ratio
-
-            # small fonts can be problematic..
-            # -> TODO: perhaps default widths could be specified
-            #          in character widths instead? then we could
-            #          calculate it instead of using arbitrary widths
-            if ratio < 1:
-                ratio = ratio * 1.25
-
-            self.size = max(int(self.size * ratio), 1)
-        except AttributeError:
-            pass
-
     def _setup_sizing(self):
         with self.handler_block(self._width_notify):
             if settings.get_option('gui/resizable_cols', False):
                 self.set_resizable(True)
                 self.set_expand(False)
                 width = settings.get_option(self.settings_width_name,
-                                            self.size + self.extrasize)
+                                            self.size)
                 self.set_fixed_width(width)
             else:
                 self.set_resizable(False)
@@ -178,44 +135,29 @@ class Column(Gtk.TreeViewColumn):
                     self.set_fixed_width(1)
                 else:
                     self.set_expand(False)
-                    self.set_fixed_width(self.size + self.extrasize)
+                    self.set_fixed_width(self.size)
 
-    def get_icon_height(self):
-        '''Returns a default icon height based on the font size'''
-        sz = Gtk.icon_size_lookup(Gtk.IconSize.BUTTON)[1]
-        return max(int(sz * self._font_ratio), 1)
+    def set_size_ratio(self, ratio):
+        self._size_ratio = ratio
 
-    def get_icon_size_ratio(self):
+    def get_size_ratio(self):
         '''Returns how much bigger or smaller an icon should be'''
-        return self._font_ratio
+        return self._size_ratio
 
     def data_func(self, col, cell, model, iter, user_data):
         # warning: this function gets called from the render function, so do as
         #          little work as possible!
         
-        path = model.get_path(iter)
-        track = model.get_value(iter, 0)
+        cache = model.get_value(iter, 1)
         
-        cell.props.text = self.formatter.format(track)
+        text = cache.get(self.name)
+        if text is None:
+            track = model.get_value(iter, 0)
+            text = self.formatter.format(track)
+            cache[self.name] = text
         
-        # TODO: cache these properties somewhere instead of computing them?s
-        playlist = self.container.playlist
-        if playlist is not self.player.queue.current_playlist:
-            cell.props.weight = Pango.Weight.NORMAL
-            cell.props.sensitive = True
-        else:
-            if track == self.player.current and \
-               path[0] == playlist.get_current_position():
-                cell.props.weight = Pango.Weight.HEAVY
-            else:
-                cell.props.weight = Pango.Weight.NORMAL
-            
-            if -1 < playlist.spat_position < path[0] and \
-                    playlist.shuffle_mode == 'disabled':
-                cell.props.sensitive = False
-            else:
-                cell.props.sensitive = True
-
+        cell.props.text = text
+        
     def __repr__(self):
         return '%s(%r, %r, %r)' % (self.__class__.__name__,
                                    self.name, self.display, self.size)
@@ -290,7 +232,7 @@ class RatingColumn(Column):
     def __init__(self, *args):
         Column.__init__(self, *args)
         self.cellrenderer.connect('rating-changed', self.on_rating_changed)
-        self.cellrenderer.size_ratio = self.get_icon_size_ratio()
+        self.cellrenderer.size_ratio = self.get_size_ratio()
         self.saved_model = None
 
     def data_func(self, col, cell, model, iter, user_data):
@@ -302,7 +244,7 @@ class RatingColumn(Column):
         """
             Retrieves the optimal size
         """
-        size = icons.MANAGER.pixbuf_from_rating(0, self.get_icon_size_ratio()).get_width()
+        size = icons.MANAGER.pixbuf_from_rating(0, self.get_size_ratio()).get_width()
         size += 2  # FIXME: Find the source of this
 
         return size


### PR DESCRIPTION
Since all the data we need is stored in the track object in the PlaylistModel, there's no reason to extract the information and store it in separate columns.    It turns out this is quite expensive. Instead, change the column renderers to    pull the text directly from the track, which has the added advantage of only
    extracting data as needed, instead of rendering the entire playlist.

Contains other misc playlist fixes too.