### PR TITLE
Fix the argument name in notify plugin's disable() method

### DIFF
--- a/plugins/notify/__init__.py
+++ b/plugins/notify/__init__.py
@@ -332,7 +332,7 @@ class NotifyPlugin(object):
         self.__notifier = Notifier(self.__exaile, caps)
         return GLib.SOURCE_REMOVE
 
-    def disable(self, _exaile):
+    def disable(self, exaile):
         self.teardown(exaile)
 
         self.__exaile = None


### PR DESCRIPTION
As noted by @sbrubes, in my previous PR I overlooked the underscore in the name of second argument  in the disable() method.