### PR TITLE
MPRIS plugin: improve conformity to spec

### DIFF
--- a/plugins/mpris2/mprisobject.py
+++ b/plugins/mpris2/mprisobject.py
@@ -322,8 +322,8 @@ class MprisObject(object):
     # Player methods
 
     def Next(self):
-        # TODO: Match behavior with spec
-        xl.player.QUEUE.next()
+        if xl.player.PLAYER.is_playing():
+            xl.player.QUEUE.next()
 
     def OpenUri(self, uri):
         pass  # TODO
@@ -343,8 +343,8 @@ class MprisObject(object):
 
 
     def Previous(self):
-        # TODO: Match behavior with spec
-        xl.player.QUEUE.prev()
+        if xl.player.PLAYER.is_playing():
+            xl.player.QUEUE.prev()
 
     def Seek(self, offset):
         pass  # TODO

--- a/plugins/mpris2/mprisobject.py
+++ b/plugins/mpris2/mprisobject.py
@@ -336,8 +336,11 @@ class MprisObject(object):
         xl.player.QUEUE.play()
 
     def PlayPause(self):
-        # TODO: Match behavior with spec
-        xl.player.PLAYER.toggle_pause()
+        if xl.player.PLAYER.is_paused() or xl.player.PLAYER.is_playing():
+            xl.player.PLAYER.toggle_pause()
+        else:
+            xl.player.QUEUE.play(track=xl.player.QUEUE.get_current())
+
 
     def Previous(self):
         # TODO: Match behavior with spec


### PR DESCRIPTION
This PR improves the conformity to MPRIS2 specification:
- PlayPause now starts the playback if it is stopped (instead of just toggling pause) - ```If playback is stopped, starts playback.```
- Next and Previous have effect only if player is in playing state - ```If playback is paused or stopped, it remains that way.```