### PR TITLE
playlist: restore view when filtering

### DIFF
--- a/xlgui/guiutil.py
+++ b/xlgui/guiutil.py
@@ -24,6 +24,7 @@
 # do so. If you do not wish to do so, delete this exception statement
 # from your version.
 
+import contextlib
 import logging
 import os.path
 
@@ -597,5 +598,72 @@ def css_from_pango_font_description(pango_font_str):
         style, variant, weight, stretch, size, new_font.get_family(),
     )
     return font_css_str
+
+
+def _get_closest_visible(model, child_path):
+    # returns closest visible path in filter model to the given child_path
+    # (which is presumed to not be visible in the model)
+    # -> derived from python's bisect_left (Python license)
+    x = child_path.get_indices()[0]
+    
+    ll = len(model)
+    lo = 0
+    hi = ll
+    if not hi:
+        return
+    
+    while lo < hi:
+        mid = (lo + hi)//2
+        amid = model.convert_path_to_child_path(model[mid].path).get_indices()[0]
+        if amid < x:
+            lo = mid + 1
+        else:
+            hi = mid
+    if lo == ll:
+        lo -= 1
+    return model[lo].path
+
+@contextlib.contextmanager
+def without_model(tv):
+    '''
+        Context manager that removes the model from a treeview and restores it
+        when finished.
+    
+        Issue #199: Anytime a large number of changes are made to the model,
+        it's better to just remove it before making the changes, as the UI
+        will freeze if you don't. However, that messes up the visible view, so
+        this saves/restores the view information.
+        
+        .. note:: Assumes the model is a Gtk.TreeModelFilter
+    '''
+    model = tv.get_model()
+    
+    # Save existing scroll information if this is a modelfilter
+    visible_data = tv.get_visible_range()
+    if visible_data:
+        # save a ref and path data -- path is used if the row disappears
+        visible_data = model.convert_path_to_child_path(visible_data[0])
+        visible_ref = Gtk.TreeRowReference(child_model, visible_data)
+    
+    tv.set_model(None)
+    yield model
+    tv.set_model(model)
+    
+    # Restore scroll position
+    if visible_data:
+        # If original item is visible, this is easy
+        if visible_ref.valid():
+            # Use the ref first if it's still valid
+            scroll_to = model.convert_child_path_to_path(visible_ref.get_path())
+        else:
+            # But if it isn't valid, then just use the path data
+            scroll_to = model.convert_child_path_to_path(visible_data)
+        
+        if scroll_to is None:
+            # If not, search for the closest visible item
+            scroll_to = _get_closest_visible(model, visible_data)
+        
+        if scroll_to:
+            tv.scroll_to_cell(scroll_to, None, True, 0, 0)
 
 # vim: et sts=4 sw=4

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -1179,11 +1179,12 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
 
         elif event.keyval == Gdk.KEY_Delete:
             indexes = [x[0] for x in self.get_selected_paths()]
-            if indexes and indexes == range(indexes[0], indexes[0] + len(indexes)):
-                del self.playlist[indexes[0]:indexes[0] + len(indexes)]
-            else:
-                for i in indexes[::-1]:
-                    del self.playlist[i]
+            with guiutil.without_model(self):
+                if indexes and indexes == range(indexes[0], indexes[0] + len(indexes)):
+                    del self.playlist[indexes[0]:indexes[0] + len(indexes)]
+                else:
+                    for i in indexes[::-1]:
+                        del self.playlist[i]
         
         # TODO: localization?
         # -> Also, would be good to expose these shortcuts somehow to the user...

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -772,12 +772,8 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
         AutoScrollTreeView.do_destroy(self)
 
     def _refilter(self):
-        # don't emit spurious view events during refilter operations (issue #199)
-        # -> cursor-changed
-        # -> selection-changed
-        self.set_model(None)
-        self.modelfilter.refilter()
-        self.set_model(self.modelfilter)
+        with guiutil.without_model(self):
+            self.modelfilter.refilter()
 
     def filter_tracks(self, filter_string):
         '''


### PR DESCRIPTION
Previously, when filtering it would just scroll to the top... which is fairly annoying if you're dealing with a large playlist.

This PR restores the normal behavior if you were just using a normal treeview + model without removing the model.

Also includes a fix to #485, as that fix can use the without_model helper function that was introduced here.