### PR TITLE
DAAP plugins: fix the retrieval of atoms with integer value 0

### DIFF
--- a/plugins/daapclient/spydaap/daap.py
+++ b/plugins/daapclient/spydaap/daap.py
@@ -102,7 +102,7 @@ class DAAPObject(object):
         if hasattr(self, 'contains'):
             for object in self.contains:
                 value = object.getAtom(code)
-                if value:
+                if value is not None:
                     return value
         return None
 

--- a/plugins/daapserver/spydaap/daap.py
+++ b/plugins/daapserver/spydaap/daap.py
@@ -98,7 +98,7 @@ class DAAPObject(object):
         if hasattr(self, 'contains'):
             for object in self.contains:
                 value = object.getAtom(code)
-                if value:
+                if value is not None:
                     return value
         return None
 


### PR DESCRIPTION
When retrieving the atom value with DAAPObject.getAtom(), None will
be incorrectly returned when the code corresponds to a child
atom with integer value 0.

This is because the validity of the returned value is checked via
boolean coercion instead of explicitly checking for None (and thus
0 evaluates to False, same as a None would have).

Fixes issue #447.