### PR TITLE
Covers: Support multiple albums having the same name

### DIFF
--- a/xl/covers.py
+++ b/xl/covers.py
@@ -124,6 +124,7 @@ class CoverManager(providers.ProviderHandler):
     """
         Handles finding covers from various sources.
     """
+    DB_VERSION = 2
 
     def __init__(self, location):
         """
@@ -135,7 +136,7 @@ class CoverManager(providers.ProviderHandler):
         self.methods = {}
         self.order = settings.get_option(
             'covers/preferred_order', [])
-        self.db = {}
+        self.db = {'version': self.DB_VERSION}
         self.load()
         for method in self.get_providers():
             self.on_provider_added(method)
@@ -405,6 +406,10 @@ class CoverManager(providers.ProviderHandler):
                 break
         if data:
             self.db = data
+        version = self.db.get('version', 1)
+        if version > self.DB_VERSION:
+            logger.error("covers.db version (%s) higher than supported (%s); using anyway",
+                version, self.DB_VERSION)
 
     @common.glib_wait_seconds(60)
     def timeout_save(self):

--- a/xl/main.py
+++ b/xl/main.py
@@ -454,6 +454,10 @@ class Exaile(object):
             logger.exception("VersionError loading collection")
             sys.exit(1)
 
+        # Migrate covers.db. This can only be done after the collection is loaded.
+        import xl.migrations.database.covers_1to2 as mig
+        mig.migrate()
+
         from xl import event
         # Set up the player and playback queue
         from xl import player

--- a/xl/migrations/database/covers_1to2.py
+++ b/xl/migrations/database/covers_1to2.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2009 Aren Olson (for the old_get_track_key function)
+# Copyright (C) 2018 Johannes Sasongko <sasongko@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#
+# The developers of the Exaile media player hereby grant permission
+# for non-GPL compatible GStreamer and Exaile plugins to be used and
+# distributed together with GStreamer and Exaile. This permission is
+# above and beyond the permissions granted by the GPL license by which
+# Exaile is covered. If you modify this code, you may extend this
+# exception to your version of the code, but you are not obligated to
+# do so. If you do not wish to do so, delete this exception statement
+# from your version.
+
+__all__ = ['migrate']
+
+import logging
+import os
+
+from gi.repository import Gio
+
+import xl.collection
+import xl.covers
+
+logger = logging.getLogger(__name__)
+
+def old_get_track_key(track):
+    """
+        Get the db mapping key for a track
+    """
+    album = track.get_tag_raw("album", join=True)
+    compilation = track.get_tag_raw("__compilation")
+
+    if compilation:
+        value = track.get_tag_raw('albumartist')
+        if value:
+            tag = 'albumartist'
+        else:
+            tag = 'compilation'
+            value = compilation
+    elif album:
+        tag = 'album'
+        value = album
+    else:
+        # no album info, cant store it
+        return None
+    return (tag, tuple(value))
+
+def migrate():
+    """Migrate covers.db version 1 to 2 (Exaile 4.0)."""
+
+    man = xl.covers.MANAGER
+    if man.db.get('version', 1) != 1:
+        return
+    logger.info("Upgrading covers.db to version 2")
+
+    valid_cachefiles = set()
+
+    old_db = man.db
+    new_db = {'version': 2}
+    for coll in xl.collection.COLLECTIONS:
+        for tr in coll.tracks.itervalues():
+            key = old_get_track_key(tr._track)
+            value = old_db.get(key)
+            if value:
+                new_key = man._get_track_key(tr)
+                new_db[new_key] = value
+                if value.startswith('cache:'):
+                    valid_cachefiles.add(value[6:])
+    man.db = new_db
+    man.save()
+
+    cachedir = os.path.join(man.location, 'cache')
+    for cachefile in (frozenset(os.listdir(cachedir)) - valid_cachefiles):
+        os.remove(os.path.join(cachedir, cachefile))


### PR DESCRIPTION
See #306 for the motivation for this patch.

One of the exciting changes here is that it adds support for the `musicbrainz_albumid` tag. When this tag is available, we don't need to check anything else; it uniquely identifies the album.

This patch also incorporates @sbrubes's idea to use the `date` tag, because [one artist can release multiple albums with the same name](https://forums.macrumors.com/threads/itunes-two-albums-with-same-name-and-album-artist.1505017/).

So the possible track keys are, in order of preference (`[]` means the tag will be used iff it's available):

* musicbrainz_albumid
* album albumartist [date]
* __compilation [date]  # __compilation is a (directory, album) tuple
* album [artist] [date]

I've also changed the format of the output of this function. The function can return anything we like as long as it's hashable. Currently we return a tuple containing another tuple containing strings. My patch changes this to just a unicode string separated by null characters, e.g. `u'tag1\0value1\0tag2\0value2'`. It should make the dict lookup (hashing) marginally faster.

Here's what the new covers.db looks like, unpickled:

    {
        u"__compilation\x00/my/dir\x01my album\x00date\x002000":
            'localfile:file:///my/dir/cover.jpg',
        u'album\x00My Album\x00albumartist\x00My Albumartist\x00date\x002000':
            'tags:cover:0:file:///my/dir/file.mp3',
        u'musicbrainz_albumid\x00aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee':
            'localfile:file:///my/dir/cover.png',
    }

Any thoughts on all this?

Open questions regarding the migration:

1. What should we do with the existing cache? We could leave it as is, but that means having the existing entries (which are all stale) take up useless space. I vote [trashing](https://developer.gnome.org/gio/stable/GFile.html#g-file-trash) `$cachedir/covers`.
2. Should we reuse the directory/file name or use a new one, e.g. `$cachedir/covers2`, in case the user wants to use it in parallel with Exaile 3?
3. Do we do the migration in `covers.py` itself, or should we use a global 3→4 migration mechanism?