### PR TITLE
Fix plugins' teardown() method signature

### DIFF
--- a/plugins/keybinder/__init__.py
+++ b/plugins/keybinder/__init__.py
@@ -68,12 +68,12 @@ class KeybinderPlugin(object):
                 self.__exaile.plugins.disable_plugin(__name__)
                 return
 
-    def teardown(self):
+    def teardown(self, exaile):
         for k in KEYS:
             Keybinder.unbind(k)
 
-    def disable(self, _exaile):
-        self.teardown()
+    def disable(self, exaile):
+        self.teardown(exaile)
         self.__exaile = None
 
 

--- a/plugins/notify/__init__.py
+++ b/plugins/notify/__init__.py
@@ -333,14 +333,14 @@ class NotifyPlugin(object):
         return GLib.SOURCE_REMOVE
 
     def disable(self, _exaile):
+        self.teardown(exaile)
+
+        self.__exaile = None
+
+    def teardown(self, exaile):
         if self.__notifier:
             self.__notifier.destroy()
             self.__notifier = None
-        self.__exaile = None
-
-    def teardown(self):
-        if self.__notifier:
-            self.__notifier.destroy()
 
     def get_preferences_pane(self):
         return notifyprefs


### PR DESCRIPTION
It seems not all plugins have been updated to have their teardown() method include the second argument. 

This causes the following errors being displayed on terminal when shutting down the program:
```
...
INFO    : Exaile is shutting down...
INFO    : Tearing down plugins...
ERROR   : Unable to tear down plugin notify
Traceback (most recent call last):
  File "/home/rok/Projects/exaile/xl/plugins.py", line 296, in teardown
    plugin.teardown(main)
TypeError: teardown() takes exactly 1 argument (2 given)
ERROR   : Unable to tear down plugin keybinder
Traceback (most recent call last):
  File "/home/rok/Projects/exaile/xl/plugins.py", line 296, in teardown
    plugin.teardown(main)
TypeError: teardown() takes exactly 1 argument (2 given)
INFO    : Saving state...
INFO    : Bye!
```

This PR fixes the signature of teardown() method of the offending plugins.