### PR TITLE
Reformat code with black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+
 sudo: required
 services:
   - docker
+language: python
 
 env:
   - IMGTAG=debian8
@@ -15,6 +17,18 @@ before_install:
 
 script:
 - docker run --rm -it -e HOME=/home -v $(pwd):/app -w /app exaile/exaile-testimg:${IMGTAG} make BUILDDIR=/tmp test test_compile check-doc
+
+jobs:
+  include:
+  - stage: format-check
+    sudo: false
+    language: python
+    python:
+    - "3.6"
+    install:
+    - pip install black
+    script:
+    - make check_format
 
 notifications:
   irc:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PYTHON2_CMD   ?= python2
-PYTEST         = py.test
+PYTEST        ?= py.test
+BLACK         ?= black
 
 PREFIX         = /usr/local
 EPREFIX        = $(PREFIX)
@@ -32,7 +33,7 @@ EXAILEMANDIR   = $(DESTDIR)$(MANPREFIX)/man
 .PHONY: all all_no_locale builddir compile make-install-dirs uninstall \
 	install install_no_locale install-target locale install-locale \
 	plugins-dist manpage completion clean pot potball dist check-doc test \
-	test_coverage lint_errors sanitycheck
+	test_coverage lint_errors sanitycheck format
 
 all: compile completion locale manpage
 	@echo "Ready to install..."
@@ -260,3 +261,9 @@ lint_errors:
 	-pylint -e --rcfile tools/pylint.cfg xl xlgui 2> /dev/null
 
 sanitycheck: lint_errors test
+
+format:
+	$(BLACK) -S *.py plugins/ xl/ xlgui/ tests/
+
+check_format:
+	$(BLACK) --check -S *.py plugins/ xl/ xlgui/ tests/

--- a/doc/dev/code_guidelines.rst
+++ b/doc/dev/code_guidelines.rst
@@ -16,9 +16,15 @@ ask!
 Basic Style
 -----------
 
--  Use 4 spaces for indents, no tabs.
--  Avoid lines >80 characters. Try to insert sensible line breaks to
-   accomplish this
+Exaile uses the `black <https://github.com/ambv/black>`_ code formatter to
+enforce a consistent style across the project. You can run black like so:
+
+:: sh
+    
+    black -S *.py plugins/ xl/ xlgui/ tests/
+
+For things that the code formatter doesn't do for you, the following applies:
+
 -  In general, `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ applies
 -  Keep imports on one line each to make sure imports cannot be missed:
 
@@ -31,20 +37,6 @@ Basic Style
     from gi.repository import Gtk
     from gi.repository import GLib
     from gi.repository import GObject
-
--  The same goes for module imports, here parentheses can be used:
-
-.. code-block:: python
-
-    # Not recommended
-    from threading import Event, Thread, Timer
-    
-    # Preferred
-    from threading import (
-        Event,
-        Thread,
-        Timer
-    )
 
 -  Always write out variable names to keep them descriptive. Thus ``notebook_page`` is to
    be preferred over ``nb``.
@@ -105,7 +97,7 @@ Events and Signals
    the (GTK) UI should prefer ``GObject`` signals over ``xl.event``.
 -  Keep in mind all events are synchronous - if your callback might take
    a while, run it in a separate thread.
--  
+-
 
     -  Make sure that every access to GTK UI components is run in the
        GTK main thread. Otherwise unpredictable issues can occur
@@ -130,7 +122,7 @@ Events and Signals
                     Serious problem: this event is run in a
                     different thread, a crash is likely to occur
                 """
-                self.label.set_text(track.get_tag_display('title'))        
+                self.label.set_text(track.get_tag_display('title'))
 
 -  Event names should be all lower-case, using underscores to separate
    words.
@@ -234,4 +226,3 @@ Other
 -  If you create a new on-disk format, add a version flag to it. This
    makes forwards and backwards compatibility MUCH easier should the
    format ever need to change.
-

--- a/exaile.py
+++ b/exaile.py
@@ -29,6 +29,7 @@ if sys.platform == 'linux2':
     # Set process name.  Only works on Linux >= 2.1.57.
     try:
         import ctypes
+
         libc = ctypes.CDLL('libc.so.6')
         libc.prctl(15, 'exaile', 0, 0, 0)  # 15 = PR_SET_NAME
     except Exception:
@@ -37,6 +38,7 @@ if sys.platform == 'linux2':
 # Set visible process name. Requires module "setproctitle"
 try:
     from setproctitle import setproctitle
+
     setproctitle('exaile')
 except ImportError:
     pass
@@ -53,8 +55,10 @@ os.environ['EXAILE_DIR'] = basedir
 
 def main():
     from xl import main
+
     global exaile
     exaile = main.Exaile()
+
 
 if __name__ == "__main__":
     main()

--- a/exaile_osx.py
+++ b/exaile_osx.py
@@ -6,7 +6,9 @@ import sys
 def main():
     sys.argv[1:1] = ['--startgui', '--no-dbus', '--no-hal']
     import exaile
+
     exaile.main()
+
 
 if __name__ == '__main__':
     main()

--- a/exaile_win.py
+++ b/exaile_win.py
@@ -21,6 +21,7 @@ def __open_inheritance_hack(*args, **kwargs):
     windll.kernel32.SetHandleInformation(handle, 1, 0)
     return result
 
+
 __builtin__.open = __open_inheritance_hack
 
 
@@ -40,6 +41,7 @@ def error(message1, message2=None, die=True):
             raw_input()
     else:
         import ctypes
+
         if not message2:
             message1, message2 = message2, message1
         ctypes.windll.user32.MessageBoxW(None, message2, message1, 0x10)
@@ -50,33 +52,35 @@ def error(message1, message2=None, die=True):
 def main():
 
     import logging
-    logging.basicConfig(level=logging.INFO, datefmt="%H:%M:%S",
-                        format="%(levelname)-8s: %(message)s")
 
-    aio_message = "\r\n\r\nPlease run the 'All-In-One PyGI/PyGObject for " + \
-        "Windows Installer' and ensure that the following are selected:" + \
-                  "\r\n\r\n" + \
-                  "* GTK+ 3.x\r\n" + \
-                  "* GStreamer 1.x and the gst-plugins package(s)\r\n" + \
-                  "\r\n" + \
-                  "The 'All-In-One PyGI/PyGObject for Windows Installer' " + \
-                  "can be downloaded at\r\n" + \
-                  "http://sourceforge.net/projects/pygobjectwin32/\r\n\r\n" + \
-                  "See README.Windows for more information."
+    logging.basicConfig(
+        level=logging.INFO, datefmt="%H:%M:%S", format="%(levelname)-8s: %(message)s"
+    )
+
+    aio_message = (
+        "\r\n\r\nPlease run the 'All-In-One PyGI/PyGObject for "
+        + "Windows Installer' and ensure that the following are selected:"
+        + "\r\n\r\n"
+        + "* GTK+ 3.x\r\n"
+        + "* GStreamer 1.x and the gst-plugins package(s)\r\n"
+        + "\r\n"
+        + "The 'All-In-One PyGI/PyGObject for Windows Installer' "
+        + "can be downloaded at\r\n"
+        + "http://sourceforge.net/projects/pygobjectwin32/\r\n\r\n"
+        + "See README.Windows for more information."
+    )
 
     try:
         import gi
     except Exception:
-        error("PyGObject not found",
-              "PyGObject could not be imported. " + aio_message)
+        error("PyGObject not found", "PyGObject could not be imported. " + aio_message)
     else:
         logging.info("PyGObject works")
     try:
         gi.require_version('Gtk', '3.0')
         from gi.repository import Gtk
     except Exception:
-        error("GTK+ not found",
-              "GTK+ could not be imported. " + aio_message)
+        error("GTK+ not found", "GTK+ could not be imported. " + aio_message)
     else:
         logging.info("GTK+ works")
 
@@ -84,18 +88,19 @@ def main():
         gi.require_version('Gst', '1.0')
         from gi.repository import Gst
     except Exception:
-        error("GStreamer not found",
-              "GStreamer could not be imported. " + aio_message)
+        error("GStreamer not found", "GStreamer could not be imported. " + aio_message)
     else:
         logging.info("GStreamer works")
 
     try:
         import mutagen
     except Exception:
-        error("Mutagen not found",
-              "The Python module Mutagen could not be imported. It can be " +
-              "downloaded from http://code.google.com/p/mutagen\r\n\r\n" +
-              "See README.Windows for more information.")
+        error(
+            "Mutagen not found",
+            "The Python module Mutagen could not be imported. It can be "
+            + "downloaded from http://code.google.com/p/mutagen\r\n\r\n"
+            + "See README.Windows for more information.",
+        )
     else:
         logging.info("Mutagen works")
 
@@ -107,11 +112,14 @@ def main():
     try:
         sys.argv[1:1] = ['--startgui', '--no-dbus', '--no-hal']
         import exaile
+
         exaile.main()
     except Exception:
         import traceback
+
         traceback.print_exc()
         raw_input()
+
 
 if __name__ == '__main__':
     main()

--- a/plugins/abrepeat/__init__.py
+++ b/plugins/abrepeat/__init__.py
@@ -22,7 +22,6 @@ from xlgui.widgets import playback
 
 
 class ABRepeatPlugin(object):
-
     def __init__(self):
         self.__menu_item = None
 
@@ -47,19 +46,17 @@ class ABRepeatPlugin(object):
 plugin_class = ABRepeatPlugin
 
 
-class RepeatSegmentMenuItem(playback.MoveMarkerMenuItem,
-                            providers.ProviderHandler):
+class RepeatSegmentMenuItem(playback.MoveMarkerMenuItem, providers.ProviderHandler):
     """
         Menu item allowing for insertion of two markers
         to signify beginning and end of the segment to repeat
     """
 
     def __init__(self):
-        playback.MoveMarkerMenuItem.__init__(self,
-                                             'repeat-segment', [], _('Repeat Segment'),
-                                             'media-playlist-repeat')
-        providers.ProviderHandler.__init__(self,
-                                           'playback-markers')
+        playback.MoveMarkerMenuItem.__init__(
+            self, 'repeat-segment', [], _('Repeat Segment'), 'media-playlist-repeat'
+        )
+        providers.ProviderHandler.__init__(self, 'playback-markers')
 
         self.beginning_marker = playback.Marker()
         self.beginning_marker.name = 'repeat-beginning'
@@ -84,11 +81,12 @@ class RepeatSegmentMenuItem(playback.MoveMarkerMenuItem,
         """
             Generates the menu item
         """
-        item = playback.MoveMarkerMenuItem.factory(self, menu,
-                                                   parent, context)
+        item = playback.MoveMarkerMenuItem.factory(self, menu, parent, context)
 
-        markers = (providers.get_provider('playback-markers', n)
-                   for n in ('repeat-beginning', 'repeat-end'))
+        markers = (
+            providers.get_provider('playback-markers', n)
+            for n in ('repeat-beginning', 'repeat-end')
+        )
 
         if player.PLAYER.current is None:
             item.set_sensitive(False)
@@ -116,8 +114,7 @@ class RepeatSegmentMenuItem(playback.MoveMarkerMenuItem,
         providers.register('playback-markers', self.beginning_marker)
         context['current-marker'] = self.beginning_marker
 
-        playback.MoveMarkerMenuItem.on_activate(self, widget,
-                                                parent, context)
+        playback.MoveMarkerMenuItem.on_activate(self, widget, parent, context)
 
     def on_parent_button_press_event(self, widget, event):
         """
@@ -125,8 +122,7 @@ class RepeatSegmentMenuItem(playback.MoveMarkerMenuItem,
         """
         if event.button == Gdk.BUTTON_PRIMARY:
             if self.move_finish():
-                if providers.get_provider('playback-markers',
-                                          'repeat-end') is None:
+                if providers.get_provider('playback-markers', 'repeat-end') is None:
                     position = event.x / widget.get_allocation().width
                     self.end_marker.props.position = position
                     providers.register('playback-markers', self.end_marker)

--- a/plugins/alarmclock/__init__.py
+++ b/plugins/alarmclock/__init__.py
@@ -14,13 +14,11 @@ LOGGER = logging.getLogger(__name__)
 
 
 class AlarmClock(object):
-
     def __init__(self):
         self.__timeout_id = None
         self.__fade_id = None
         self.__current_volume = None
-        event.add_callback(self.__on_option_set,
-                           'plugin_alarmclock_option_set')
+        event.add_callback(self.__on_option_set, 'plugin_alarmclock_option_set')
         self.__update_timeout()
 
     def stop_timeout(self):
@@ -41,13 +39,15 @@ class AlarmClock(object):
         if day_nr < 1 or day_nr > 7:
             raise ValueError
 
-        weekdays = [acprefs.MondayPreference,
-                    acprefs.TuesdayPreference,
-                    acprefs.WednesdayPreference,
-                    acprefs.ThursdayPreference,
-                    acprefs.FridayPreference,
-                    acprefs.SaturdayPreference,
-                    acprefs.SundayPreference]
+        weekdays = [
+            acprefs.MondayPreference,
+            acprefs.TuesdayPreference,
+            acprefs.WednesdayPreference,
+            acprefs.ThursdayPreference,
+            acprefs.FridayPreference,
+            acprefs.SaturdayPreference,
+            acprefs.SundayPreference,
+        ]
         pref_class = weekdays[day_nr - 1]
         return AlarmClock.__get_pref(pref_class)
 
@@ -62,8 +62,13 @@ class AlarmClock(object):
         hour = self.__get_pref(acprefs.HourPreference)
         minute = self.__get_pref(acprefs.MinutesPreference)
         tmp_timer = GLib.DateTime.new_local(
-            current.get_year(), current.get_month(),
-            current.get_day_of_month(), hour, minute, 0)
+            current.get_year(),
+            current.get_month(),
+            current.get_day_of_month(),
+            hour,
+            minute,
+            0,
+        )
 
         next_timer = None
         for delta_days in range(0, 8):  # current weekday is checked twice intentional
@@ -82,9 +87,10 @@ class AlarmClock(object):
             return
 
         diff = next_timer.difference(current) // 1000
-        LOGGER.debug("Alarm due in %i seconds (%i hours)", diff // 1000, diff // 3600000)
-        self.__timeout_id = GLib.timeout_add(
-            diff, self.__on_timeout_finished)
+        LOGGER.debug(
+            "Alarm due in %i seconds (%i hours)", diff // 1000, diff // 3600000
+        )
+        self.__timeout_id = GLib.timeout_add(diff, self.__on_timeout_finished)
 
     def __on_timeout_finished(self):
         LOGGER.debug("Finished timeout")
@@ -94,8 +100,7 @@ class AlarmClock(object):
             self.__current_volume = min_volume
             player.PLAYER.set_volume(self.__current_volume)
             timer_step = self.__get_pref(acprefs.TimerStepPreference)
-            self.__fade_id = GLib.timeout_add(
-                timer_step * 1000, self.__fade_in)
+            self.__fade_id = GLib.timeout_add(timer_step * 1000, self.__fade_in)
         else:
             max_volume = self.__get_pref(acprefs.MaxVolumePreference)
             player.PLAYER.set_volume(max_volume)
@@ -117,8 +122,11 @@ class AlarmClock(object):
         increment = self.__get_pref(acprefs.IncrementPreference)
         # try to detect whether the user interacted with exaile and abort
         delta_volume = abs(player.PLAYER.get_volume() - self.__current_volume)
-        if player.PLAYER.is_paused() or not player.PLAYER.is_playing() \
-                or delta_volume > (increment / 2):
+        if (
+            player.PLAYER.is_paused()
+            or not player.PLAYER.is_playing()
+            or delta_volume > (increment / 2)
+        ):
             self.__fade_id = None
             LOGGER.debug("Aborting fade in because of user interaction")
             return GLib.SOURCE_REMOVE
@@ -143,7 +151,6 @@ class AlarmClock(object):
 
 
 class AlarmclockPlugin(object):
-
     def __init__(self):
         self.__alarm_clock = None
 

--- a/plugins/amazoncovers/__init__.py
+++ b/plugins/amazoncovers/__init__.py
@@ -17,13 +17,7 @@
 import logging
 import time
 
-from xl import (
-    common,
-    covers,
-    event,
-    providers,
-    settings
-)
+from xl import common, covers, event, providers, settings
 
 import _ecs as ecs
 import amazonprefs
@@ -60,6 +54,7 @@ class AmazonCoverSearch(covers.CoverSearchMethod):
     """
         Searches amazon for an album cover
     """
+
     name = 'amazon'
     title = 'Amazon'
 
@@ -77,13 +72,13 @@ class AmazonCoverSearch(covers.CoverSearchMethod):
             return []
 
         # get the settings for amazon key and secret key
-        api_key = settings.get_option(
-            'plugin/amazoncovers/api_key', '')
-        secret_key = settings.get_option(
-            'plugin/amazoncovers/secret_key', '')
+        api_key = settings.get_option('plugin/amazoncovers/api_key', '')
+        secret_key = settings.get_option('plugin/amazoncovers/secret_key', '')
         if not api_key or not secret_key:
-            logger.warning('Please enter your Amazon API and secret '
-                           'keys in the Amazon Covers preferences')
+            logger.warning(
+                'Please enter your Amazon API and secret '
+                'keys in the Amazon Covers preferences'
+            )
             return []
 
         # wait at least 1 second until the next attempt

--- a/plugins/amazoncovers/_ecs.py
+++ b/plugins/amazoncovers/_ecs.py
@@ -34,6 +34,7 @@ def generate_timestamp():
     ret = datetime.datetime.utcnow()
     return ret.isoformat() + 'Z'
 
+
 # make a valid RESTful AWS query, that is signed, from a dictionary
 # http://docs.amazonwebservices.com/AWSECommerceService/latest/DG/index.html?RequestAuthenticationArticle.html
 # code by Robert Wallis: SmilingRob@gmail.com, your hourly software contractor
@@ -42,19 +43,21 @@ def generate_timestamp():
 def get_aws_query_string(aws_access_key_id, secret, query_dictionary):
     query_dictionary["AWSAccessKeyId"] = aws_access_key_id
     query_dictionary["Timestamp"] = generate_timestamp()
-    query_pairs = sorted(map(
-        lambda k, v: (k + "=" + urllib2.quote(v)),
-        query_dictionary.items()
-    ))
+    query_pairs = sorted(
+        map(lambda k, v: (k + "=" + urllib2.quote(v)), query_dictionary.items())
+    )
     # The Amazon specs require a sorted list of arguments
     query_string = "&".join(query_pairs)
     hm = hmac.new(
         secret,
         "GET\nwebservices.amazon.com\n/onca/xml\n" + query_string,
-        hashlib.sha256
+        hashlib.sha256,
     )
     signature = urllib2.quote(base64.b64encode(hm.digest()))
-    query_string = "https://webservices.amazon.com/onca/xml?%s&Signature=%s" % (query_string, signature)
+    query_string = "https://webservices.amazon.com/onca/xml?%s&Signature=%s" % (
+        query_string,
+        signature,
+    )
     return query_string
 
 
@@ -69,8 +72,9 @@ def search_covers(search, api_key, secret_key, user_agent):
         'ResponseGroup': 'ItemAttributes,Images',
     }
 
-    query_string = get_aws_query_string(str(api_key).strip(),
-                                        str(secret_key).strip(), params)
+    query_string = get_aws_query_string(
+        str(api_key).strip(), str(secret_key).strip(), params
+    )
 
     headers = {'User-Agent': user_agent}
     req = urllib2.Request(query_string, None, headers)

--- a/plugins/audioscrobbler/_scrobbler.py
+++ b/plugins/audioscrobbler/_scrobbler.py
@@ -17,13 +17,13 @@ POST_URL = None
 POST_URL = None
 NOW_URL = None
 HARD_FAILS = 0
-LAST_HS = None   # Last handshake time
-HS_DELAY = 0      # wait this many seconds until next handshake
+LAST_HS = None  # Last handshake time
+HS_DELAY = 0  # wait this many seconds until next handshake
 SUBMIT_CACHE = []
-MAX_CACHE = 5      # keep only this many songs in the cache
-MAX_SUBMIT = 10     # submit at most this many tracks at one time
+MAX_CACHE = 5  # keep only this many songs in the cache
+MAX_SUBMIT = 10  # submit at most this many tracks at one time
 PROTOCOL_VERSION = '1.2'
-__LOGIN = {}     # data required to login
+__LOGIN = {}  # data required to login
 
 USER_AGENT_HEADERS = None
 
@@ -58,8 +58,7 @@ def set_user_agent(s):
     USER_AGENT_HEADERS = {'User-Agent': s}
 
 
-def login(user, password, hashpw=False, client=('exa', '0.3.0'),
-          post_url=None):
+def login(user, password, hashpw=False, client=('exa', '0.3.0'), post_url=None):
     """Authencitate with AS (The Handshake)
 
     @param user:     The username
@@ -70,8 +69,7 @@ def login(user, password, hashpw=False, client=('exa', '0.3.0'),
                      password.
     @param client:   Client information (see http://www.audioscrobbler.net/development/protocol/ for more info)
     @type  client:   Tuple: (client-id, client-version)"""
-    global LAST_HS, SESSION_ID, POST_URL, NOW_URL, HARD_FAILS, HS_DELAY, \
-        PROTOCOL_VERSION, INITIAL_URL, __LOGIN
+    global LAST_HS, SESSION_ID, POST_URL, NOW_URL, HARD_FAILS, HS_DELAY, PROTOCOL_VERSION, INITIAL_URL, __LOGIN
 
     __LOGIN['u'] = user
     __LOGIN['c'] = client
@@ -80,8 +78,11 @@ def login(user, password, hashpw=False, client=('exa', '0.3.0'),
         next_allowed_hs = LAST_HS + timedelta(seconds=HS_DELAY)
         if datetime.now() < next_allowed_hs:
             delta = next_allowed_hs - datetime.now()
-            raise ProtocolError("""Please wait another %d seconds until next handshake
-(login) attempt.""" % delta.seconds)
+            raise ProtocolError(
+                """Please wait another %d seconds until next handshake
+(login) attempt."""
+                % delta.seconds
+            )
 
     LAST_HS = datetime.now()
 
@@ -104,7 +105,7 @@ def login(user, password, hashpw=False, client=('exa', '0.3.0'),
         'v': client[1],
         'u': user,
         't': tstamp,
-        'a': token
+        'a': token,
     }
     data = urllib.urlencode(values)
     req = urllib2.Request("%s?%s" % (url, data), None, USER_AGENT_HEADERS)
@@ -116,17 +117,20 @@ def login(user, password, hashpw=False, client=('exa', '0.3.0'),
         raise AuthError('Bad username/password')
 
     elif lines[0] == 'BANNED':
-        raise Exception('''This client-version was banned by Audioscrobbler. Please
-contact the author of this module!''')
+        raise Exception(
+            '''This client-version was banned by Audioscrobbler. Please
+contact the author of this module!'''
+        )
 
     elif lines[0] == 'BADTIME':
-        raise ValueError('''Your system time is out of sync with Audioscrobbler.
-Consider using an NTP-client to keep you system time in sync.''')
+        raise ValueError(
+            '''Your system time is out of sync with Audioscrobbler.
+Consider using an NTP-client to keep you system time in sync.'''
+        )
 
     elif lines[0].startswith('FAILED'):
         handle_hard_error()
-        raise BackendError("Authencitation with AS failed. Reason: %s" %
-                           lines[0])
+        raise BackendError("Authencitation with AS failed. Reason: %s" % lines[0])
 
     elif lines[0] == 'OK':
         # wooooooohooooooo. We made it!
@@ -157,8 +161,9 @@ def handle_hard_error():
         SESSION_ID = None
 
 
-def now_playing(artist, track, album="", length="", trackno="", mbid="",
-                inner_call=False):
+def now_playing(
+    artist, track, album="", length="", trackno="", mbid="", inner_call=False
+):
     """Tells audioscrobbler what is currently running in your player. This won't
     affect the user-profile on last.fm. To do submissions, use the "submit"
     method
@@ -192,13 +197,15 @@ def now_playing(artist, track, album="", length="", trackno="", mbid="",
     artist = artist or ''
     album = album or ''
 
-    values = {'s': SESSION_ID,
-              'a': unicode(artist).encode('utf-8'),
-              't': unicode(track).encode('utf-8'),
-              'b': unicode(album).encode('utf-8'),
-              'l': length,
-              'n': trackno,
-              'm': mbid}
+    values = {
+        's': SESSION_ID,
+        'a': unicode(artist).encode('utf-8'),
+        't': unicode(track).encode('utf-8'),
+        'b': unicode(album).encode('utf-8'),
+        'l': length,
+        'n': trackno,
+        'm': mbid,
+    }
 
     data = urllib.urlencode(values)
 
@@ -221,8 +228,18 @@ def now_playing(artist, track, album="", length="", trackno="", mbid="",
     return False
 
 
-def submit(artist, track, time=0, source='P', rating="", length="", album="",
-           trackno="", mbid="", autoflush=False):
+def submit(
+    artist,
+    track,
+    time=0,
+    source='P',
+    rating="",
+    length="",
+    album="",
+    trackno="",
+    mbid="",
+    autoflush=False,
+):
     """Append a song to the submission cache. Use 'flush()' to send the cache to
     AS. You can also set "autoflush" to True.
 
@@ -286,30 +303,38 @@ def submit(artist, track, time=0, source='P', rating="", length="", album="",
     rating = rating.upper()
 
     if source == 'L' and (rating == 'B' or rating == 'S'):
-        raise ProtocolError("""You can only use rating 'B' or 'S' on source 'L'.
-    See the docs!""")
+        raise ProtocolError(
+            """You can only use rating 'B' or 'S' on source 'L'.
+    See the docs!"""
+        )
 
     if source == 'P' and length == '':
-        raise ProtocolError("""Song length must be specified when using 'P' as
-    source!""")
+        raise ProtocolError(
+            """Song length must be specified when using 'P' as
+    source!"""
+        )
 
     if not isinstance(time, type(1)):
-        raise ValueError("""The time parameter must be of type int (unix
-    timestamp). Instead it was %s""" % time)
+        raise ValueError(
+            """The time parameter must be of type int (unix
+    timestamp). Instead it was %s"""
+            % time
+        )
 
     album = album or ''
 
     SUBMIT_CACHE.append(
-        {'a': unicode(artist).encode('utf-8'),
-         't': unicode(track).encode('utf-8'),
-         'i': time,
-         'o': source,
-         'r': rating,
-         'l': length,
-         'b': unicode(album).encode('utf-8'),
-         'n': trackno,
-         'm': mbid
-         }
+        {
+            'a': unicode(artist).encode('utf-8'),
+            't': unicode(track).encode('utf-8'),
+            'i': time,
+            'o': source,
+            'r': rating,
+            'l': length,
+            'b': unicode(album).encode('utf-8'),
+            'n': trackno,
+            'm': mbid,
+        }
     )
 
     if autoflush or len(SUBMIT_CACHE) >= MAX_CACHE:
@@ -325,8 +350,10 @@ def flush(inner_call=False):
     global SUBMIT_CACHE, __LOGIN, MAX_SUBMIT, POST_URL, INITIAL_URL
 
     if POST_URL is None:
-        raise ProtocolError('''Cannot submit without having a valid post-URL. Did
-you login?''')
+        raise ProtocolError(
+            '''Cannot submit without having a valid post-URL. Did
+you login?'''
+        )
 
     values = {}
 
@@ -354,34 +381,28 @@ you login?''')
             raise Warning("Infinite loop prevented")
     elif lines[0].startswith('FAILED'):
         handle_hard_error()
-        raise BackendError("Submission to AS failed. Reason: %s" %
-                           lines[0])
+        raise BackendError("Submission to AS failed. Reason: %s" % lines[0])
     else:
         # some hard error
         handle_hard_error()
         return False
 
+
 if __name__ == "__main__":
     login('user', 'password')
-    submit(
-        'De/Vision',
-        'Scars',
-        1192374052,
-        source='P',
-        length=3 * 60 + 44
-    )
+    submit('De/Vision', 'Scars', 1192374052, source='P', length=3 * 60 + 44)
     submit(
         'Spineshank',
         'Beginning of the End',
         1192374052 + (5 * 60),
         source='P',
-        length=3 * 60 + 32
+        length=3 * 60 + 32,
     )
     submit(
         'Dry Cell',
         'Body Crumbles',
         1192374052 + (10 * 60),
         source='P',
-        length=3 * 60 + 3
+        length=3 * 60 + 3,
     )
     print(flush())

--- a/plugins/audioscrobbler/asprefs.py
+++ b/plugins/audioscrobbler/asprefs.py
@@ -20,10 +20,7 @@ from gi.repository import Gtk
 import os.path
 import _scrobbler
 
-from xl import (
-    common,
-    settings,
-)
+from xl import common, settings
 from xl.nls import gettext as _
 from xlgui import icons
 from xlgui.preferences import widgets
@@ -33,8 +30,9 @@ name = _('AudioScrobbler')
 basedir = os.path.dirname(os.path.realpath(__file__))
 ui = os.path.join(basedir, "asprefs_pane.ui")
 
-icons.MANAGER.add_icon_name_from_directory('audioscrobbler',
-                                           os.path.join(basedir, 'icons'))
+icons.MANAGER.add_icon_name_from_directory(
+    'audioscrobbler', os.path.join(basedir, 'icons')
+)
 icon = 'audioscrobbler'
 
 
@@ -66,7 +64,7 @@ class UrlPreference(widgets.ComboEntryPreference):
     default = 'http://post.audioscrobbler.com/'
     preset_items = {
         'http://post.audioscrobbler.com/': 'Last.fm',
-        'http://turtle.libre.fm/': 'Libre.fm'
+        'http://turtle.libre.fm/': 'Libre.fm',
     }
 
 
@@ -81,7 +79,7 @@ class VerifyLoginButton(widgets.Button):
 
         self.message = dialogs.MessageBar(
             parent=preferences.builder.get_object('preferences_box'),
-            buttons=Gtk.ButtonsType.CLOSE
+            buttons=Gtk.ButtonsType.CLOSE,
         )
 
     @common.threaded
@@ -92,8 +90,9 @@ class VerifyLoginButton(widgets.Button):
         """
         username = settings.get_option('plugin/ascrobbler/user', '')
         password = settings.get_option('plugin/ascrobbler/password', '')
-        url = settings.get_option('plugin/ascrobbler/url',
-                                  'http://post.audioscrobbler.com/')
+        url = settings.get_option(
+            'plugin/ascrobbler/url', 'http://post.audioscrobbler.com/'
+        )
         login_verified = False
 
         try:
@@ -109,16 +108,12 @@ class VerifyLoginButton(widgets.Button):
             login_verified = True
 
         if login_verified:
-            GLib.idle_add(
-                self.message.show_info,
-                _('Verification successful'),
-                ''
-            )
+            GLib.idle_add(self.message.show_info, _('Verification successful'), '')
         else:
             GLib.idle_add(
                 self.message.show_error,
                 _('Verification failed'),
-                _('Please make sure the entered data is correct.')
+                _('Please make sure the entered data is correct.'),
             )
 
         GLib.idle_add(self.widget.set_sensitive, True)

--- a/plugins/awn/__init__.py
+++ b/plugins/awn/__init__.py
@@ -33,19 +33,17 @@ log = logging.getLogger(__name__)
 
 
 class InvalidOverlayOption(Exception):
-
     def __init__(self, option):
         self.option = option
 
     def __str__(self):
         return 'Got %s, must be one of %s' % (
             repr(self.option),
-            str(awn_prefs.OverlayDisplay.map)
+            str(awn_prefs.OverlayDisplay.map),
         )
 
 
 class ExaileAwn(object):
-
     def __init__(self):
         bus = dbus.SessionBus()
         obj = bus.get_object("com.google.code.Awn", "/com/google/code/Awn")
@@ -115,8 +113,9 @@ class ExaileAwn(object):
         elif not self.cover_display:
             self.unset_cover()
         else:
-            image_data = covers.MANAGER.get_cover(player.PLAYER.current,
-                                                  set_only=True, use_default=True)
+            image_data = covers.MANAGER.get_cover(
+                player.PLAYER.current, set_only=True, use_default=True
+            )
             pixbuf = pixbuf_from_data(image_data)
             descriptor, self.temp_icon_path = tempfile.mkstemp()
             pixbuf.save(self.temp_icon_path, 'png')
@@ -181,12 +180,15 @@ def enable(exaile):
     EXAILE_AWN.exaile = exaile
     for signal in TRACK_CHANGE_CALLBACKS:
         xl.event.add_callback(EXAILE_AWN.set_cover, signal, player.PLAYER)
-    xl.event.add_callback(EXAILE_AWN.enable_progress,
-                          'playback_player_start', player.PLAYER)
-    xl.event.add_callback(EXAILE_AWN.disable_progress,
-                          'playback_player_end', player.PLAYER)
-    xl.event.add_callback(EXAILE_AWN.toggle_pause_progress,
-                          'playback_toggle_pause', player.PLAYER)
+    xl.event.add_callback(
+        EXAILE_AWN.enable_progress, 'playback_player_start', player.PLAYER
+    )
+    xl.event.add_callback(
+        EXAILE_AWN.disable_progress, 'playback_player_end', player.PLAYER
+    )
+    xl.event.add_callback(
+        EXAILE_AWN.toggle_pause_progress, 'playback_toggle_pause', player.PLAYER
+    )
     xl.event.add_callback(EXAILE_AWN.on_option_set, 'plugin_awn_option_set')
     EXAILE_AWN.set_cover()
 
@@ -195,12 +197,15 @@ def disable(exaile):
     global EXAILE_AWN
     for signal in TRACK_CHANGE_CALLBACKS:
         xl.event.remove_callback(EXAILE_AWN.set_cover, signal)
-    xl.event.remove_callback(EXAILE_AWN.enable_progress,
-                             'playback_player_start', player.PLAYER)
-    xl.event.remove_callback(EXAILE_AWN.disable_progress,
-                             'playback_player_end', player.PLAYER)
-    xl.event.remove_callback(EXAILE_AWN.toggle_pause_progress,
-                             'playback_toggle_pause', player.PLAYER)
+    xl.event.remove_callback(
+        EXAILE_AWN.enable_progress, 'playback_player_start', player.PLAYER
+    )
+    xl.event.remove_callback(
+        EXAILE_AWN.disable_progress, 'playback_player_end', player.PLAYER
+    )
+    xl.event.remove_callback(
+        EXAILE_AWN.toggle_pause_progress, 'playback_toggle_pause', player.PLAYER
+    )
     EXAILE_AWN.unset_cover()
     EXAILE_AWN.unset_timer()
     EXAILE_AWN.exaile = None

--- a/plugins/bookmarks/__init__.py
+++ b/plugins/bookmarks/__init__.py
@@ -26,13 +26,7 @@ import threading
 from gi.repository import GLib
 from gi.repository import Gtk
 
-from xl import (
-    covers,
-    player,
-    trax,
-    xdg,
-    providers
-)
+from xl import covers, player, trax, xdg, providers
 from xl import common
 from xl.nls import gettext as _
 import xlgui
@@ -54,8 +48,9 @@ class Bookmark:
 
     __counter = 0
 
-    def __init__(self, bookmarks_menu, delete_menu,
-                 delete_bookmark_callback, path, time):
+    def __init__(
+        self, bookmarks_menu, delete_menu, delete_bookmark_callback, path, time
+    ):
         """
             Creates a bookmark for current track/position if path or time are
             None. Creates a bookmark for the given track/positon otherwise.
@@ -78,8 +73,7 @@ class Bookmark:
         self.item = None
 
         self.__fetch_metadata()
-        self.__create_menu_item(bookmarks_menu, delete_menu,
-                                delete_bookmark_callback)
+        self.__create_menu_item(bookmarks_menu, delete_menu, delete_bookmark_callback)
 
     def get_menu_item(self):
         return self.item
@@ -98,8 +92,7 @@ class Bookmark:
                 image = covers.MANAGER.get_cover(item, set_only=True)
                 if image:
                     try:
-                        self.__cover_pixbuf = pixbuf_from_data(image,
-                                                               size=(16, 16))
+                        self.__cover_pixbuf = pixbuf_from_data(image, size=(16, 16))
                     except GLib.GError:
                         LOGGER.warning('Could not load cover')
             else:
@@ -108,8 +101,7 @@ class Bookmark:
             LOGGER.exception("Cannot open %s", self.__path)
             return
 
-    def __create_menu_item(self, bookmarks_menu, delete_menu,
-                           delete_bookmark_callback):
+    def __create_menu_item(self, bookmarks_menu, delete_menu, delete_bookmark_callback):
         """
             Create menu entries for this bookmark.
         """
@@ -120,8 +112,7 @@ class Bookmark:
             "menu factory for new bookmarks"
             menu_item = Gtk.ImageMenuItem.new_with_mnemonic(label)
             if self.__cover_pixbuf:
-                menu_item.set_image(
-                    Gtk.Image.new_from_pixbuf(self.__cover_pixbuf))
+                menu_item.set_image(Gtk.Image.new_from_pixbuf(self.__cover_pixbuf))
 
             if menu_ is bookmarks_menu:
                 menu_item.connect('activate', self.__on_bookmark_activated)
@@ -197,8 +188,7 @@ class BookmarksManager:
 
             def factory(_menu, _parent, _context):
                 item = Gtk.ImageMenuItem.new_with_mnemonic(display_name)
-                image = Gtk.Image.new_from_icon_name(icon_name,
-                                                     size=Gtk.IconSize.MENU)
+                image = Gtk.Image.new_from_icon_name(icon_name, size=Gtk.IconSize.MENU)
                 item.set_image(image)
 
                 if callback is not None:
@@ -213,13 +203,22 @@ class BookmarksManager:
             return factory
 
         items = []
-        items.append(_smi('bookmark', [], _('_Bookmark This Track'),
-                          'bookmark-new', self.__on_add_bookmark))
-        delete_cb = factory_factory(_('_Delete Bookmark'), 'gtk-close',
-                                    submenu=self.delete_menu)
+        items.append(
+            _smi(
+                'bookmark',
+                [],
+                _('_Bookmark This Track'),
+                'bookmark-new',
+                self.__on_add_bookmark,
+            )
+        )
+        delete_cb = factory_factory(
+            _('_Delete Bookmark'), 'gtk-close', submenu=self.delete_menu
+        )
         items.append(menu.MenuItem('delete', delete_cb, ['bookmark']))
-        clear_cb = factory_factory(_('_Clear Bookmarks'), 'gtk-clear',
-                                   callback=self.__clear_bookmarks)
+        clear_cb = factory_factory(
+            _('_Clear Bookmarks'), 'gtk-clear', callback=self.__clear_bookmarks
+        )
         items.append(menu.MenuItem('clear', clear_cb, ['delete']))
         items.append(_sep('sep', ['clear']))
 
@@ -232,8 +231,9 @@ class BookmarksManager:
     def __add_bookmark(self, path=None, time=None, save_db=True):
         if not self.menu:
             return  # this plugin is shutting down
-        bookmark = Bookmark(self.menu, self.delete_menu,
-                            self.__delete_bookmark, path, time)
+        bookmark = Bookmark(
+            self.menu, self.delete_menu, self.__delete_bookmark, path, time
+        )
         self.__bookmarks.append(bookmark)
         if save_db:
             self.__save_db()
@@ -297,13 +297,13 @@ class BookmarksManager:
     def __do_save_db(self, bookmarks):
         with self.__db_file_lock:
             with open(self.__PATH, 'wb') as bm_file:
-                json.dump(bookmarks, bm_file, indent=2,
-                          default=Bookmark.serialize_bookmark)
+                json.dump(
+                    bookmarks, bm_file, indent=2, default=Bookmark.serialize_bookmark
+                )
             LOGGER.debug('saved %d bookmarks', len(bookmarks))
 
 
 class BookmarksPlugin(object):
-
     def __init__(self):
         self.__manager = None
 
@@ -319,9 +319,16 @@ class BookmarksPlugin(object):
         self.__manager = BookmarksManager()
 
         # add tools menu items
-        providers.register('menubar-tools-menu', _sep('plugin-sep', ['track-properties']))
-        item = _smi('bookmarks', ['plugin-sep'], _('_Bookmarks'),
-                    'user-bookmarks', submenu=self.__manager.menu)
+        providers.register(
+            'menubar-tools-menu', _sep('plugin-sep', ['track-properties'])
+        )
+        item = _smi(
+            'bookmarks',
+            ['plugin-sep'],
+            _('_Bookmarks'),
+            'user-bookmarks',
+            submenu=self.__manager.menu,
+        )
         providers.register('menubar-tools-menu', item)
 
     def disable(self, _exaile):

--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -43,6 +43,7 @@ import cdprefs
 try:
     import DiscID
     import CDDB
+
     CDDB_AVAIL = True
 except Exception:
     CDDB_AVAIL = False
@@ -61,7 +62,6 @@ CDROM_DATA_TRACK = 0x04
 
 
 class CdPlugin(object):
-
     def enable(self, exaile):
         self.exaile = exaile
         self.hal = None
@@ -94,6 +94,7 @@ class CdPlugin(object):
 
     def get_preferences_pane(self):
         return cdprefs
+
 
 plugin_class = CdPlugin
 
@@ -151,7 +152,6 @@ class CDTocParser(object):
 
 
 class CDPlaylist(playlist.Playlist):
-
     def __init__(self, name=_("Audio Disc"), device=None):
         playlist.Playlist.__init__(self, name=name)
 
@@ -172,14 +172,15 @@ class CDPlaylist(playlist.Playlist):
         for count, length in enumerate(lengths):
             count += 1
             song = trax.Track("cdda://%d/#%s" % (count, self.device))
-            song.set_tags(title="Track %d" % count,
-                          tracknumber=str(count),
-                          __length=length)
+            song.set_tags(
+                title="Track %d" % count, tracknumber=str(count), __length=length
+            )
             songs[song.get_loc_for_io()] = song
 
         # FIXME: this can probably be cleaner
-        sort_tups = sorted([(int(s.get_tag_raw('tracknumber')[0]), s)
-                            for s in songs.values()])
+        sort_tups = sorted(
+            [(int(s.get_tag_raw('tracknumber')[0]), s) for s in songs.values()]
+        )
         sorted_elements = [s[1] for s in sort_tups]
 
         self.extend(sorted_elements)
@@ -207,11 +208,13 @@ class CDPlaylist(playlist.Playlist):
         title = info['DTITLE'].split(" / ")
         for i in range(self.info[1]):
             tr = self[i]
-            tr.set_tags(title=info['TTITLE' + str(i)].decode('iso-8859-15', 'replace'),
-                        album=title[1].decode('iso-8859-15', 'replace'),
-                        artist=title[0].decode('iso-8859-15', 'replace'),
-                        year=info['EXTD'].replace("YEAR: ", ""),
-                        genre=info['DGENRE'])
+            tr.set_tags(
+                title=info['TTITLE' + str(i)].decode('iso-8859-15', 'replace'),
+                album=title[1].decode('iso-8859-15', 'replace'),
+                artist=title[0].decode('iso-8859-15', 'replace'),
+                year=info['EXTD'].replace("YEAR: ", ""),
+                genre=info['DGENRE'],
+            )
 
         self.name = title[1].decode('iso-8859-15', 'replace')
         event.log_event('cddb_info_retrieved', self, True)
@@ -221,6 +224,7 @@ class CDDevice(KeyedDevice):
     """
         represents a CD
     """
+
     class_autoconnect = True
 
     def __init__(self, dev):
@@ -230,9 +234,11 @@ class CDDevice(KeyedDevice):
 
     def _get_panel_type(self):
         import imp
+
         try:
-            _cdguipanel = imp.load_source("_cdguipanel",
-                                          os.path.join(os.path.dirname(__file__), "_cdguipanel.py"))
+            _cdguipanel = imp.load_source(
+                "_cdguipanel", os.path.join(os.path.dirname(__file__), "_cdguipanel.py")
+            )
             return _cdguipanel.CDPanel
         except Exception:
             logger.exception("Could not import cd gui panel")
@@ -326,5 +332,6 @@ class UDisks2CdProvider(UDisksProvider):
     def on_device_changed(self, obj, udisks, device):
         if self._get_num_tracks(obj, udisks) is None:
             return 'remove'
+
 
 # vim: et sts=4 sw=4

--- a/plugins/cd/_cdguipanel.py
+++ b/plugins/cd/_cdguipanel.py
@@ -40,7 +40,6 @@ logger = logging.getLogger(__name__)
 
 
 class CDImportThread(common.ProgressThread):
-
     def __init__(self, cd_importer):
         common.ProgressThread.__init__(self)
 
@@ -75,7 +74,6 @@ class CDImportThread(common.ProgressThread):
 
 
 class CDPanel(device.FlatPlaylistDevicePanel):
-
     def __init__(self, *args):
         device.FlatPlaylistDevicePanel.__init__(self, *args)
         self.__importing = False
@@ -97,22 +95,24 @@ class CDPanel(device.FlatPlaylistDevicePanel):
         cd_importer = CDImporter(tracks)
         thread = CDImportThread(cd_importer)
         thread.connect('done', lambda *e: self._import_finish())
-        self.main.controller.progress_manager.add_monitor(thread,
-                                                          _("Importing CD..."), 'drive-optical')
+        self.main.controller.progress_manager.add_monitor(
+            thread, _("Importing CD..."), 'drive-optical'
+        )
 
     def _import_finish(self):
         self.__importing = False
 
 
 class CDImporter(object):
-
     def __init__(self, tracks):
-        self.tracks = [t for t in tracks if
-                       t.get_loc_for_io().startswith("cdda")]
+        self.tracks = [t for t in tracks if t.get_loc_for_io().startswith("cdda")]
         self.duration = float(sum(t.get_tag_raw('__length') for t in self.tracks))
-        self.formatter = formatter.TrackFormatter(settings.get_option(
-            "cd_import/outpath",
-            "%s/$artist/$album/$tracknumber - $title" % os.getenv("HOME")))
+        self.formatter = formatter.TrackFormatter(
+            settings.get_option(
+                "cd_import/outpath",
+                "%s/$artist/$album/$tracknumber - $title" % os.getenv("HOME"),
+            )
+        )
         self.current = None
         self.current_len = None
         self.progress = 0.0
@@ -129,7 +129,8 @@ class CDImporter(object):
         default_quality = formats[default_format]['default']
         self.quality = settings.get_option("cd_import/quality", default_quality)
         self.transcoder = transcoder.Transcoder(
-            self.format, self.quality, self._error_cb, self._end_cb)
+            self.format, self.quality, self._error_cb, self._end_cb
+        )
 
     def do_import(self):
         self.running = True
@@ -155,7 +156,9 @@ class CDImporter(object):
             if not self.running:
                 break
             tr2 = trax.Track("file://" + outloc)
-            ntags = {t: tr.get_tag_raw(t) for t in tr.list_tags() if not t.startswith("__")}
+            ntags = {
+                t: tr.get_tag_raw(t) for t in tr.list_tags() if not t.startswith("__")
+            }
             tr2.set_tags(**ntags)
             tr2.write_tags()
             try:
@@ -167,14 +170,13 @@ class CDImporter(object):
 
     def _end_cb(self):
         self.cont.set()
-        xlgui.main.mainwindow().message.show_info(
-            "Finished transcoding files")
+        xlgui.main.mainwindow().message.show_info("Finished transcoding files")
 
     def _error_cb(self, gerror, message_string):
         self.running = False
         xlgui.main.mainwindow().message.show_error(
-            _("Error transcoding files from CD."),
-            "%s" % gerror.message.encode())
+            _("Error transcoding files from CD."), "%s" % gerror.message.encode()
+        )
 
     def get_output_location(self, track):
         path = self.formatter.format(track)

--- a/plugins/cd/cdprefs.py
+++ b/plugins/cd/cdprefs.py
@@ -76,7 +76,8 @@ class OutputQualityPreference(widgets.ComboPreference, widgets.Conditional):
                 self.default = default  # raw value
 
         default_title = formatinfo['kbs_steps'][
-            formatinfo['raw_steps'].index(self.default)]
+            formatinfo['raw_steps'].index(self.default)
+        ]
         active_iter = self.widget.get_active_iter()
 
         if active_iter is not None:
@@ -123,9 +124,8 @@ class OutputPathPreference(widgets.ComboEntryPreference):
         '$__last_played': _('Last played'),
         '$bpm': _('BPM'),
     }
-    preset_items = [
-        "%s/$artist/$album/$tracknumber - $title" % os.getenv("HOME")
-    ]
+    preset_items = ["%s/$artist/$album/$tracknumber - $title" % os.getenv("HOME")]
     default = "%s/$artist/$album/$tracknumber - $title" % os.getenv("HOME")
+
 
 # vim: et sts=4 sw=4

--- a/plugins/console/__init__.py
+++ b/plugins/console/__init__.py
@@ -29,18 +29,22 @@ import traceback
 from cStringIO import StringIO
 
 
-class PyConsole():
-
+class PyConsole:
     def __init__(self, dict, exaile):
         self.dict = dict
         self.buffer = StringIO()
 
         ui = Gtk.Builder()
-        ui.add_from_file(os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'console_window.ui'))
+        ui.add_from_file(
+            os.path.join(
+                os.path.dirname(os.path.realpath(__file__)), 'console_window.ui'
+            )
+        )
 
         self.window = ui.get_object('simple_console_window')
-        self.close_handler = self.window.connect('delete-event', console_destroyed, exaile)
+        self.close_handler = self.window.connect(
+            'delete-event', console_destroyed, exaile
+        )
 
         self.text_view = tv = ui.get_object('console_output')
 
@@ -84,12 +88,14 @@ class PyConsole():
         self.text_view.scroll_to_mark(self.end_mark, 0, False, 0.5, 0.5)
         self.entry.grab_focus()
 
+
 PLUGIN = None
 
 
 def enable(exaile):
     if exaile.loading:
         from xl import event
+
         event.add_callback(_enable, 'gui_loaded')
     else:
         _enable(None, exaile, None)
@@ -115,5 +121,6 @@ def disable(exaile):
         PLUGIN.window.disconnect(PLUGIN.close_handler)
         PLUGIN.window.destroy()
         PLUGIN = None
+
 
 # vi: et sts=4 sw=4 ts=4

--- a/plugins/currentsong/__init__.py
+++ b/plugins/currentsong/__init__.py
@@ -23,7 +23,6 @@ from xl import event, player
 
 
 class Pidgin:
-
     def __init__(self, dbusInterface):
         """
             Constructor
@@ -74,6 +73,7 @@ class Pidgin:
 
         return True
 
+
 ##############################################################################
 
 
@@ -81,7 +81,7 @@ def on_begin_action(type, player, track):
     client.setTune(
         track.get_tag_display('artist'),
         track.get_tag_display('title'),
-        track.get_tag_display('album')
+        track.get_tag_display('album'),
     )
 
 
@@ -98,8 +98,9 @@ def on_pause_action(type, player, track):
 
 def enable(exaile):
     global client
-    obj = dbus.SessionBus().get_object('im.pidgin.purple.PurpleService',
-                                       '/im/pidgin/purple/PurpleObject')
+    obj = dbus.SessionBus().get_object(
+        'im.pidgin.purple.PurpleService', '/im/pidgin/purple/PurpleObject'
+    )
     purple = dbus.Interface(obj, "im.pidgin.purple.PurpleInterface")
     client = Pidgin(purple)
     event.add_callback(on_stop_action, 'quit_application')

--- a/plugins/daapclient/test.py
+++ b/plugins/daapclient/test.py
@@ -20,8 +20,9 @@ def main():
     else:
         port = 3689
 
-    logging.basicConfig(level=logging.DEBUG,
-                        format='%(asctime)s %(levelname)s %(message)s')
+    logging.basicConfig(
+        level=logging.DEBUG, format='%(asctime)s %(levelname)s %(message)s'
+    )
 
     try:
         # do everything in a big try, so we can disconnect at the end
@@ -36,7 +37,7 @@ def main():
         tracks = library.tracks()
 
         # demo - save the first track to disk
-        #print("Saving %s by %s to disk as 'track.mp3'"%(tracks[0].name, tracks[0].artist))
+        # print("Saving %s by %s to disk as 'track.mp3'"%(tracks[0].name, tracks[0].artist))
         # tracks[0].save("track.mp3")
         if len(tracks) > 0:
             tracks[0].atom.printTree()

--- a/plugins/daapserver/__init__.py
+++ b/plugins/daapserver/__init__.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__file__)
 # todo support multiple connections?
 class CollectionWrapper:
     '''Class to wrap Exaile's collection to make it spydaap compatible'''
+
     class TrackWrapper:
         '''Wrap a single track for spydaap'''
 
@@ -65,9 +66,10 @@ class DaapServerPlugin(object):
         name = settings.get_option('plugin/daapserver/name', 'Exaile Share')
         host = settings.get_option('plugin/daapserver/host', '0.0.0.0')
 
-        self.__daapserver = DaapServer(CollectionWrapper(self.__exaile.collection),
-                                       port=port, name=name, host=host)
-        if(settings.get_option('plugin/daapserver/enabled', True)):
+        self.__daapserver = DaapServer(
+            CollectionWrapper(self.__exaile.collection), port=port, name=name, host=host
+        )
+        if settings.get_option('plugin/daapserver/enabled', True):
             self.__daapserver.start()
 
     def enable(self, exaile):

--- a/plugins/daapserver/config.py
+++ b/plugins/daapserver/config.py
@@ -3,22 +3,28 @@ import spydaap.parser.mp3
 import spydaap.parser.ogg
 import spydaap.parser.flac
 
-spydaap.parsers = [spydaap.parser.mp3.Mp3Parser(),
-                   spydaap.parser.flac.FlacParser(),
-                   spydaap.parser.ogg.OggParser()]
+spydaap.parsers = [
+    spydaap.parser.mp3.Mp3Parser(),
+    spydaap.parser.flac.FlacParser(),
+    spydaap.parser.ogg.OggParser(),
+]
 
 # to process .mov files
-#from spydaap.parser import mp3,mov
+# from spydaap.parser import mp3,mov
 
-#spydaap.server_name = "spydaap"
-#spydaap.port = 3689
+# spydaap.server_name = "spydaap"
+# spydaap.port = 3689
 
 # top path to scan for media
-#spydaap.media_path = "media"
+# spydaap.media_path = "media"
 
-#spydaap.cache_dir = 'cache'
+# spydaap.cache_dir = 'cache'
 
-spydaap.container_list.append(spydaap.playlists.Genre('reggae', ["reggae", "reggae: dub", "dub"]))
-spydaap.container_list.append(spydaap.playlists.Recent('last 30 days', (60 * 60 * 24 * 30)))
+spydaap.container_list.append(
+    spydaap.playlists.Genre('reggae', ["reggae", "reggae: dub", "dub"])
+)
+spydaap.container_list.append(
+    spydaap.playlists.Recent('last 30 days', (60 * 60 * 24 * 30))
+)
 spydaap.container_list.append(spydaap.playlists.YearRange('1970s', 1970, 1979))
 spydaap.container_list.append(spydaap.playlists.Rating('top rated', 100))

--- a/plugins/daapserver/exaile_parser.py
+++ b/plugins/daapserver/exaile_parser.py
@@ -27,7 +27,7 @@ class ExaileParser(spydaap.parser.Parser):
         'artist': 'daap.songartist',
         'composer': 'daap.songcomposer',
         'genre': 'daap.songgenre',
-        'album': 'daap.songalbum'
+        'album': 'daap.songalbum',
     }
 
     _int_map = {
@@ -37,11 +37,12 @@ class ExaileParser(spydaap.parser.Parser):
         'year': 'daap.songyear',
         'tracknumber': 'daap.songtracknumber',
         'tracktotal': 'daap.songtrackcount',
-        'discnumber': 'daap.songdiscnumber'
+        'discnumber': 'daap.songdiscnumber',
     }
 
     def understands(self, filename):
         return True
+
     #   return self.file_re.match(filename)
 
     # returns a list in exaile
@@ -52,15 +53,16 @@ class ExaileParser(spydaap.parser.Parser):
                     tn = str(md.get_tag_raw(k)[0])
                     if '/' in tn:
                         num, tot = tn.split('/')
-                        if num == '':           # empty tags
+                        if num == '':  # empty tags
                             num = 0
                         daap.append(do(map[k], int(num)))
                         # set total?
                     else:
                         daap.append(do(map[k], int(tn)))
                 except Exception:
-                    logger.exception('exception caught parsing tag: %s=%s from %s',
-                                     k, tn, md)
+                    logger.exception(
+                        'exception caught parsing tag: %s=%s from %s', k, tn, md
+                    )
 
     # We can't use functions in __init__ because exaile tracks no longer
     # give us access to .tags
@@ -76,7 +78,7 @@ class ExaileParser(spydaap.parser.Parser):
 
     def parse(self, trk):
         try:
-            #trk = mutagen.File(filename)
+            # trk = mutagen.File(filename)
             d = []
             if len(trk.list_tags()) > 0:
                 if 'title' in trk.list_tags():
@@ -86,24 +88,28 @@ class ExaileParser(spydaap.parser.Parser):
 
                 self.handle_string_tags(self._string_map, trk, d)
                 self.handle_int_tags(self._int_map, trk, d)
-#                self.handle_rating(trk, d)
+            #                self.handle_rating(trk, d)
             else:
                 name = str(trk)
-            #statinfo = os.stat(filename)
+            # statinfo = os.stat(filename)
 
             _len = trk.get_tag_raw('__length')
-            if _len is None:    # don't parse songs that don't have length
+            if _len is None:  # don't parse songs that don't have length
                 return (None, None)
 
-            d.extend([  # do('daap.songsize', trk.get_size()),
-                #do('daap.songdateadded', statinfo.st_ctime),
-                #do('daap.songdatemodified', statinfo.st_ctime),
-                do('daap.songtime', _len * 1000),
-                #                      do('daap.songbitrate', trk.get_tag_raw('__bitrate') / 1000),
-                #                      do('daap.songsamplerate', ogg.info.sample_rate), # todo ??
-                do('daap.songformat', trk.get_local_path().split('.')[-1]),  # todo ??
-                do('daap.songdescription', 'Exaile Streaming Audio'),
-            ])
+            d.extend(
+                [  # do('daap.songsize', trk.get_size()),
+                    # do('daap.songdateadded', statinfo.st_ctime),
+                    # do('daap.songdatemodified', statinfo.st_ctime),
+                    do('daap.songtime', _len * 1000),
+                    #                      do('daap.songbitrate', trk.get_tag_raw('__bitrate') / 1000),
+                    #                      do('daap.songsamplerate', ogg.info.sample_rate), # todo ??
+                    do(
+                        'daap.songformat', trk.get_local_path().split('.')[-1]
+                    ),  # todo ??
+                    do('daap.songdescription', 'Exaile Streaming Audio'),
+                ]
+            )
             return (d, name)
 
         except Exception:

--- a/plugins/daapserver/server.py
+++ b/plugins/daapserver/server.py
@@ -72,6 +72,7 @@ __all__ = ['DaapServer']
 
 class MyThreadedHTTPServer(SocketServer.ThreadingMixIn, BaseHTTPServer.HTTPServer):
     """Handle requests in a separate thread."""
+
     timeout = 1
     daemon_threads = True
 
@@ -81,8 +82,7 @@ class MyThreadedHTTPServer(SocketServer.ThreadingMixIn, BaseHTTPServer.HTTPServe
         BaseHTTPServer.HTTPServer.__init__(self, *args)
 
 
-class DaapServer():
-
+class DaapServer:
     def __init__(self, library, name=spydaap.server_name, host='', port=spydaap.port):
         #        Thread.__init__(self)
         self.host = host
@@ -95,16 +95,17 @@ class DaapServer():
         self.__cache.clean()
 
         # Set a callback that will let us propagate library changes to clients
-        event.add_callback(self.update_rev, 'libraries_modified',
-                           library.collection)
+        event.add_callback(self.update_rev, 'libraries_modified', library.collection)
 
     def update_rev(self, *args):
         if self.handler is not None:
             # Updating the server revision, so if a client checks
             # it can see the library has changed
             self.handler.daap_server_revision += 1
-            logger.info('Libraries Changed, incrementing revision to %d.'
-                        % self.handler.daap_server_revision)
+            logger.info(
+                'Libraries Changed, incrementing revision to %d.'
+                % self.handler.daap_server_revision
+            )
         self.__cache.clean()
 
     def set(self, **kwargs):
@@ -113,16 +114,16 @@ class DaapServer():
 
     @common.threaded
     def run(self):
-        self.zeroconf = spydaap.zeroconf.Zeroconf(self.name,
-                                                  self.port,
-                                                  stype="_daap._tcp")
+        self.zeroconf = spydaap.zeroconf.Zeroconf(
+            self.name, self.port, stype="_daap._tcp"
+        )
         self.handler = spydaap.server.makeDAAPHandlerClass(
-            str(self.name), self.__cache, self.library, [])
-        self.httpd = MyThreadedHTTPServer((self.host, self.port),
-                                          self.handler)
+            str(self.name), self.__cache, self.library, []
+        )
+        self.httpd = MyThreadedHTTPServer((self.host, self.port), self.handler)
 
-        #signal.signal(signal.SIGTERM, make_shutdown(httpd))
-        #signal.signal(signal.SIGHUP, rebuild_cache)
+        # signal.signal(signal.SIGTERM, make_shutdown(httpd))
+        # signal.signal(signal.SIGHUP, rebuild_cache)
         if self.httpd.address_family == socket.AF_INET:
             self.zeroconf.publish(ipv4=True, ipv6=False)
         else:
@@ -156,6 +157,7 @@ class DaapServer():
 
     def stop_server(self):
         self.stop()
+
 
 # def rebuild_cache(signum=None, frame=None):
 #    md_cache.build(os.path.abspath(spydaap.media_path))

--- a/plugins/daapserver/spydaap/daap.py
+++ b/plugins/daapserver/spydaap/daap.py
@@ -24,7 +24,9 @@ def DAAPParseCodeTypes(treeroot):
     # the treeroot we are given should be a
     # dmap.contentcodesresponse
     if treeroot.codeName() != 'dmap.contentcodesresponse':
-        raise DAAPError("DAAPParseCodeTypes: We cannot generate a dictionary from this tree.")
+        raise DAAPError(
+            "DAAPParseCodeTypes: We cannot generate a dictionary from this tree."
+        )
         return
     for object in treeroot.contains:
         # each item should be one of two things
@@ -48,10 +50,17 @@ def DAAPParseCodeTypes(treeroot):
                     try:
                         dtype = dmapDataTypes[info.value]
                     except KeyError:
-                        log.debug('DAAPParseCodeTypes: unknown data type %s for code %s, defaulting to s', info.value, name)
+                        log.debug(
+                            'DAAPParseCodeTypes: unknown data type %s for code %s, defaulting to s',
+                            info.value,
+                            name,
+                        )
                         dtype = 's'
                 else:
-                    raise DAAPError('DAAPParseCodeTypes: unexpected code %s at level 2' % info.codeName())
+                    raise DAAPError(
+                        'DAAPParseCodeTypes: unexpected code %s at level 2'
+                        % info.codeName()
+                    )
             if code is None or name is None or dtype is None:
                 log.debug('DAAPParseCodeTypes: missing information, not adding entry')
             else:
@@ -59,10 +68,12 @@ def DAAPParseCodeTypes(treeroot):
                     dtype = dmapFudgeDataTypes[name]
                 except KeyError:
                     pass
-                #print("** %s %s %s", code, name, dtype)
+                # print("** %s %s %s", code, name, dtype)
                 dmapCodeTypes[code] = (name, dtype)
         else:
-            raise DAAPError('DAAPParseCodeTypes: unexpected code %s at level 1' % info.codeName())
+            raise DAAPError(
+                'DAAPParseCodeTypes: unexpected code %s at level 1' % info.codeName()
+            )
 
 
 class DAAPError(Exception):
@@ -70,10 +81,9 @@ class DAAPError(Exception):
 
 
 class DAAPObject(object):
-
     def __init__(self, code=None, value=None, **kwargs):
-        if (code is not None):
-            if (len(code) == 4):
+        if code is not None:
+            if len(code) == 4:
                 self.code = code
             else:
                 self.code = dmapNames[code]
@@ -116,9 +126,16 @@ class DAAPObject(object):
 
     def printTree(self, level=0, out=sys.stdout):
         if hasattr(self, 'value'):
-            out.write('\t' * level + '%s (%s)\t%s\t%s\n' % (self.codeName(), self.code, self.type, self.value))
+            out.write(
+                '\t' * level
+                + '%s (%s)\t%s\t%s\n'
+                % (self.codeName(), self.code, self.type, self.value)
+            )
         else:
-            out.write('\t' * level + '%s (%s)\t%s\t%s\n' % (self.codeName(), self.code, self.type, None))
+            out.write(
+                '\t' * level
+                + '%s (%s)\t%s\t%s\n' % (self.codeName(), self.code, self.type, None)
+            )
         if hasattr(self, 'contains'):
             for object in self.contains:
                 object.printTree(level + 1)
@@ -160,7 +177,7 @@ class DAAPObject(object):
             elif self.type == 'ul':
                 packing = 'Q'
             elif self.type == 'i':
-                if (isinstance(value, str) and len(value) <= 4):
+                if isinstance(value, str) and len(value) <= 4:
                     packing = '4s'
                 else:
                     packing = 'i'
@@ -168,9 +185,9 @@ class DAAPObject(object):
                 packing = 'I'
             elif self.type == 'h':
                 packing = 'h'
-                if (value > 32767):
+                if value > 32767:
                     value = 32767
-                elif (value < -32768):
+                elif value < -32768:
                     value = -32768
             elif self.type == 'uh':
                 packing = 'H'
@@ -257,15 +274,22 @@ class DAAPObject(object):
             # we need to read length characters from the string
             try:
                 self.value = unicode(
-                    struct.unpack('!%ss' % self.length, code)[0], 'utf-8')
+                    struct.unpack('!%ss' % self.length, code)[0], 'utf-8'
+                )
             except UnicodeDecodeError:
                 # oh, urgh
                 self.value = unicode(
-                    struct.unpack('!%ss' % self.length, code)[0], 'latin-1')
+                    struct.unpack('!%ss' % self.length, code)[0], 'latin-1'
+                )
         else:
             # we don't know what to do with this object
             # put it's raw data into value
-            log.debug('DAAPObject: Unknown code %s for type %s, writing raw data', code, self.code)
+            log.debug(
+                'DAAPObject: Unknown code %s for type %s, writing raw data',
+                code,
+                self.code,
+            )
             self.value = code
+
 
 do = DAAPObject

--- a/plugins/desktopcover/__init__.py
+++ b/plugins/desktopcover/__init__.py
@@ -22,12 +22,7 @@ from gi.repository import GdkPixbuf
 from gi.repository import GLib
 from gi.repository import Gtk
 
-from xl import (
-    covers,
-    event,
-    player,
-    settings
-)
+from xl import covers, event, player, settings
 
 from xlgui.guiutil import get_workarea_dimensions, pixbuf_from_data
 
@@ -37,7 +32,6 @@ DESKTOPCOVER = None
 
 
 class DesktopCoverPlugin(object):
-
     def __init__(self):
         self.__desktop_cover = None
 
@@ -89,7 +83,7 @@ class DesktopCover(Gtk.Window):
         'topleft': Gdk.Gravity.NORTH_WEST,
         'topright': Gdk.Gravity.NORTH_EAST,
         'bottomleft': Gdk.Gravity.SOUTH_WEST,
-        'bottomright': Gdk.Gravity.SOUTH_EAST
+        'bottomright': Gdk.Gravity.SOUTH_EAST,
     }
 
     def __init__(self):
@@ -118,7 +112,7 @@ class DesktopCover(Gtk.Window):
             'playback_track_start',
             'playback_player_end',
             'cover_set',
-            'cover_removed'
+            'cover_removed',
         ]
 
         screen = self.get_screen()
@@ -170,8 +164,7 @@ class DesktopCover(Gtk.Window):
         size = settings.get_option('plugin/desktopcover/size', 200)
         upscale = settings.get_option('plugin/desktopcover/override_size', False)
         pixbuf = self.image.get_pixbuf()
-        next_pixbuf = pixbuf_from_data(cover_data,
-                                       size=(size, size), upscale=upscale)
+        next_pixbuf = pixbuf_from_data(cover_data, size=(size, size), upscale=upscale)
         fading = settings.get_option('plugin/desktopcover/fading', False)
 
         if fading and pixbuf is not None and self._cross_fade_id is None:
@@ -180,11 +173,11 @@ class DesktopCover(Gtk.Window):
             pixbuf = pixbuf.scale_simple(width, height, GdkPixbuf.InterpType.BILINEAR)
             self.image.set_from_pixbuf(pixbuf)
 
-            duration = settings.get_option(
-                'plugin/desktopcover/fading_duration', 50)
+            duration = settings.get_option('plugin/desktopcover/fading_duration', 50)
 
-            self._cross_fade_id = GLib.timeout_add(int(duration),
-                                                   self.cross_fade, pixbuf, next_pixbuf, duration)
+            self._cross_fade_id = GLib.timeout_add(
+                int(duration), self.cross_fade, pixbuf, next_pixbuf, duration
+            )
         else:
             self.image.set_from_pixbuf(next_pixbuf)
 
@@ -193,8 +186,9 @@ class DesktopCover(Gtk.Window):
             Updates the position based
             on gravity and offsets
         """
-        gravity = self.gravity_map[settings.get_option(
-            'plugin/desktopcover/anchor', 'topleft')]
+        gravity = self.gravity_map[
+            settings.get_option('plugin/desktopcover/anchor', 'topleft')
+        ]
         cover_offset_x = settings.get_option('plugin/desktopcover/x', 0)
         cover_offset_y = settings.get_option('plugin/desktopcover/y', 0)
         allocation = self.get_allocation()
@@ -226,10 +220,8 @@ class DesktopCover(Gtk.Window):
         Gtk.Window.show(self)
 
         if fading and self._fade_in_id is None:
-            duration = settings.get_option(
-                'plugin/desktopcover/fading_duration', 50)
-            self._fade_in_id = GLib.timeout_add(
-                int(duration), self.fade_in)
+            duration = settings.get_option('plugin/desktopcover/fading_duration', 50)
+            self._fade_in_id = GLib.timeout_add(int(duration), self.fade_in)
 
     def hide(self):
         """
@@ -238,10 +230,8 @@ class DesktopCover(Gtk.Window):
         fading = settings.get_option('plugin/desktopcover/fading', False)
 
         if fading and self._fade_out_id is None:
-            duration = settings.get_option(
-                'plugin/desktopcover/fading_duration', 50)
-            self._fade_out_id = GLib.timeout_add(
-                int(duration), self.fade_out)
+            duration = settings.get_option('plugin/desktopcover/fading_duration', 50)
+            self._fade_out_id = GLib.timeout_add(int(duration), self.fade_out)
         else:
             Gtk.Window.hide(self)
             self.image.set_from_pixbuf(None)
@@ -295,12 +285,16 @@ class DesktopCover(Gtk.Window):
 
             next_pixbuf.composite(
                 dest=pixbuf,
-                dest_x=0, dest_y=0,
-                dest_width=width, dest_height=height,
-                offset_x=0, offset_y=0,
-                scale_x=1, scale_y=1,
+                dest_x=0,
+                dest_y=0,
+                dest_width=width,
+                dest_height=height,
+                offset_x=0,
+                offset_y=0,
+                scale_x=1,
+                scale_y=1,
                 interp_type=GdkPixbuf.InterpType.BILINEAR,
-                overall_alpha=int(alpha)
+                overall_alpha=int(alpha),
             )
 
             self.image.queue_draw()
@@ -362,12 +356,17 @@ class DesktopCover(Gtk.Window):
         """
             Updates the appearance
         """
-        if option in ('plugin/desktopcover/anchor',
-                      'plugin/desktopcover/x',
-                      'plugin/desktopcover/y'):
+        if option in (
+            'plugin/desktopcover/anchor',
+            'plugin/desktopcover/x',
+            'plugin/desktopcover/y',
+        ):
             self.update_position()
-        elif option in ('plugin/desktopcover/override_size',
-                        'plugin/desktopcover/size'):
+        elif option in (
+            'plugin/desktopcover/override_size',
+            'plugin/desktopcover/size',
+        ):
             self.set_cover_from_track(player.PLAYER.current)
+
 
 # vi: et sts=4 sw=4 tw=80

--- a/plugins/desktopcover/desktopcover_preferences.py
+++ b/plugins/desktopcover/desktopcover_preferences.py
@@ -59,8 +59,7 @@ class FadingPreference(widgets.CheckPreference):
     name = 'plugin/desktopcover/fading'
 
 
-class FadingDurationPreference(widgets.SpinPreference,
-                               widgets.CheckConditional):
+class FadingDurationPreference(widgets.SpinPreference, widgets.CheckConditional):
     default = 50
     name = 'plugin/desktopcover/fading_duration'
     condition_preference_name = 'plugin/desktopcover/fading'
@@ -68,5 +67,6 @@ class FadingDurationPreference(widgets.SpinPreference,
     def __init__(self, preferences, widget):
         widgets.SpinPreference.__init__(self, preferences, widget)
         widgets.CheckConditional.__init__(self)
+
 
 # vi: et sts=4 sw=4 tw=80

--- a/plugins/developer/__init__.py
+++ b/plugins/developer/__init__.py
@@ -19,10 +19,7 @@ from __future__ import print_function
 from gi.repository import GLib
 from gi.repository import Gtk
 
-from xl import (
-    event,
-    providers
-)
+from xl import event, providers
 from xl.nls import gettext as _
 
 from xlgui.guiutil import GtkTemplate
@@ -63,8 +60,9 @@ class DeveloperPlugin(object):
     def on_gui_loaded(self):
 
         # add a thing to the view menu
-        self.menu = menu.simple_menu_item('developer', '', _('Developer Tools'),
-                                          callback=self.on_view_menu)
+        self.menu = menu.simple_menu_item(
+            'developer', '', _('Developer Tools'), callback=self.on_view_menu
+        )
 
         providers.register('menubar-tools-menu', self.menu)
 
@@ -118,10 +116,12 @@ class DeveloperWindow(Gtk.Window):
 
     __gtype_name__ = 'DeveloperWindow'
 
-    (event_filter_entry, \
-        event_model_filter, \
-        event_tree, \
-        event_store) = GtkTemplate.Child.widgets(4)
+    (
+        event_filter_entry,
+        event_model_filter,
+        event_tree,
+        event_store,
+    ) = GtkTemplate.Child.widgets(4)
 
     def __init__(self, parent, plugin):
         Gtk.Window.__init__(self)
@@ -140,8 +140,9 @@ class DeveloperWindow(Gtk.Window):
         self.event_model_filter.set_visible_func(self.on_event_filter_row)
 
         self.event_tree.set_search_entry(self.event_filter_entry)
-        self.event_tree.connect('start-interactive-search',
-                                lambda *a: self.event_filter_entry.grab_focus())
+        self.event_tree.connect(
+            'start-interactive-search', lambda *a: self.event_filter_entry.grab_focus()
+        )
 
         self.event_timeout_id = GLib.timeout_add(250, self.on_event_update)
 

--- a/plugins/developer/__init__.py
+++ b/plugins/developer/__init__.py
@@ -118,10 +118,10 @@ class DeveloperWindow(Gtk.Window):
 
     __gtype_name__ = 'DeveloperWindow'
 
-    event_filter_entry, \
+    (event_filter_entry, \
         event_model_filter, \
         event_tree, \
-        event_store = GtkTemplate.Child.widgets(4)
+        event_store) = GtkTemplate.Child.widgets(4)
 
     def __init__(self, parent, plugin):
         Gtk.Window.__init__(self)

--- a/plugins/dist_plugin.py
+++ b/plugins/dist_plugin.py
@@ -38,14 +38,23 @@ from optparse import OptionParser
 
 
 p = OptionParser()
-p.add_option("-c", "--compression", dest="compression",
-             action="store", choices=("", "gz", "bz2"), default="bz2")
-p.add_option("-e", "--ignore-extension", dest="extensions",
-             action="append", default=(".pyc", ".pyo"))
-p.add_option("-f", "--ignore-file", dest="files",
-             action="append", default=("test.py"))
-p.add_option("-O", "--output", dest="output",
-             action="store", default="")
+p.add_option(
+    "-c",
+    "--compression",
+    dest="compression",
+    action="store",
+    choices=("", "gz", "bz2"),
+    default="bz2",
+)
+p.add_option(
+    "-e",
+    "--ignore-extension",
+    dest="extensions",
+    action="append",
+    default=(".pyc", ".pyo"),
+)
+p.add_option("-f", "--ignore-file", dest="files", action="append", default=("test.py"))
+p.add_option("-O", "--output", dest="output", action="store", default="")
 options, args = p.parse_args()
 
 # allowed values: "", "gz", "bz2"
@@ -89,8 +98,8 @@ for dir in args:
         continue
 
     tfile = tarfile.open(
-        options.output + dir + "-%s.exz" % info["Version"],
-        "w:%s" % COMPRESSION)
+        options.output + dir + "-%s.exz" % info["Version"], "w:%s" % COMPRESSION
+    )
     tfile.posix = True  # we like being standards-compilant
 
     for fold, subdirs, files in os.walk(dir):

--- a/plugins/equalizer/__init__.py
+++ b/plugins/equalizer/__init__.py
@@ -43,8 +43,10 @@ def isclose(float_a, float_b, rel_tol=1e-09, abs_tol=0.0):
     """
         copied from python 3.5, where this function was introduced to the math module
     """
-    return abs(float_a - float_b) <= \
-        max(rel_tol * max(abs(float_a), abs(float_b)), abs_tol)
+    return abs(float_a - float_b) <= max(
+        rel_tol * max(abs(float_a), abs(float_b)), abs_tol
+    )
+
 
 # Values from <http://www.xmms.org/faq.php#General3>, adjusted to be less loud
 # in general ((mean + max) / 2 = 0).
@@ -77,6 +79,7 @@ class GSTEqualizer(ElementBin):
     """
     Equalizer GST class
     """
+
     index = 99
     name = "equalizer-10bands"
 
@@ -94,13 +97,13 @@ class GSTEqualizer(ElementBin):
 
         self.setup_elements()
 
-        event.add_ui_callback(self._on_option_set,
-                              "plugin_equalizer_option_set")
+        event.add_ui_callback(self._on_option_set, "plugin_equalizer_option_set")
 
         setts = ["band%s" for _number in range(10)] + ["pre", "enabled"]
         for setting in setts:
-            self._on_option_set("plugin_equalizer_option_set", None,
-                                "plugin/equalizer/%s" % setting)
+            self._on_option_set(
+                "plugin_equalizer_option_set", None, "plugin/equalizer/%s" % setting
+            )
 
     def _on_option_set(self, _name, _object, data):
         for band in range(10):
@@ -108,25 +111,31 @@ class GSTEqualizer(ElementBin):
                 if settings.get_option("plugin/equalizer/enabled") is True:
                     self.eq10band.set_property(
                         "band%s" % band,
-                        settings.get_option("plugin/equalizer/band%s" % band))
+                        settings.get_option("plugin/equalizer/band%s" % band),
+                    )
                 else:
                     self.eq10band.set_property("band%s" % band, 0.0)
 
         if data == "plugin/equalizer/pre":
             if settings.get_option("plugin/equalizer/enabled") is True:
-                self.preamp.set_property("volume", self.dB_to_percent(
-                    settings.get_option("plugin/equalizer/pre")))
+                self.preamp.set_property(
+                    "volume",
+                    self.dB_to_percent(settings.get_option("plugin/equalizer/pre")),
+                )
             else:
                 self.preamp.set_property("volume", 1.0)
 
         if data == "plugin/equalizer/enabled":
             if settings.get_option("plugin/equalizer/enabled") is True:
-                self.preamp.set_property("volume", self.dB_to_percent(
-                    settings.get_option("plugin/equalizer/pre")))
+                self.preamp.set_property(
+                    "volume",
+                    self.dB_to_percent(settings.get_option("plugin/equalizer/pre")),
+                )
                 for band in range(10):
                     self.eq10band.set_property(
                         "band%s" % band,
-                        settings.get_option("plugin/equalizer/band%s" % band))
+                        settings.get_option("plugin/equalizer/band%s" % band),
+                    )
             else:
                 self.preamp.set_property("volume", 1.0)
                 for band in range(10):
@@ -134,7 +143,7 @@ class GSTEqualizer(ElementBin):
 
     @staticmethod
     def dB_to_percent(dB):
-        return 10**(dB / 10)
+        return 10 ** (dB / 10)
 
 
 @GtkTemplate('equalizer.ui', relto=__file__)
@@ -143,16 +152,28 @@ class EqualizerWindow(Gtk.Window):
 
     PRESETS_PATH = os.path.join(xdg.get_config_dir(), 'eq-presets.dat')
 
-    (band0, band1, band2, band3, band4, band5, band6, band7, band8, band9, \
-        chk_enabled, combo_presets, presets, pre) \
-        = GtkTemplate.Child.widgets(14)
+    (
+        band0,
+        band1,
+        band2,
+        band3,
+        band4,
+        band5,
+        band6,
+        band7,
+        band8,
+        band9,
+        chk_enabled,
+        combo_presets,
+        presets,
+        pre,
+    ) = GtkTemplate.Child.widgets(14)
 
     def __init__(self):
         Gtk.Window.__init__(self)
         self.init_template()
         self.pre.set_value(settings.get_option("plugin/equalizer/pre"))
-        self.chk_enabled.set_active(
-            settings.get_option("plugin/equalizer/enabled"))
+        self.chk_enabled.set_active(settings.get_option("plugin/equalizer/enabled"))
         # Setup bands/preamp from current equalizer settings
         for number in (0, 1, 2, 3, 4, 5, 6, 7, 8, 9):
             band = getattr(self, 'band%s' % number)
@@ -179,8 +200,7 @@ class EqualizerWindow(Gtk.Window):
         band = widget_name[-1]
         settings_value = settings.get_option("plugin/equalizer/band" + band)
         if not isclose(widget.get_value(), settings_value):
-            settings.set_option("plugin/equalizer/band" + band,
-                                widget.get_value())
+            settings.set_option("plugin/equalizer/band" + band, widget.get_value())
             self.combo_presets.set_active(0)
 
     @GtkTemplate.Callback
@@ -196,13 +216,11 @@ class EqualizerWindow(Gtk.Window):
     def add_preset(self, _widget):
 
         new_preset = []
-        new_preset.append(
-            self.combo_presets.get_child().get_text())
+        new_preset.append(self.combo_presets.get_child().get_text())
         new_preset.append(settings.get_option("plugin/equalizer/pre"))
 
         for band in range(10):
-            new_preset.append(settings.get_option(
-                "plugin/equalizer/band%s" % band))
+            new_preset.append(settings.get_option("plugin/equalizer/band%s" % band))
 
         self.presets.append(new_preset)
         self.save_presets()
@@ -222,13 +240,16 @@ class EqualizerWindow(Gtk.Window):
 
         # If an option other than "Custom" is chosen:
         if index > 0:
-            settings.set_option("plugin/equalizer/pre",
-                                model.get_value(model.get_iter(index), 1))
+            settings.set_option(
+                "plugin/equalizer/pre", model.get_value(model.get_iter(index), 1)
+            )
             self.pre.set_value(model.get_value(model.get_iter(index), 1))
 
             for band in range(10):
-                settings.set_option("plugin/equalizer/band%s" % band,
-                                    model.get_value(model.get_iter(index), band + 2))
+                settings.set_option(
+                    "plugin/equalizer/band%s" % band,
+                    model.get_value(model.get_iter(index), band + 2),
+                )
                 band_widget = getattr(self, "band%s" % band)
                 band_widget.set_value(model.get_value(model.get_iter(index), band + 2))
 
@@ -318,8 +339,11 @@ class EqualizerPlugin(object):
         """
         # add menu item to tools menu
         self.__menu_item = menu.simple_menu_item(
-            'equalizer', ['plugin-sep'], _('_Equalizer'),
-            callback=lambda *x: self.__show_gui())
+            'equalizer',
+            ['plugin-sep'],
+            _('_Equalizer'),
+            callback=lambda *x: self.__show_gui(),
+        )
         providers.register('menubar-tools-menu', self.__menu_item)
 
         self.window = EqualizerWindow()

--- a/plugins/equalizer/__init__.py
+++ b/plugins/equalizer/__init__.py
@@ -46,10 +46,10 @@ def isclose(float_a, float_b, rel_tol=1e-09, abs_tol=0.0):
     return abs(float_a - float_b) <= \
         max(rel_tol * max(abs(float_a), abs(float_b)), abs_tol)
 
-
 # Values from <http://www.xmms.org/faq.php#General3>, adjusted to be less loud
 # in general ((mean + max) / 2 = 0).
 DEFAULT_PRESETS = [
+    # fmt: off
     ('Custom', 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
     ('Default', 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
     ('Classical', 0, 1.6, 1.6, 1.6, 1.6, 1.6, 1.6, -5.6, -5.6, -5.6, -8.0),
@@ -69,6 +69,7 @@ DEFAULT_PRESETS = [
     ('Soft', 0, -3.6, -6.8, -8.4, -10.8, -8.4, -4.4, -0.4, 1.2, 2.8, 3.6),
     ('Soft Rock', 0, -0.8, -0.8, -2.4, -4.8, -8.8, -10.4, -8.0, -4.8, -2.4, 4.0),
     ('Techno', 0, 1.2, -1.2, -6.8, -12.4, -11.6, -6.8, 1.2, 2.8, 2.8, 2.0),
+    # fmt: on
 ]
 
 
@@ -142,8 +143,8 @@ class EqualizerWindow(Gtk.Window):
 
     PRESETS_PATH = os.path.join(xdg.get_config_dir(), 'eq-presets.dat')
 
-    band0, band1, band2, band3, band4, band5, band6, band7, band8, band9, \
-        chk_enabled, combo_presets, presets, pre \
+    (band0, band1, band2, band3, band4, band5, band6, band7, band8, band9, \
+        chk_enabled, combo_presets, presets, pre) \
         = GtkTemplate.Child.widgets(14)
 
     def __init__(self):

--- a/plugins/grouptagger/__init__.py
+++ b/plugins/grouptagger/__init__.py
@@ -27,12 +27,7 @@
 from gi.repository import Gtk
 from gi.repository import Pango
 
-from xl import (
-    event,
-    providers,
-    player,
-    settings
-)
+from xl import event, providers, player, settings
 
 from xl.nls import gettext as _
 
@@ -84,70 +79,116 @@ class GroupTaggerPlugin(object):
 
         # ok, register for some events
         event.add_ui_callback(self.on_playback_track_start, 'playback_track_start')
-        event.add_ui_callback(self.on_playlist_cursor_changed, 'playlist_cursor_changed')
-        event.add_ui_callback(self.on_plugin_options_set, 'plugin_grouptagger_option_set')
+        event.add_ui_callback(
+            self.on_playlist_cursor_changed, 'playlist_cursor_changed'
+        )
+        event.add_ui_callback(
+            self.on_plugin_options_set, 'plugin_grouptagger_option_set'
+        )
 
         # add our own submenu for functionality
         tools_submenu = menu.Menu(None, context_func=lambda p: self.exaile)
 
         tools_submenu.add_item(
-            menu.simple_menu_item('gt_get_tags', [], _('_Get all tags from collection'),
-                                  callback=self.on_get_tags_menu)
+            menu.simple_menu_item(
+                'gt_get_tags',
+                [],
+                _('_Get all tags from collection'),
+                callback=self.on_get_tags_menu,
+            )
         )
 
         tools_submenu.add_item(
-            menu.simple_menu_item('gt_import', [], _('_Import tags from directory'),
-                                  callback=self.on_import_tags)
+            menu.simple_menu_item(
+                'gt_import',
+                [],
+                _('_Import tags from directory'),
+                callback=self.on_import_tags,
+            )
         )
 
         tools_submenu.add_item(
-            menu.simple_menu_item('gt_rename', [], _('_Mass rename/delete tags'),
-                                  callback=self.on_mass_rename)
+            menu.simple_menu_item(
+                'gt_rename',
+                [],
+                _('_Mass rename/delete tags'),
+                callback=self.on_mass_rename,
+            )
         )
-        
+
         tools_submenu.add_item(
-            menu.simple_menu_item('gt_export', [], _('E_xport collecton tags to JSON'),
-                                  callback=self.on_export_tags)
+            menu.simple_menu_item(
+                'gt_export',
+                [],
+                _('E_xport collecton tags to JSON'),
+                callback=self.on_export_tags,
+            )
         )
 
         # group them together to make it not too long
-        self.tools_menuitem = menu.simple_menu_item('grouptagger', ['plugin-sep'],
-                                                    _('_GroupTagger'), submenu=tools_submenu)
+        self.tools_menuitem = menu.simple_menu_item(
+            'grouptagger', ['plugin-sep'], _('_GroupTagger'), submenu=tools_submenu
+        )
         providers.register('menubar-tools-menu', self.tools_menuitem)
 
         # playlist context menu items
         self.provider_items = []
         track_subitem = menu.Menu(None, inherit_context=True)
 
-        track_subitem.add_item(menu.simple_menu_item('gt_search_all', [],
-                                                     _('Show tracks with all tags'),
-                                                     callback=self.on_playlist_context_select_all_menu,
-                                                     callback_args=[self.exaile]))
+        track_subitem.add_item(
+            menu.simple_menu_item(
+                'gt_search_all',
+                [],
+                _('Show tracks with all tags'),
+                callback=self.on_playlist_context_select_all_menu,
+                callback_args=[self.exaile],
+            )
+        )
 
-        track_subitem.add_item(menu.simple_menu_item('gt_search_custom', ['gt_search_all'],
-                                                     _('Show tracks with tags (custom)'),
-                                                     callback=self.on_playlist_context_select_custom_menu,
-                                                     callback_args=[self.exaile]))
+        track_subitem.add_item(
+            menu.simple_menu_item(
+                'gt_search_custom',
+                ['gt_search_all'],
+                _('Show tracks with tags (custom)'),
+                callback=self.on_playlist_context_select_custom_menu,
+                callback_args=[self.exaile],
+            )
+        )
 
         tag_cond_fn = lambda n, p, c: c['selection-count'] > 1
 
-        track_subitem.add_item(menu.simple_menu_item('gt_tag_add_multi', ['gt_search_custom'],
-                                                     _('Add tags to all'),
-                                                     callback=self.on_add_tags, condition_fn=tag_cond_fn,
-                                                     callback_args=[self.exaile]))
+        track_subitem.add_item(
+            menu.simple_menu_item(
+                'gt_tag_add_multi',
+                ['gt_search_custom'],
+                _('Add tags to all'),
+                callback=self.on_add_tags,
+                condition_fn=tag_cond_fn,
+                callback_args=[self.exaile],
+            )
+        )
 
-        track_subitem.add_item(menu.simple_menu_item('gt_tag_rm_multi', ['gt_tag_add_multi'],
-                                                     _('Remove tags from all'),
-                                                     callback=self.on_rm_tags, condition_fn=tag_cond_fn,
-                                                     callback_args=[self.exaile]))
+        track_subitem.add_item(
+            menu.simple_menu_item(
+                'gt_tag_rm_multi',
+                ['gt_tag_add_multi'],
+                _('Remove tags from all'),
+                callback=self.on_rm_tags,
+                condition_fn=tag_cond_fn,
+                callback_args=[self.exaile],
+            )
+        )
 
-        self.provider_items.append(menu.simple_menu_item('grouptagger', ['rating'],
-                                                         _('GroupTagger'), submenu=track_subitem))
+        self.provider_items.append(
+            menu.simple_menu_item(
+                'grouptagger', ['rating'], _('GroupTagger'), submenu=track_subitem
+            )
+        )
 
         for item in self.provider_items:
             providers.register('playlist-context-menu', item)
             # Hm, doesn't work..
-            #providers.register('track-panel-menu', item)
+            # providers.register('track-panel-menu', item)
 
         # trigger start event if exaile is currently playing something
         if player.PLAYER.is_playing():
@@ -173,8 +214,12 @@ class GroupTaggerPlugin(object):
 
         # de-register the exaile events
         event.remove_callback(self.on_playback_track_start, 'playback_track_start')
-        event.remove_callback(self.on_playlist_cursor_changed, 'playlist_cursor_changed')
-        event.remove_callback(self.on_plugin_options_set, 'plugin_grouptagger_option_set')
+        event.remove_callback(
+            self.on_playlist_cursor_changed, 'playlist_cursor_changed'
+        )
+        event.remove_callback(
+            self.on_plugin_options_set, 'plugin_grouptagger_option_set'
+        )
 
         providers.unregister('main-panel', self.panel)
 
@@ -192,15 +237,19 @@ class GroupTaggerPlugin(object):
     #
     # Menu callbacks
     #
-    
+
     def on_export_tags(self, widget, name, parent, exaile):
         gt_export.export_tags(exaile)
 
     def on_get_tags_menu(self, widget, name, parent, exaile):
 
         if self.tag_dialog is None:
-            self.tag_dialog = gt_widgets.AllTagsDialog(exaile, self.panel.tagger.add_groups)
-            self.tag_dialog.connect('delete-event', self.on_get_tags_menu_window_deleted)
+            self.tag_dialog = gt_widgets.AllTagsDialog(
+                exaile, self.panel.tagger.add_groups
+            )
+            self.tag_dialog.connect(
+                'delete-event', self.on_get_tags_menu_window_deleted
+            )
 
         self.tag_dialog.show_all()
 
@@ -260,7 +309,9 @@ class GroupTaggerPlugin(object):
         '''Called when a new track starts'''
         self.set_display_track(track)
 
-    def on_playlist_context_select_all_menu(self, menu, display_name, playlist_view, context, exaile):
+    def on_playlist_context_select_all_menu(
+        self, menu, display_name, playlist_view, context, exaile
+    ):
         '''Called when 'Select tracks with same tags' is selected'''
         tracks = context['selected-tracks']
         groups = set()
@@ -273,7 +324,9 @@ class GroupTaggerPlugin(object):
         else:
             dialogs.error(None, _('No categorization tags found in selected tracks'))
 
-    def on_playlist_context_select_custom_menu(self, menu, display_name, playlist_view, context, exaile):
+    def on_playlist_context_select_custom_menu(
+        self, menu, display_name, playlist_view, context, exaile
+    ):
         '''Called when 'select tracks with similar tags (custom)' is selected'''
         tracks = context['selected-tracks']
         groups = set()
@@ -359,5 +412,6 @@ class GroupTaggerPlugin(object):
         elif option == tagname_option:
             if self.track is not None:
                 self.set_display_track(self.track, True)
+
 
 plugin_class = GroupTaggerPlugin

--- a/plugins/grouptagger/gt_common.py
+++ b/plugins/grouptagger/gt_common.py
@@ -34,10 +34,7 @@ from gi.repository import GObject
 
 import re
 
-from xl import (
-    playlist,
-    settings
-)
+from xl import playlist, settings
 
 from xl.nls import gettext as _
 from xl.trax import search
@@ -62,7 +59,7 @@ def migrate_settings():
         if default_groups is not None:
             group_categories = {_('Uncategorized'): [True, default_groups]}
             set_group_categories(group_categories)
-            #settings.remove_option( 'plugin/grouptagger/default_groups' )
+            # settings.remove_option( 'plugin/grouptagger/default_groups' )
 
         settings.set_option(migrated_option, True)
 
@@ -98,7 +95,11 @@ def set_track_groups(track, groups):
     track.set_tag_raw(get_tagname(), grouping)
 
     if not track.write_tags():
-        dialogs.error(None, "Error writing tags to %s" % GObject.markup_escape_text(track.get_loc_for_io()))
+        dialogs.error(
+            None,
+            "Error writing tags to %s"
+            % GObject.markup_escape_text(track.get_loc_for_io()),
+        )
         return False
 
     return True
@@ -146,7 +147,10 @@ def get_all_collection_groups(collection):
 
 def _create_search_playlist(name, search_string, exaile):
     '''Create a playlist based on a search string'''
-    tracks = [x.track for x in search.search_tracks_from_string(exaile.collection, search_string)]
+    tracks = [
+        x.track
+        for x in search.search_tracks_from_string(exaile.collection, search_string)
+    ]
 
     # create the playlist
     pl = playlist.Playlist(name, tracks)
@@ -159,7 +163,12 @@ def create_all_search_playlist(groups, exaile):
     tagname = get_tagname()
 
     name = '%s: %s' % (tagname.title(), ' and '.join(groups))
-    search_string = ' '.join(['%s~"\\b%s\\b"' % (tagname, re.escape(group.replace(' ', '_'))) for group in groups])
+    search_string = ' '.join(
+        [
+            '%s~"\\b%s\\b"' % (tagname, re.escape(group.replace(' ', '_')))
+            for group in groups
+        ]
+    )
 
     _create_search_playlist(name, search_string, exaile)
 

--- a/plugins/grouptagger/gt_export.py
+++ b/plugins/grouptagger/gt_export.py
@@ -38,6 +38,7 @@ from xlgui.widgets import dialogs
 from gt_common import get_track_groups
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -45,15 +46,17 @@ def export_tags(exaile):
     '''
         Exports all tags to a user specified JSON file
     '''
-    
-    uri = dialogs.save(parent=exaile.gui.main.window,
-                       output_fname='tags.json',
-                       output_setting='plugin/grouptagger/export_dir',
-                       title=_('Export tags to JSON'),
-                       extensions={'.json': 'grouptagger JSON export'})
-    
+
+    uri = dialogs.save(
+        parent=exaile.gui.main.window,
+        output_fname='tags.json',
+        output_setting='plugin/grouptagger/export_dir',
+        title=_('Export tags to JSON'),
+        extensions={'.json': 'grouptagger JSON export'},
+    )
+
     if uri is not None:
-        
+
         # collect the data
         trackdata = {}
         for strack in search.search_tracks_from_string(exaile.collection, ''):
@@ -61,7 +64,7 @@ def export_tags(exaile):
             tags = list(sorted(get_track_groups(track)))
             if tags:
                 trackdata[track.get_loc_for_io()] = tags
-        
+
         data = {
             '_meta': {
                 'date': time.strftime('%Y-%m-%d %H:%M:%S'),
@@ -70,10 +73,9 @@ def export_tags(exaile):
             },
             'tracks': trackdata,
         }
-        
+
         # save it
         with GioFileOutputStream(Gio.File.new_for_uri(uri), 'w') as fp:
-            json.dump(data, fp,
-                      sort_keys=True, indent=4, separators=(',', ': '))
-        
+            json.dump(data, fp, sort_keys=True, indent=4, separators=(',', ': '))
+
         logger.info("Exported tags of %s tracks to %s", len(trackdata), uri)

--- a/plugins/grouptagger/gt_import.py
+++ b/plugins/grouptagger/gt_import.py
@@ -1,7 +1,5 @@
 
-from gi.repository import (
-    Gtk
-)
+from gi.repository import Gtk
 
 from xl.common import idle_add, SimpleProgressThread
 from xl.collection import Collection, Library, CollectionScanThread
@@ -16,6 +14,7 @@ from xlgui.guiutil import GtkTemplate
 from gt_common import get_track_groups, set_track_groups
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -28,13 +27,15 @@ class GtImporter(Gtk.Window):
 
     __gtype_name__ = 'GtImporter'
 
-    (content_area,       \
-        ok_button,          \
-        tags_model,         \
-        tags_view,          \
-        tags_vbox,          \
-        radio_merge,        \
-        radio_replace) = GtkTemplate.Child.widgets(7)
+    (
+        content_area,
+        ok_button,
+        tags_model,
+        tags_view,
+        tags_vbox,
+        radio_merge,
+        radio_replace,
+    ) = GtkTemplate.Child.widgets(7)
 
     def __init__(self, exaile, uris):
         Gtk.Window.__init__(self, transient_for=exaile.gui.main.window)
@@ -54,7 +55,9 @@ class GtImporter(Gtk.Window):
 
         self.import_thread = None
 
-        self.manager.add_monitor(self.rescan_thread, _("Importing tracks"), 'document-open')
+        self.manager.add_monitor(
+            self.rescan_thread, _("Importing tracks"), 'document-open'
+        )
 
     #
     # Status routines
@@ -73,11 +76,16 @@ class GtImporter(Gtk.Window):
 
         # now that the collection has loaded, import the groups from them
         self.import_track_data = []
-        self.import_thread = SimpleProgressThread(track_import_thread,
-                                                  self.collection, self.exaile.collection,
-                                                  self.import_track_data)
+        self.import_thread = SimpleProgressThread(
+            track_import_thread,
+            self.collection,
+            self.exaile.collection,
+            self.import_track_data,
+        )
         self.import_thread.connect('done', self._on_import_done)
-        self.manager.add_monitor(self.import_thread, _("Importing groups"), 'document-open')
+        self.manager.add_monitor(
+            self.import_thread, _("Importing groups"), 'document-open'
+        )
 
     @idle_add()
     def _on_import_done(self, thread):
@@ -95,9 +103,13 @@ class GtImporter(Gtk.Window):
         if len(track_data) == 0:
             self.destroy()
 
-            locations = ';'.join([l.get_location() for l in self.collection.get_libraries()])
+            locations = ';'.join(
+                [l.get_location() for l in self.collection.get_libraries()]
+            )
 
-            dialogs.info(self.exaile.gui.main.window, 'No new tracks found at "%s"' % locations)
+            dialogs.info(
+                self.exaile.gui.main.window, 'No new tracks found at "%s"' % locations
+            )
             return
 
         self.tags_view.freeze_child_notify()
@@ -105,7 +117,16 @@ class GtImporter(Gtk.Window):
 
         # add the data to the model
         for old_group_str, new_group_str, matched_track, newgroups in track_data:
-            self.tags_model.append((True, str(matched_track), old_group_str, new_group_str, matched_track, newgroups))
+            self.tags_model.append(
+                (
+                    True,
+                    str(matched_track),
+                    old_group_str,
+                    new_group_str,
+                    matched_track,
+                    newgroups,
+                )
+            )
 
         self.tags_view.set_model(self.tags_model)
         self.tags_view.thaw_child_notify()
@@ -153,8 +174,9 @@ class GtImporter(Gtk.Window):
         data = [(row[4], row[5]) for row in self.tags_model if row[0]]
         logger.info('Updating %s tracks', len(data))
 
-        self.update_thread = SimpleProgressThread(track_update_thread,
-                                                  data, self.radio_replace.get_active())
+        self.update_thread = SimpleProgressThread(
+            track_update_thread, data, self.radio_replace.get_active()
+        )
         self.update_thread.connect('done', self._on_update_done)
 
         self.manager.add_monitor(self.update_thread, _("Updating groups"), 'system-run')
@@ -211,7 +233,12 @@ def track_import_thread(import_collection, user_collection, track_data):
 
         yield (i, total)
 
-    logger.info("Match information: %s exact dups, %s no change, %s differing tracks", exact_dups, no_change, len(track_data))
+    logger.info(
+        "Match information: %s exact dups, %s no change, %s differing tracks",
+        exact_dups,
+        no_change,
+        len(track_data),
+    )
 
 
 def track_update_thread(trackdata, replace):
@@ -241,8 +268,9 @@ def import_tags(exaile):
         import_dialog = GtImporter(exaile, uris)
         import_dialog.show()
 
-    file_dialog = dialogs.DirectoryOpenDialog(exaile.gui.main.window,
-                                              title=_('Select directory to import grouping tags from'))
+    file_dialog = dialogs.DirectoryOpenDialog(
+        exaile.gui.main.window, title=_('Select directory to import grouping tags from')
+    )
     file_dialog.connect('uris-selected', _on_uris_selected)
     file_dialog.run()
     file_dialog.destroy()

--- a/plugins/grouptagger/gt_import.py
+++ b/plugins/grouptagger/gt_import.py
@@ -28,13 +28,13 @@ class GtImporter(Gtk.Window):
 
     __gtype_name__ = 'GtImporter'
 
-    content_area,       \
+    (content_area,       \
         ok_button,          \
         tags_model,         \
         tags_view,          \
         tags_vbox,          \
         radio_merge,        \
-        radio_replace = GtkTemplate.Child.widgets(7)
+        radio_replace) = GtkTemplate.Child.widgets(7)
 
     def __init__(self, exaile, uris):
         Gtk.Window.__init__(self, transient_for=exaile.gui.main.window)

--- a/plugins/grouptagger/gt_mass.py
+++ b/plugins/grouptagger/gt_mass.py
@@ -39,12 +39,12 @@ class GtMassRename(Gtk.Window):
 
     __gtype_name__ = 'GTMassRename'
 
-    found_label,    \
+    (found_label,    \
         playlists,      \
         replace,        \
         replace_entry,  \
         search_entry,   \
-        tracks_list = GtkTemplate.Child.widgets(6)
+        tracks_list) = GtkTemplate.Child.widgets(6)
 
     def __init__(self, exaile):
         Gtk.Window.__init__(self, transient_for=exaile.gui.main.window)

--- a/plugins/grouptagger/gt_mass.py
+++ b/plugins/grouptagger/gt_mass.py
@@ -39,12 +39,14 @@ class GtMassRename(Gtk.Window):
 
     __gtype_name__ = 'GTMassRename'
 
-    (found_label,    \
-        playlists,      \
-        replace,        \
-        replace_entry,  \
-        search_entry,   \
-        tracks_list) = GtkTemplate.Child.widgets(6)
+    (
+        found_label,
+        playlists,
+        replace,
+        replace_entry,
+        search_entry,
+        tracks_list,
+    ) = GtkTemplate.Child.widgets(6)
 
     def __init__(self, exaile):
         Gtk.Window.__init__(self, transient_for=exaile.gui.main.window)
@@ -101,9 +103,13 @@ class GtMassRename(Gtk.Window):
                 if self.search_str != '' and self.search_str not in groups:
                     continue
 
-                name = ' - '.join([track.get_tag_display('artist'),
-                                   track.get_tag_display('album'),
-                                   track.get_tag_display('title')])
+                name = ' - '.join(
+                    [
+                        track.get_tag_display('artist'),
+                        track.get_tag_display('album'),
+                        track.get_tag_display('title'),
+                    ]
+                )
                 model.append((True, name, track))
 
         # unfreeze, draw it up
@@ -121,7 +127,11 @@ class GtMassRename(Gtk.Window):
         replace_str = self.replace_entry.get_text().strip()
 
         if replace_str:
-            query = _("Replace '%s' with '%s' on %s tracks?") % (self.search_str, replace_str, len(tracks))
+            query = _("Replace '%s' with '%s' on %s tracks?") % (
+                self.search_str,
+                replace_str,
+                len(tracks),
+            )
         else:
             query = _("Delete '%s' from %s tracks?") % (self.search_str, len(tracks))
 
@@ -146,8 +156,10 @@ class GtMassRename(Gtk.Window):
 
 
 def mass_rename(exaile):
-    message = _("You should rescan your collection before using mass tag "
-                "rename to ensure that all tags are up to date. Rescan now?")
+    message = _(
+        "You should rescan your collection before using mass tag "
+        "rename to ensure that all tags are up to date. Rescan now?"
+    )
 
     if dialogs.yesno(exaile.gui.main.window, message) == Gtk.ResponseType.YES:
         exaile.gui.on_rescan_collection()

--- a/plugins/grouptagger/gt_widgets.py
+++ b/plugins/grouptagger/gt_widgets.py
@@ -44,22 +44,23 @@ import gt_common
 # GroupTaggerView signal 'changed' enum
 #
 
-group_change = common.enum(added=object(),
-                           deleted=object(),
-                           edited=object())       # edited/toggled group
+group_change = common.enum(
+    added=object(), deleted=object(), edited=object()
+)  # edited/toggled group
 
-category_change = common.enum(added=object(),
-                              deleted=object(),
-                              expanded=object(),   # user expanded category display
-                              collapsed=object(),  # user collapsed category display
-                              updated=object())   # added group, changed name
+category_change = common.enum(
+    added=object(),
+    deleted=object(),
+    expanded=object(),  # user expanded category display
+    collapsed=object(),  # user collapsed category display
+    updated=object(),
+)  # added group, changed name
 
 # default group category
 uncategorized = _('Uncategorized')
 
 
 class GTShowTracksMenuItem(menu.MenuItem):
-
     def __init__(self, name, after):
         menu.MenuItem.__init__(self, name, None, after)
 
@@ -75,12 +76,16 @@ class GTShowTracksMenuItem(menu.MenuItem):
             display_name = _('Show tracks with all selected')
 
         menuitem = Gtk.MenuItem.new_with_mnemonic(display_name)
-        menuitem.connect('activate', lambda *e: gt_common.create_all_search_playlist(context['groups'], parent.exaile))
+        menuitem.connect(
+            'activate',
+            lambda *e: gt_common.create_all_search_playlist(
+                context['groups'], parent.exaile
+            ),
+        )
         return menuitem
 
 
 class GroupTaggerContextMenu(menu.Menu):
-
     def __init__(self, tagger):
         menu.Menu.__init__(self, tagger)
 
@@ -92,11 +97,26 @@ class GroupTaggerView(Gtk.TreeView):
     '''Treeview widget to display tag lists'''
 
     __gsignals__ = {
-
-        'category-changed': (GObject.SignalFlags.ACTION, None, (GObject.TYPE_PYOBJECT, GObject.TYPE_STRING)),
-        'category-edited': (GObject.SignalFlags.ACTION, None, (GObject.TYPE_STRING, GObject.TYPE_STRING)),
-        'group-changed': (GObject.SignalFlags.ACTION, None, (GObject.TYPE_PYOBJECT, GObject.TYPE_STRING)),
-        'group-edited': (GObject.SignalFlags.ACTION, None, (GObject.TYPE_STRING, GObject.TYPE_STRING)),
+        'category-changed': (
+            GObject.SignalFlags.ACTION,
+            None,
+            (GObject.TYPE_PYOBJECT, GObject.TYPE_STRING),
+        ),
+        'category-edited': (
+            GObject.SignalFlags.ACTION,
+            None,
+            (GObject.TYPE_STRING, GObject.TYPE_STRING),
+        ),
+        'group-changed': (
+            GObject.SignalFlags.ACTION,
+            None,
+            (GObject.TYPE_PYOBJECT, GObject.TYPE_STRING),
+        ),
+        'group-edited': (
+            GObject.SignalFlags.ACTION,
+            None,
+            (GObject.TYPE_STRING, GObject.TYPE_STRING),
+        ),
     }
 
     def __init__(self, exaile, model=None, editable=False):
@@ -131,7 +151,9 @@ class GroupTaggerView(Gtk.TreeView):
             cell.connect('edited', self.on_edit)
 
         self.text_column = cell
-        self.append_column(Gtk.TreeViewColumn(_('Tag'), self.text_column, text=1, weight=3))
+        self.append_column(
+            Gtk.TreeViewColumn(_('Tag'), self.text_column, text=1, weight=3)
+        )
 
         #
         # Menu setup
@@ -146,33 +168,52 @@ class GroupTaggerView(Gtk.TreeView):
 
         if editable:
 
-            item = smi('addgrp', [], _('Add new tag'),
-                       callback=self.on_menu_add_group)
+            item = smi('addgrp', [], _('Add new tag'), callback=self.on_menu_add_group)
             self.menu.add_item(item)
 
-            item = smi('delgrp', ['addgrp'], _('Delete tag'),
-                       callback=self.on_menu_delete_group,
-                       condition_fn=lambda n, p, c: False if len(c['groups']) == 0 else True)
+            item = smi(
+                'delgrp',
+                ['addgrp'],
+                _('Delete tag'),
+                callback=self.on_menu_delete_group,
+                condition_fn=lambda n, p, c: False if len(c['groups']) == 0 else True,
+            )
             self.menu.add_item(item)
 
             self.menu.add_item(sep('sep1', ['delgrp']))
 
-            item = smi('addcat', ['sep1'], _('Add new category'),
-                       callback=self.on_menu_add_category)
+            item = smi(
+                'addcat',
+                ['sep1'],
+                _('Add new category'),
+                callback=self.on_menu_add_category,
+            )
             self.menu.add_item(item)
 
-            item = smi('remcat', ['addcat'], _('Remove category'),
-                       callback=self.on_menu_del_category,
-                       condition_fn=lambda n, p, c: False if len(c['categories']) == 0 else True)
+            item = smi(
+                'remcat',
+                ['addcat'],
+                _('Remove category'),
+                callback=self.on_menu_del_category,
+                condition_fn=lambda n, p, c: False
+                if len(c['categories']) == 0
+                else True,
+            )
             self.menu.add_item(item)
 
             self.menu.add_item(sep('sep2', ['remcat']))
 
         self.menu.add_item(GTShowTracksMenuItem('sel', ['sep2']))
 
-        item = smi('selcust', ['sel'], _('Show tracks with selected (custom)'),
-                   callback=lambda w, n, p, c: gt_common.create_custom_search_playlist(c['groups'], exaile),
-                   condition_fn=lambda n, p, c: True if len(c['groups']) > 1 else False)
+        item = smi(
+            'selcust',
+            ['sel'],
+            _('Show tracks with selected (custom)'),
+            callback=lambda w, n, p, c: gt_common.create_custom_search_playlist(
+                c['groups'], exaile
+            ),
+            condition_fn=lambda n, p, c: True if len(c['groups']) > 1 else False,
+        )
         self.menu.add_item(item)
 
         # TODO:
@@ -194,9 +235,15 @@ class GroupTaggerView(Gtk.TreeView):
     def get_context(self):
         '''Returns context parameter required by menus'''
         context = common.LazyDict(self)
-        context['selected-rows'] = lambda name, parent: parent.get_selection().get_selected_rows()
-        context['groups'] = lambda name, parent: parent.get_selected_groups(context['selected-rows'])
-        context['categories'] = lambda name, parent: parent.get_selected_categories(context['selected-rows'])
+        context[
+            'selected-rows'
+        ] = lambda name, parent: parent.get_selection().get_selected_rows()
+        context['groups'] = lambda name, parent: parent.get_selected_groups(
+            context['selected-rows']
+        )
+        context['categories'] = lambda name, parent: parent.get_selected_categories(
+            context['selected-rows']
+        )
         return context
 
     def show_click_column(self):
@@ -233,7 +280,11 @@ class GroupTaggerView(Gtk.TreeView):
                 self.expand_to_path(path)
 
     def on_row_collapsed(self, widget, iter, path):
-        self.emit('category-changed', category_change.collapsed, self.get_model().get_category(path))
+        self.emit(
+            'category-changed',
+            category_change.collapsed,
+            self.get_model().get_category(path),
+        )
 
     def on_row_deleted(self, model, path):
         if self.get_model() and not model.is_category(path):
@@ -242,7 +293,11 @@ class GroupTaggerView(Gtk.TreeView):
                 self.emit('category-changed', category_change.updated, category)
 
     def on_row_expanded(self, widget, iter, path):
-        self.emit('category-changed', category_change.expanded, self.get_model().get_category(path))
+        self.emit(
+            'category-changed',
+            category_change.expanded,
+            self.get_model().get_category(path),
+        )
 
     def on_toggle(self, cell, path):
         self.get_model()[path][0] = not cell.get_active()
@@ -268,7 +323,7 @@ class GroupTaggerView(Gtk.TreeView):
                     self.emit('group-changed', group_change.added, group)
                 else:
                     self.emit('group-changed', group_change.edited, None)
-                    
+
                 self.emit('category-changed', category_change.updated, category)
 
     def on_menu_delete_group(self, widget, name, parent, context):
@@ -282,7 +337,9 @@ class GroupTaggerView(Gtk.TreeView):
 
     def on_menu_add_category(self, widget, name, parent, context):
         # TODO: instead of dialog, just add a new thing, make it editable?
-        input = dialogs.TextEntryDialog(_('New Category?'), _('Enter new category name'))
+        input = dialogs.TextEntryDialog(
+            _('New Category?'), _('Enter new category name')
+        )
 
         if input.run() == Gtk.ResponseType.OK:
             category = input.get_value()
@@ -340,10 +397,12 @@ class GroupTaggerTreeStore(Gtk.TreeStore, Gtk.TreeDragSource, Gtk.TreeDragDest):
     '''
 
     def __init__(self):
-        super(GroupTaggerTreeStore, self).__init__(GObject.TYPE_BOOLEAN,
-                                                   GObject.TYPE_STRING,
-                                                   GObject.TYPE_BOOLEAN,
-                                                   GObject.TYPE_INT)
+        super(GroupTaggerTreeStore, self).__init__(
+            GObject.TYPE_BOOLEAN,
+            GObject.TYPE_STRING,
+            GObject.TYPE_BOOLEAN,
+            GObject.TYPE_INT,
+        )
         self.set_sort_column_id(1, Gtk.SortType.ASCENDING)
 
     def add_category(self, category):
@@ -533,7 +592,9 @@ class GroupTaggerWidget(Gtk.Box):
         if title is None:
             self.title.hide()
         else:
-            self.title.set_markup('<big><b>' + GLib.markup_escape_text(title) + '</b></big>')
+            self.title.set_markup(
+                '<big><b>' + GLib.markup_escape_text(title) + '</b></big>'
+            )
             self.title.show()
 
     def set_artist(self, artist):
@@ -634,7 +695,6 @@ class GroupTaggerPanel(notebook.NotebookPage):
 
 
 class AllTagsListView(Gtk.TreeView):
-
     def __init__(self, model=None):
         Gtk.TreeView.__init__(self, model)
 
@@ -649,7 +709,9 @@ class AllTagsListView(Gtk.TreeView):
         self.append_column(Gtk.TreeViewColumn(None, cell, active=0))
 
         # Setup the second column
-        self.append_column(Gtk.TreeViewColumn(_('Group'), Gtk.CellRendererText(), text=1))
+        self.append_column(
+            Gtk.TreeViewColumn(_('Group'), Gtk.CellRendererText(), text=1)
+        )
 
         self.connect('key_press_event', self.on_key_press)
 
@@ -669,7 +731,6 @@ class AllTagsListView(Gtk.TreeView):
 
 
 class AllTagsListStore(Gtk.ListStore):
-
     def __init__(self):
         Gtk.ListStore.__init__(self, GObject.TYPE_BOOLEAN, GObject.TYPE_STRING)
         self.set_sort_column_id(1, Gtk.SortType.ASCENDING)
@@ -682,7 +743,6 @@ class AllTagsListStore(Gtk.ListStore):
 
 
 class AllTagsDialog(Gtk.Window):
-
     def __init__(self, exaile, callback):
 
         Gtk.Window.__init__(self)
@@ -744,7 +804,12 @@ class GroupTaggerQueryDialog(Gtk.Dialog):
             self.group_model.append([group])
 
         self.combo_model = Gtk.ListStore(GObject.TYPE_STRING)
-        self.choices = [_('Must have this tag [AND]'), _('May have this tag [OR]'), _('Must not have this tag [NOT]'), _('Ignored')]
+        self.choices = [
+            _('Must have this tag [AND]'),
+            _('May have this tag [OR]'),
+            _('Must not have this tag [NOT]'),
+            _('Ignored'),
+        ]
         for choice in self.choices:
             self.combo_model.append([choice])
 
@@ -775,7 +840,9 @@ class GroupTaggerQueryDialog(Gtk.Dialog):
 
         self.vbox.pack_start(self.table, True, True, 0)
 
-        self.add_buttons(Gtk.STOCK_OK, Gtk.ResponseType.OK, Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+        self.add_buttons(
+            Gtk.STOCK_OK, Gtk.ResponseType.OK, Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL
+        )
         self.show_all()
 
     def _init_combo(self, model):
@@ -794,7 +861,7 @@ class GroupTaggerQueryDialog(Gtk.Dialog):
     def get_search_params(self):
         '''Returns (name, search_string) from user selections'''
 
-        and_p = [[], '']        # groups, name, re_string
+        and_p = [[], '']  # groups, name, re_string
         or_p = [[], '']
         not_p = [[], '']
 
@@ -820,7 +887,12 @@ class GroupTaggerQueryDialog(Gtk.Dialog):
             name += ' and '.join(and_p[0])
             first = False
 
-            and_p[1] = ' '.join(['%s~"\\b%s\\b"' % (tagname, re.escape(group.replace(' ', '_'))) for group in and_p[0]])
+            and_p[1] = ' '.join(
+                [
+                    '%s~"\\b%s\\b"' % (tagname, re.escape(group.replace(' ', '_')))
+                    for group in and_p[0]
+                ]
+            )
 
         # create the NOT conditions
         if len(not_p[0]):
@@ -830,7 +902,15 @@ class GroupTaggerQueryDialog(Gtk.Dialog):
                 name += ' and ' + ' and '.join(['not ' + p for p in not_p[0]])
             first = False
 
-            not_p[1] = ' ! %s~"%s"' % (tagname, '|'.join(['\\b' + re.escape(group.replace(' ', '_')) + '\\b' for group in not_p[0]]))
+            not_p[1] = ' ! %s~"%s"' % (
+                tagname,
+                '|'.join(
+                    [
+                        '\\b' + re.escape(group.replace(' ', '_')) + '\\b'
+                        for group in not_p[0]
+                    ]
+                ),
+            )
 
         # create the OR conditions
         if len(or_p[0]):
@@ -841,7 +921,15 @@ class GroupTaggerQueryDialog(Gtk.Dialog):
             else:
                 name += ' and ' + ' or '.join(or_p[0])
 
-            or_p[1] = ' %s~"%s"' % (tagname, '|'.join(['\\b' + re.escape(group.replace(' ', '_')) + '\\b' for group in or_p[0]]))
+            or_p[1] = ' %s~"%s"' % (
+                tagname,
+                '|'.join(
+                    [
+                        '\\b' + re.escape(group.replace(' ', '_')) + '\\b'
+                        for group in or_p[0]
+                    ]
+                ),
+            )
 
         regex = (and_p[1] + or_p[1] + not_p[1]).strip()
 
@@ -849,7 +937,6 @@ class GroupTaggerQueryDialog(Gtk.Dialog):
 
 
 class GroupTaggerAddRemoveDialog(Gtk.Dialog):
-
     def __init__(self, add, tracks, exaile):
 
         self.add = add

--- a/plugins/helloworld/__init__.py
+++ b/plugins/helloworld/__init__.py
@@ -76,7 +76,6 @@ import testlib
 
 
 class HelloWorld(object):
-
     def enable(self, exaile):
         print("Hello, world!")
         testlib.sucess()

--- a/plugins/history/__init__.py
+++ b/plugins/history/__init__.py
@@ -30,13 +30,7 @@ import os
 import os.path
 import datetime
 
-from xl import (
-    event,
-    player,
-    providers,
-    settings,
-    xdg
-)
+from xl import event, player, providers, settings, xdg
 
 from xl.playlist import Playlist
 from xl.nls import gettext as _
@@ -60,7 +54,9 @@ class HistoryPlugin(object):
         self.exaile = exaile
 
     def on_gui_loaded(self):
-        save_on_exit = settings.get_option('plugin/history/save_on_exit', history_preferences.save_on_exit_default)
+        save_on_exit = settings.get_option(
+            'plugin/history/save_on_exit', history_preferences.save_on_exit_default
+        )
         shown = settings.get_option('plugin/history/shown', False)
 
         # immutable playlist that stores everything we've played
@@ -75,8 +71,13 @@ class HistoryPlugin(object):
         self.history_tab = NotebookTab(main.get_playlist_notebook(), self.history_page)
 
         # add menu item to 'view' to display our playlist
-        self.menu = menu.check_menu_item('history', '', _('Playback history'),
-                                         lambda *e: self.is_shown(), self.on_playback_history)
+        self.menu = menu.check_menu_item(
+            'history',
+            '',
+            _('Playback history'),
+            lambda *e: self.is_shown(),
+            self.on_playback_history,
+        )
 
         providers.register('menubar-view-menu', self.menu)
 
@@ -87,7 +88,9 @@ class HistoryPlugin(object):
     def teardown(self, exaile):
         '''Called when exaile is exiting'''
 
-        if settings.get_option('plugin/history/save_on_exit', history_preferences.save_on_exit_default):
+        if settings.get_option(
+            'plugin/history/save_on_exit', history_preferences.save_on_exit_default
+        ):
             self.history_playlist.save_to_location(self.history_loc)
             settings.set_option('plugin/history/shown', self.is_shown())
         else:
@@ -106,8 +109,13 @@ class HistoryPlugin(object):
         if os.path.exists(self.history_loc):
             # TODO: The parent should be the Preferences window, but we don't
             # have access to it, so this just uses the main window.
-            dialog = Gtk.MessageDialog(exaile.gui.main.window, Gtk.DialogFlags.MODAL, Gtk.MessageType.QUESTION, Gtk.ButtonsType.YES_NO,
-                                       _('Erase stored history?'))
+            dialog = Gtk.MessageDialog(
+                exaile.gui.main.window,
+                Gtk.DialogFlags.MODAL,
+                Gtk.MessageType.QUESTION,
+                Gtk.ButtonsType.YES_NO,
+                _('Erase stored history?'),
+            )
 
             if dialog.run() == Gtk.ResponseType.YES:
                 try:
@@ -133,6 +141,7 @@ class HistoryPlugin(object):
             pn.add_tab(self.history_tab, self.history_page)
         else:
             self.history_tab.close()
+
 
 plugin_class = HistoryPlugin
 
@@ -202,27 +211,49 @@ class HistoryPlaylistPage(PlaylistPageBase):
 def __create_history_tab_context_menu():
     smi = menu.simple_menu_item
     items = []
-    items.append(smi('save', [], _("Save History"), 'gtk-save',
-                     lambda w, n, o, c: o.save_history()))
-    items.append(smi('clear', ['save'], _("_Clear History"), 'gtk-clear',
-                     lambda w, n, o, c: o.playlist._clear()))
+    items.append(
+        smi(
+            'save',
+            [],
+            _("Save History"),
+            'gtk-save',
+            lambda w, n, o, c: o.save_history(),
+        )
+    )
+    items.append(
+        smi(
+            'clear',
+            ['save'],
+            _("_Clear History"),
+            'gtk-clear',
+            lambda w, n, o, c: o.playlist._clear(),
+        )
+    )
 
 
 class HistoryPlaylist(Playlist):
-
     def __init__(self, player):
         Playlist.__init__(self, _('History'))
 
         # catch the history
-        event.add_ui_callback(self.__on_playback_track_start, 'playback_track_start', player)
+        event.add_ui_callback(
+            self.__on_playback_track_start, 'playback_track_start', player
+        )
 
         if player.is_paused() or player.is_playing():
-            self.__on_playback_track_start('playback_track_start', player, player.current)
+            self.__on_playback_track_start(
+                'playback_track_start', player, player.current
+            )
 
     def __on_playback_track_start(self, event, player, track):
         '''Every time a track plays, add it to the playlist'''
 
-        maxlen = int(settings.get_option('plugin/history/history_length', history_preferences.history_length_default))
+        maxlen = int(
+            settings.get_option(
+                'plugin/history/history_length',
+                history_preferences.history_length_default,
+            )
+        )
         if maxlen < 0:
             maxlen = 0
             settings.set_option('plugin/history/history_length', 0)

--- a/plugins/icecast/__init__.py
+++ b/plugins/icecast/__init__.py
@@ -12,11 +12,7 @@ from urllib2 import urlparse
 from xml.dom import minidom
 
 from xl import common, event, playlist, xdg
-from xl.radio import (
-    RadioStation,
-    RadioList,
-    RadioItem,
-)
+from xl.radio import RadioStation, RadioList, RadioItem
 from xl.nls import gettext as _
 from xlgui.widgets import dialogs
 
@@ -47,6 +43,7 @@ def disable(exaile):
 
 def set_status(message, timeout=0):
     from xlgui.panel import radio
+
     radio.set_status(message, timeout)
 
 
@@ -64,6 +61,7 @@ class IcecastRadioStation(RadioStation):
         True
         >>>
     """
+
     name = 'icecast'
 
     def __init__(self, exaile):
@@ -113,25 +111,22 @@ class IcecastRadioStation(RadioStation):
             Returns the rlists for icecast
         """
         from xlgui.panel import radio
+
         if no_cache or not self.data:
             set_status(_('Contacting Icecast server...'))
             hostinfo = urlparse.urlparse(self.genre_url)
             try:
-                c = httplib.HTTPConnection(hostinfo.netloc,
-                                           timeout=20)
+                c = httplib.HTTPConnection(hostinfo.netloc, timeout=20)
             except TypeError:  # python 2.5 doesnt have timeout=
                 c = httplib.HTTPConnection(hostinfo.netloc)
             try:
-                c.request('GET', hostinfo.path, headers={'User-Agent':
-                                                         self.user_agent})
+                c.request('GET', hostinfo.path, headers={'User-Agent': self.user_agent})
                 response = c.getresponse()
             except (socket.timeout, socket.error):
-                raise radio.RadioException(
-                    _('Error connecting to Icecast server.'))
+                raise radio.RadioException(_('Error connecting to Icecast server.'))
 
             if response.status != 200:
-                raise radio.RadioException(
-                    _('Error connecting to Icecast server.'))
+                raise radio.RadioException(_('Error connecting to Icecast server.'))
 
             body = response.read()
             c.close()
@@ -158,8 +153,9 @@ class IcecastRadioStation(RadioStation):
 
         for item in data.keys():
             rlist = RadioList(item, station=self)
-            rlist.get_items = lambda no_cache, name=item: \
-                self._get_subrlists(name=name, no_cache=no_cache)
+            rlist.get_items = lambda no_cache, name=item: self._get_subrlists(
+                name=name, no_cache=no_cache
+            )
             rlists.append(rlist)
 
         sort_list = sorted([(item.name, item) for item in rlists])
@@ -222,16 +218,17 @@ class IcecastRadioStation(RadioStation):
         while thisPage < nextPage:
             thisPage += 1
             try:
-                c.request('GET', "%s?%s" % (hostinfo.path, query),
-                          headers={'User-Agent': self.user_agent})
+                c.request(
+                    'GET',
+                    "%s?%s" % (hostinfo.path, query),
+                    headers={'User-Agent': self.user_agent},
+                )
                 response = c.getresponse()
             except (socket.timeout, socket.error):
-                raise radio.RadioException(
-                    _('Error connecting to Icecast server.'))
+                raise radio.RadioException(_('Error connecting to Icecast server.'))
 
             if response.status != 200:
-                raise radio.RadioException(
-                    _('Error connecting to Icecast server.'))
+                raise radio.RadioException(_('Error connecting to Icecast server.'))
 
             body = response.read()
 
@@ -259,21 +256,27 @@ class IcecastRadioStation(RadioStation):
                                 anchors = td.getElementsByTagName('a')
                                 for anchor in anchors:
                                     href = anchor.getAttribute('href')
-                                    matcher = re.match('/listen/(\d+)/listen\.xspf\Z', href)
+                                    matcher = re.match(
+                                        '/listen/(\d+)/listen\.xspf\Z', href
+                                    )
                                     if matcher:
                                         sid = matcher.group(1)
                                         break
                                 paragraphs = td.getElementsByTagName('p')
                                 for paragraph in paragraphs:
                                     if paragraph.hasAttribute('title'):
-                                        quality = paragraph.getAttribute('title').split()
+                                        quality = paragraph.getAttribute(
+                                            'title'
+                                        ).split()
                                         if quality[0] == 'Quality':
                                             sbitrate = self._calc_bitrate(quality[1])
                                         elif len(quality[0]) > 3:
                                             sbitrate = str(int(quality[0]) / 1024)
                                         else:
                                             sbitrate = quality[0]
-                                        anchor = paragraph.getElementsByTagName('a').item(0)
+                                        anchor = paragraph.getElementsByTagName(
+                                            'a'
+                                        ).item(0)
                                         anchor.normalize()
                                         for text in anchor.childNodes:
                                             if text.nodeType == minidom.Node.TEXT_NODE:
@@ -288,7 +291,9 @@ class IcecastRadioStation(RadioStation):
                     for ul in uls:
                         if ul.getAttribute('class') == 'pager':
                             anchors = ul.getElementsByTagName('a')
-                            query = anchors.item(anchors.length - 1).getAttribute('href')
+                            query = anchors.item(anchors.length - 1).getAttribute(
+                                'href'
+                            )
                             matcher = re.match('\?(.*?page=(\d+))\Z', query)
                             query = matcher.group(1)
                             nextPage = int(matcher.group(2))
@@ -303,8 +308,9 @@ class IcecastRadioStation(RadioStation):
             rlist = RadioItem(item[0], station=self)
             rlist.bitrate = item[2]
             rlist.format = item[3]
-            rlist.get_playlist = lambda name=item[0], station_id=item[1]: \
-                self._get_playlist(name, station_id)
+            rlist.get_playlist = lambda name=item[0], station_id=item[
+                1
+            ]: self._get_playlist(name, station_id)
             rlists.append(rlist)
 
         return rlists
@@ -323,8 +329,9 @@ class IcecastRadioStation(RadioStation):
         """
             Called when the user wants to search for a specific stream
         """
-        dialog = dialogs.TextEntryDialog(_("Enter the search keywords"),
-                                         _("Icecast Search"))
+        dialog = dialogs.TextEntryDialog(
+            _("Enter the search keywords"), _("Icecast Search")
+        )
 
         result = dialog.run()
         if result == Gtk.ResponseType.OK:
@@ -389,7 +396,6 @@ class IcecastRadioStation(RadioStation):
 
 
 class ResultsDialog(dialogs.ListDialog):
-
     def __init__(self, title):
         dialogs.ListDialog.__init__(self, title)
         col = self.list.get_column(0)
@@ -400,12 +406,20 @@ class ResultsDialog(dialogs.ListDialog):
         text = Gtk.CellRendererText()
         text.set_property('xalign', 1.0)
         col = Gtk.TreeViewColumn(_('Bitrate'), text)
-        col.set_cell_data_func(text, lambda column, cell, model, iter:
-                               cell.set_property('text', model.get_value(iter, 0).bitrate))
+        col.set_cell_data_func(
+            text,
+            lambda column, cell, model, iter: cell.set_property(
+                'text', model.get_value(iter, 0).bitrate
+            ),
+        )
         self.list.append_column(col)
         text = Gtk.CellRendererText()
         text.set_property('xalign', 0.5)
         col = Gtk.TreeViewColumn(_('Format'), text)
-        col.set_cell_data_func(text, lambda column, cell, model, iter:
-                               cell.set_property('text', model.get_value(iter, 0).format))
+        col.set_cell_data_func(
+            text,
+            lambda column, cell, model, iter: cell.set_property(
+                'text', model.get_value(iter, 0).format
+            ),
+        )
         self.list.append_column(col)

--- a/plugins/inhibitsuspend/__init__.py
+++ b/plugins/inhibitsuspend/__init__.py
@@ -82,8 +82,10 @@ class SuspendInhibit(object):
             self.adapter = XfceAdapter()
         # TODO implement for LXDE, X-Cinnamon, Unity; systemd-inhibit
         elif session is '' and xdg_session is '':
-            logger.warning('Could not detect Desktop Session, will try default \
-                    Power Manager then Gnome')
+            logger.warning(
+                'Could not detect Desktop Session, will try default \
+                    Power Manager then Gnome'
+            )
             try:
                 self.adapter = PowerManagerAdapter()
             except EnvironmentError:
@@ -104,6 +106,7 @@ class SuspendAdapter(adapters.PlaybackAdapter):
 
         Thread safe
     """
+
     PROGRAM = 'exaile'
     ACTIVITY = 'playing-music'
 
@@ -218,9 +221,12 @@ class PowerManagerAdapter(SuspendAdapter):
         and have other small variances
     """
 
-    def __init__(self, bus_name='org.freedesktop.PowerManagement',
-                 object_name='/org/freedesktop/PowerManagement/Inhibit',
-                 interface_name='org.freedesktop.PowerManagement.Inhibit'):
+    def __init__(
+        self,
+        bus_name='org.freedesktop.PowerManagement',
+        object_name='/org/freedesktop/PowerManagement/Inhibit',
+        interface_name='org.freedesktop.PowerManagement.Inhibit',
+    ):
         SuspendAdapter.__init__(self, bus_name, object_name, interface_name)
 
     def _dbus_inhibit_call(self):
@@ -236,18 +242,24 @@ class GnomeAdapter(SuspendAdapter):
         but is has different bus name, object path and interface name
         The inhibit and uninhibit method signatures are also different
     """
+
     SUSPEND_FLAG = 8
 
     def __init__(self):
-        SuspendAdapter.__init__(self, 'org.gnome.SessionManager',
-                                '/org/gnome/SessionManager',
-                                'org.gnome.SessionManager')
+        SuspendAdapter.__init__(
+            self,
+            'org.gnome.SessionManager',
+            '/org/gnome/SessionManager',
+            'org.gnome.SessionManager',
+        )
 
     def _dbus_inhibit_call(self):
         """
             Gnome Interface has more paramters
         """
-        self.cookie = self.iface.Inhibit(self.PROGRAM, 1, self.ACTIVITY, self.SUSPEND_FLAG)
+        self.cookie = self.iface.Inhibit(
+            self.PROGRAM, 1, self.ACTIVITY, self.SUSPEND_FLAG
+        )
 
     def _dbus_uninhibit_call(self):
         """

--- a/plugins/ipconsole/__init__.py
+++ b/plugins/ipconsole/__init__.py
@@ -57,9 +57,9 @@ class Quitter(object):
         return 'Type %s() to exit.' % self.name
 
     def __call__(self):
-        self.exit_function()     # Passed in exit function
-        site.setquit()           # Restore default builtins
-        exit()                   # Call builtin
+        self.exit_function()  # Passed in exit function
+        site.setquit()  # Restore default builtins
+        exit()  # Call builtin
 
 
 class IPView(ip.IPythonView):
@@ -85,17 +85,18 @@ class IPView(ip.IPythonView):
         self.updateNamespace(namespace)  # expose exaile (passed in)
 
         # prevent exit and quit - freezes window? does bad things
-        self.updateNamespace({'exit': None,
-                              'quit': None})
+        self.updateNamespace({'exit': None, 'quit': None})
 
         style_context = self.get_style_context()
         self.__css_provider = Gtk.CssProvider()
-        style_context.add_provider(self.__css_provider,
-                                   Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        style_context.add_provider(
+            self.__css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
         # Trigger setup through options
         for option in ('text_color', 'background_color', 'font'):
-            self.__on_option_set(None, xl_settings,
-                                 'plugin/ipconsole/{option}'.format(option=option))
+            self.__on_option_set(
+                None, xl_settings, 'plugin/ipconsole/{option}'.format(option=option)
+            )
 
     def __on_option_set(self, _event, settings, option):
         if option == 'plugin/ipconsole/font':
@@ -106,26 +107,32 @@ class IPView(ip.IPythonView):
             rgba_str = settings.get_option(option, 'lavender')
             rgba = Gdk.RGBA()
             rgba.parse(rgba_str)
-            self.__text_color_str = "color: " \
-                + guiutil.css_from_rgba_without_alpha(rgba)
+            self.__text_color_str = "color: " + guiutil.css_from_rgba_without_alpha(
+                rgba
+            )
             GLib.idle_add(self.__update_css)
         if option == 'plugin/ipconsole/background_color':
             rgba_str = settings.get_option(option, 'black')
             rgba = Gdk.RGBA()
             rgba.parse(rgba_str)
-            self.__background_color_str = "background-color: " \
-                + guiutil.css_from_rgba_without_alpha(rgba)
+            self.__background_color_str = (
+                "background-color: " + guiutil.css_from_rgba_without_alpha(rgba)
+            )
             GLib.idle_add(self.__update_css)
 
     def __update_css(self):
-        if self.__text_color_str is None \
-                or self.__background_color_str is None \
-                or self.__font_str is None:
+        if (
+            self.__text_color_str is None
+            or self.__background_color_str is None
+            or self.__font_str is None
+        ):
             # early initialization state: not all properties have been initialized yet
             return False
 
         data_str = "text {%s; %s;} textview {%s;}" % (
-            self.__background_color_str, self.__text_color_str, self.__font_str
+            self.__background_color_str,
+            self.__text_color_str,
+            self.__font_str,
         )
         self.__css_provider.load_from_data(data_str)
         return False
@@ -201,8 +208,12 @@ class IPConsolePlugin(object):
             self.__show_console()
 
         # add menuitem to tools menu
-        item = menu.simple_menu_item('ipconsole', ['plugin-sep'], _('Show _IPython Console'),
-                                     callback=lambda *_args: self.__show_console())
+        item = menu.simple_menu_item(
+            'ipconsole',
+            ['plugin-sep'],
+            _('Show _IPython Console'),
+            callback=lambda *_args: self.__show_console(),
+        )
         providers.register('menubar-tools-menu', item)
 
     def teardown(self, _exaile):
@@ -230,12 +241,16 @@ class IPConsolePlugin(object):
         if self.__console_window is None:
             import xl
             import xlgui
+
             self.__console_window = IPythonConsoleWindow(
-                {'exaile': self.__exaile, 'xl': xl, 'xlgui': xlgui})
+                {'exaile': self.__exaile, 'xl': xl, 'xlgui': xlgui}
+            )
             self.__console_window.connect('destroy', self.__console_destroyed)
 
         self.__console_window.present()
-        self.__console_window.on_option_set(None, xl_settings, 'plugin/ipconsole/opacity')
+        self.__console_window.on_option_set(
+            None, xl_settings, 'plugin/ipconsole/opacity'
+        )
 
     def __console_destroyed(self, *_args):
         """

--- a/plugins/ipconsole/ipconsoleprefs.py
+++ b/plugins/ipconsole/ipconsoleprefs.py
@@ -36,7 +36,9 @@ class OpacityPreference(widgets.ScalePreference):
             self.set_widget_sensitive(False)
             # Setting opacity on Windows crashes with segfault,
             # see https://bugzilla.gnome.org/show_bug.cgi?id=674449
-            self.widget.set_tooltip(_("Opacity cannot be set on Windows due to a bug in Gtk+"))
+            self.widget.set_tooltip(
+                _("Opacity cannot be set on Windows due to a bug in Gtk+")
+            )
 
 
 class FontPreference(widgets.FontButtonPreference):

--- a/plugins/ipconsole/ipython_view.py
+++ b/plugins/ipconsole/ipython_view.py
@@ -126,6 +126,7 @@ class IterableIPShell(object):
         excepthook = sys.excepthook
 
         from IPython.config.loader import Config
+
         cfg = Config()
         cfg.InteractiveShell.colors = "Linux"
 
@@ -138,12 +139,14 @@ class IterableIPShell(object):
         # InteractiveShell inherits from SingletonConfigurable, so use instance()
         #
         self.IP = IPython.terminal.embed.InteractiveShellEmbed.instance(
-            config=cfg, user_ns=user_ns)
+            config=cfg, user_ns=user_ns
+        )
 
         sys.stdout, sys.stderr = old_stdout, old_stderr
 
-        self.IP.system = lambda cmd: self.shell(self.IP.var_expand(cmd),
-                                                header='IPython system call: ')
+        self.IP.system = lambda cmd: self.shell(
+            self.IP.var_expand(cmd), header='IPython system call: '
+        )
         # local_ns=user_ns)
         # global_ns=user_global_ns)
         # verbose=self.IP.rc.system_verbose)
@@ -163,6 +166,7 @@ class IterableIPShell(object):
 
         # help() is blocking, which hangs GTK+.
         import pydoc
+
         self.updateNamespace({'help': pydoc.doc})
 
     def __update_namespace(self):
@@ -209,8 +213,7 @@ class IterableIPShell(object):
             self.IP.input_splitter.push(line)
             self.iter_more = self.IP.input_splitter.push_accepts_more()
             self.prompt = self.generatePrompt(self.iter_more)
-            if (self.IP.SyntaxTB.last_syntax_error and
-                    self.IP.autoedit_syntax):
+            if self.IP.SyntaxTB.last_syntax_error and self.IP.autoedit_syntax:
                 self.IP.edit_syntax_error()
             if not self.iter_more:
                 source_raw = self.IP.input_splitter.raw_reset()
@@ -307,6 +310,7 @@ class IterableIPShell(object):
             completed = line
             possibilities = ['', []]
         if possibilities:
+
             def _commonPrefix(str1, str2):
                 '''
                 Reduction function. returns common prefix of two given strings.
@@ -320,12 +324,13 @@ class IterableIPShell(object):
                 @rtype: string
                 '''
                 for i in range(len(str1)):
-                    if not str2.startswith(str1[:i + 1]):
+                    if not str2.startswith(str1[: i + 1]):
                         return str1[:i]
                 return str1
+
             if possibilities[1]:
                 common_prefix = reduce(_commonPrefix, possibilities[1]) or line[-1]
-                completed = line[:-len(split_line[-1])] + common_prefix
+                completed = line[: -len(split_line[-1])] + common_prefix
             else:
                 completed = line
         else:
@@ -350,8 +355,13 @@ class IterableIPShell(object):
         # flush stdout so we don't mangle python's buffering
         if not debug:
             popen = subprocess.Popen(
-                cmd, bufsize=0, stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
+                cmd,
+                bufsize=0,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                close_fds=True,
+            )
             print((popen.stdout.read()))
 
 
@@ -371,14 +381,25 @@ class ConsoleView(Gtk.TextView):
     @ivar line_start: Start of command line mark.
     @type line_start: gtk.TextMark
     '''
-    ANSI_COLORS = {'0;30': 'Black', '0;31': 'Red',
-                   '0;32': 'Green', '0;33': 'Brown',
-                   '0;34': 'Blue', '0;35': 'Purple',
-                   '0;36': 'Cyan', '0;37': 'LightGray',
-                   '1;30': 'DarkGray', '1;31': 'DarkRed',
-                   '1;32': 'SeaGreen', '1;33': 'Yellow',
-                   '1;34': 'LightBlue', '1;35': 'MediumPurple',
-                   '1;36': 'LightCyan', '1;37': 'White'}
+
+    ANSI_COLORS = {
+        '0;30': 'Black',
+        '0;31': 'Red',
+        '0;32': 'Green',
+        '0;33': 'Brown',
+        '0;34': 'Blue',
+        '0;35': 'Purple',
+        '0;36': 'Cyan',
+        '0;37': 'LightGray',
+        '1;30': 'DarkGray',
+        '1;31': 'DarkRed',
+        '1;32': 'SeaGreen',
+        '1;33': 'Yellow',
+        '1;34': 'LightBlue',
+        '1;35': 'MediumPurple',
+        '1;36': 'LightCyan',
+        '1;37': 'White',
+    }
 
     def __init__(self):
         '''
@@ -389,15 +410,18 @@ class ConsoleView(Gtk.TextView):
         self.set_cursor_visible(True)
         self.text_buffer = self.get_buffer()
         self.mark = self.text_buffer.create_mark(
-            'scroll_mark', self.text_buffer.get_end_iter(), False)
+            'scroll_mark', self.text_buffer.get_end_iter(), False
+        )
         for code in self.ANSI_COLORS:
             self.text_buffer.create_tag(
-                code, foreground=self.ANSI_COLORS[code], weight=700)
+                code, foreground=self.ANSI_COLORS[code], weight=700
+            )
         self.text_buffer.create_tag('0')
         self.text_buffer.create_tag('notouch', editable=False)
         self.color_pat = re.compile(r'\x01?\x1b\[(.*?)m\x02?')
         self.line_start = self.text_buffer.create_mark(
-            'line_start', self.text_buffer.get_end_iter(), True)
+            'line_start', self.text_buffer.get_end_iter(), True
+        )
         self.connect('key-press-event', self.onKeyPress)
 
     def write(self, text, editable=False):
@@ -415,7 +439,8 @@ class ConsoleView(Gtk.TextView):
         segments = self.color_pat.split(text)
         segment = segments.pop(0)
         start_mark = self.text_buffer.create_mark(
-            None, self.text_buffer.get_end_iter(), True)
+            None, self.text_buffer.get_end_iter(), True
+        )
         self.text_buffer.insert(self.text_buffer.get_end_iter(), segment)
 
         if segments:
@@ -423,12 +448,15 @@ class ConsoleView(Gtk.TextView):
             for tag in ansi_tags:
                 i = segments.index(tag)
                 self.text_buffer.insert_with_tags_by_name(
-                    self.text_buffer.get_end_iter(), segments[i + 1], tag)
+                    self.text_buffer.get_end_iter(), segments[i + 1], tag
+                )
                 segments.pop(i)
         if not editable:
             self.text_buffer.apply_tag_by_name(
-                'notouch', self.text_buffer.get_iter_at_mark(start_mark),
-                self.text_buffer.get_end_iter())
+                'notouch',
+                self.text_buffer.get_iter_at_mark(start_mark),
+                self.text_buffer.get_end_iter(),
+            )
         self.text_buffer.delete_mark(start_mark)
         self.scroll_mark_onscreen(self.mark)
 
@@ -443,8 +471,7 @@ class ConsoleView(Gtk.TextView):
         @type prompt: string
         '''
         self._write(prompt)
-        self.text_buffer.move_mark(self.line_start,
-                                   self.text_buffer.get_end_iter())
+        self.text_buffer.move_mark(self.line_start, self.text_buffer.get_end_iter())
 
     def changeLine(self, text):
         GLib.idle_add(self._changeLine, text)
@@ -458,7 +485,9 @@ class ConsoleView(Gtk.TextView):
         '''
         text_iter = self.text_buffer.get_iter_at_mark(self.line_start)
         text_iter.forward_to_line_end()
-        self.text_buffer.delete(self.text_buffer.get_iter_at_mark(self.line_start), text_iter)
+        self.text_buffer.delete(
+            self.text_buffer.get_iter_at_mark(self.line_start), text_iter
+        )
         self._write(text, True)
 
     def getCurrentLine(self):
@@ -470,7 +499,9 @@ class ConsoleView(Gtk.TextView):
         '''
         rv = self.text_buffer.get_slice(
             self.text_buffer.get_iter_at_mark(self.line_start),
-            self.text_buffer.get_end_iter(), False)
+            self.text_buffer.get_end_iter(),
+            False,
+        )
         return rv
 
     def showReturned(self, text):
@@ -486,13 +517,12 @@ class ConsoleView(Gtk.TextView):
         text_iter = self.text_buffer.get_iter_at_mark(self.line_start)
         text_iter.forward_to_line_end()
         self.text_buffer.apply_tag_by_name(
-            'notouch',
-            self.text_buffer.get_iter_at_mark(self.line_start),
-            text_iter)
+            'notouch', self.text_buffer.get_iter_at_mark(self.line_start), text_iter
+        )
         self._write('\n' + text)
         if text:
             self._write('\n')
-        self._write('\n')    # Add extra line, like normal IPython
+        self._write('\n')  # Add extra line, like normal IPython
         self._showPrompt(self.prompt)
         self.text_buffer.move_mark(self.line_start, self.text_buffer.get_end_iter())
         self.text_buffer.place_cursor(self.text_buffer.get_end_iter())
@@ -521,8 +551,10 @@ class ConsoleView(Gtk.TextView):
         selection_iter = self.text_buffer.get_iter_at_mark(selection_mark)
         start_iter = self.text_buffer.get_iter_at_mark(self.line_start)
         if event.keyval == Gdk.KEY_Home:
-            if event.state & Gdk.ModifierType.CONTROL_MASK or \
-                    event.state & Gdk.ModifierType.MOD1_MASK:
+            if (
+                event.state & Gdk.ModifierType.CONTROL_MASK
+                or event.state & Gdk.ModifierType.MOD1_MASK
+            ):
                 pass
             elif event.state & Gdk.ModifierType.SHIFT_MASK:
                 self.text_buffer.move_mark(insert_mark, start_iter)
@@ -536,11 +568,15 @@ class ConsoleView(Gtk.TextView):
                 return True
         elif not event.string:
             pass
-        elif start_iter.compare(insert_iter) <= 0 and \
-                start_iter.compare(selection_iter) <= 0:
+        elif (
+            start_iter.compare(insert_iter) <= 0
+            and start_iter.compare(selection_iter) <= 0
+        ):
             pass
-        elif start_iter.compare(insert_iter) > 0 and \
-                start_iter.compare(selection_iter) > 0:
+        elif (
+            start_iter.compare(insert_iter) > 0
+            and start_iter.compare(selection_iter) > 0
+        ):
             self.text_buffer.place_cursor(start_iter)
         elif insert_iter.compare(selection_iter) < 0:
             self.text_buffer.move_mark(insert_mark, start_iter)
@@ -568,9 +604,10 @@ class IPythonView(ConsoleView, IterableIPShell):
         '''
         ConsoleView.__init__(self)
         self.cout = StringIO()
-        IterableIPShell.__init__(self, cout=self.cout, cerr=self.cout,
-                                 input_func=self.raw_input)
-#        self.connect('key_press_event', self.keyPress)
+        IterableIPShell.__init__(
+            self, cout=self.cout, cerr=self.cout, input_func=self.raw_input
+        )
+        #        self.connect('key_press_event', self.keyPress)
         self.interrupt = False
         self.execute()
         self.prompt = self.generatePrompt(False)

--- a/plugins/jamendo/__init__.py
+++ b/plugins/jamendo/__init__.py
@@ -33,19 +33,10 @@ import jamtree
 import jamapi
 import menu
 import os
-from xl import (
-    common,
-    event,
-    settings,
-    providers,
-    trax as xltrack,
-)
+from xl import common, event, settings, providers, trax as xltrack
 from xl.covers import CoverSearchMethod
 from xl.nls import gettext as _
-from xlgui import (
-    icons,
-    panel
-)
+from xlgui import icons, panel
 from xlgui.widgets.common import DragTreeView
 
 JAMENDO_NOTEBOOK_PAGE = None
@@ -53,7 +44,7 @@ COVERS_METHOD = None
 
 
 def enable(exaile):
-    if (exaile.loading):
+    if exaile.loading:
         event.add_callback(_enable, 'exaile_loaded')
     else:
         _enable(None, exaile, None)
@@ -131,49 +122,68 @@ class JamendoPanel(panel.Panel):
 
     # is called when the user wants to download something
     def download_selected(self):
-        print('It would be really cool if this worked, unfortunately I still need to implement it.')
+        print(
+            'It would be really cool if this worked, unfortunately I still need to implement it.'
+        )
 
     # initialise the widgets
     def setup_widgets(self):
         # connect to the signals we listen for
-        self.builder.connect_signals({
-            'search_entry_activated': self.on_search_entry_activated,
-            'search_entry_icon_release': self.clear_search_terms,
-            'refresh_button_clicked': self.on_search_entry_activated,
-            'search_combobox_changed': self.on_search_combobox_changed,
-            'ordertype_combobox_changed': self.on_ordertype_combobox_changed,
-            'orderdirection_combobox_changed': self.on_orderdirection_combobox_changed,
-            'results_combobox_changed': self.on_results_combobox_changed
-        })
+        self.builder.connect_signals(
+            {
+                'search_entry_activated': self.on_search_entry_activated,
+                'search_entry_icon_release': self.clear_search_terms,
+                'refresh_button_clicked': self.on_search_entry_activated,
+                'search_combobox_changed': self.on_search_combobox_changed,
+                'ordertype_combobox_changed': self.on_ordertype_combobox_changed,
+                'orderdirection_combobox_changed': self.on_orderdirection_combobox_changed,
+                'results_combobox_changed': self.on_results_combobox_changed,
+            }
+        )
 
         # set up the rightclick menu
         self.menu = menu.JamendoMenu(self)
 
         # setup images
         self.artist_image = icons.MANAGER.pixbuf_from_icon_name(
-            'artist', Gtk.IconSize.SMALL_TOOLBAR)
+            'artist', Gtk.IconSize.SMALL_TOOLBAR
+        )
         self.album_image = icons.MANAGER.pixbuf_from_icon_name(
-            'media-optical', Gtk.IconSize.SMALL_TOOLBAR)
+            'media-optical', Gtk.IconSize.SMALL_TOOLBAR
+        )
         self.title_image = icons.MANAGER.pixbuf_from_icon_name(
-            'audio-x-generic', Gtk.IconSize.SMALL_TOOLBAR)
+            'audio-x-generic', Gtk.IconSize.SMALL_TOOLBAR
+        )
 
         # setup search combobox
         self.search_combobox = self.builder.get_object('searchComboBox')
-        self.search_combobox.set_active(settings.get_option('plugin/jamendo/searchtype', 0))
+        self.search_combobox.set_active(
+            settings.get_option('plugin/jamendo/searchtype', 0)
+        )
 
         # get handle on search entrybox
         self.search_textentry = self.builder.get_object('searchEntry')
-        self.search_textentry.set_text(settings.get_option('plugin/jamendo/searchterms', ""))
+        self.search_textentry.set_text(
+            settings.get_option('plugin/jamendo/searchterms', "")
+        )
 
         # setup order_by comboboxes
         self.orderby_type_combobox = self.builder.get_object('orderTypeComboBox')
-        self.orderby_type_combobox.set_active(settings.get_option('plugin/jamendo/ordertype', 0))
-        self.orderby_direction_combobox = self.builder.get_object('orderDirectionComboBox')
-        self.orderby_direction_combobox.set_active(settings.get_option('plugin/jamendo/orderdirection', 0))
+        self.orderby_type_combobox.set_active(
+            settings.get_option('plugin/jamendo/ordertype', 0)
+        )
+        self.orderby_direction_combobox = self.builder.get_object(
+            'orderDirectionComboBox'
+        )
+        self.orderby_direction_combobox.set_active(
+            settings.get_option('plugin/jamendo/orderdirection', 0)
+        )
 
         # setup num_results combobox
         self.numresults_spinbutton = self.builder.get_object('numResultsSpinButton')
-        self.numresults_spinbutton.set_value(settings.get_option('plugin/jamendo/numresults', 10))
+        self.numresults_spinbutton.set_value(
+            settings.get_option('plugin/jamendo/numresults', 10)
+        )
 
         # setup status label
         self.status_label = self.builder.get_object('statusLabel')
@@ -241,7 +251,9 @@ class JamendoPanel(panel.Panel):
     def expand_artist(self, artist, add_to_playlist=False):
         self.set_status(self.STATUS_RETRIEVING_DATA)
         artist.expanded = True
-        jamapi_thread = jamapi.get_albums(artist, self.expand_artist_callback, add_to_playlist)
+        jamapi_thread = jamapi.get_albums(
+            artist, self.expand_artist_callback, add_to_playlist
+        )
         jamapi_thread.start()
 
     # Callback function for when the jamapi thread started in expand_artist() completes
@@ -249,7 +261,9 @@ class JamendoPanel(panel.Panel):
     def expand_artist_callback(self, artist, add_to_playlist=False):
         self.remove_dummy(artist)
         for album in artist.albums:
-            parent = self.model.append(artist.row_pointer, (self.album_image, album.name, album))
+            parent = self.model.append(
+                artist.row_pointer, (self.album_image, album.name, album)
+            )
             album.row_pointer = parent
             self.model.append(parent, (self.title_image, "", ""))
         if add_to_playlist:
@@ -263,7 +277,9 @@ class JamendoPanel(panel.Panel):
     def expand_album(self, album, add_to_playlist=False):
         self.set_status(self.STATUS_RETRIEVING_DATA)
         album.expanded = True
-        jamapi_thread = jamapi.get_tracks(album, self.expand_album_callback, add_to_playlist)
+        jamapi_thread = jamapi.get_tracks(
+            album, self.expand_album_callback, add_to_playlist
+        )
         jamapi_thread.start()
 
     # Callback function for when the jamapi thread started in expand_album() completes
@@ -271,9 +287,11 @@ class JamendoPanel(panel.Panel):
     def expand_album_callback(self, album, add_to_playlist=False):
         self.remove_dummy(album)
         for track in album.tracks:
-            parent = self.model.append(album.row_pointer, (self.title_image, track.name, track))
+            parent = self.model.append(
+                album.row_pointer, (self.title_image, track.name, track)
+            )
             track.row_pointer = parent
-        if (add_to_playlist):
+        if add_to_playlist:
             self.add_to_playlist()
         self.expand_node(album)
         self.set_status(self.STATUS_READY)
@@ -343,19 +361,27 @@ class JamendoPanel(panel.Panel):
         settings.set_option('plugin/jamendo/searchterms', search_term)
 
         if search_type == 'artist':
-            resultthread = jamapi.get_artist_list(search_term, orderby, numresults, self.response_callback)
+            resultthread = jamapi.get_artist_list(
+                search_term, orderby, numresults, self.response_callback
+            )
             resultthread.start()
 
         if search_type == 'album':
-            resultthread = jamapi.get_album_list(search_term, orderby, numresults, self.response_callback)
+            resultthread = jamapi.get_album_list(
+                search_term, orderby, numresults, self.response_callback
+            )
             resultthread.start()
 
         if search_type == 'genre_tags':
-            resultthread = jamapi.get_artist_list_by_genre(search_term, orderby, numresults, self.response_callback)
+            resultthread = jamapi.get_artist_list_by_genre(
+                search_term, orderby, numresults, self.response_callback
+            )
             resultthread.start()
 
         if search_type == 'track':
-            resultthread = jamapi.get_track_list(search_term, orderby, numresults, self.response_callback)
+            resultthread = jamapi.get_track_list(
+                search_term, orderby, numresults, self.response_callback
+            )
             resultthread.start()
 
     # clear the search box and results
@@ -389,9 +415,9 @@ class JamendoPanel(panel.Panel):
         xltrack_list = []
         for track in track_list:
             tr = xltrack.Track(track.url, scan=False)
-            tr.set_tags(title=track.name,
-                        artist=track.artist_name,
-                        album=track.album_name)
+            tr.set_tags(
+                title=track.name, artist=track.artist_name, album=track.album_name
+            )
             xltrack_list.append(tr)
         self.exaile.gui.main.get_selected_page().playlist.extend(xltrack_list)
 
@@ -405,13 +431,14 @@ class JamendoPanel(panel.Panel):
     def drag_get_data(self, treeview, context, selection, target_id, etime):
         self.add_to_playlist()
 
+
 # The following is a custom CoverSearchMethod to retrieve covers from Jamendo
 # It is designed to only to get covers for streaming tracks from jamendo
 
 
 class JamendoCoverSearch(CoverSearchMethod):
     name = 'jamendo'
-    use_cache = False   # do this since the tracks dont stay on local.
+    use_cache = False  # do this since the tracks dont stay on local.
     fixed = True
     fixed_priority = 5  # take precendence, since we know we are 'right'
     # for matching tracks.
@@ -423,8 +450,7 @@ class JamendoCoverSearch(CoverSearchMethod):
         jamendo_url = track.get_loc_for_io()
         # http://stream10.jamendo.com/stream/61541/ogg2/02%20-%20PieRreF%20-%20Hologram.ogg?u=0&h=f2b227d38d
         split = jamendo_url.split('/')
-        if len(split) > 5 and split[0] == 'http:' and \
-                split[2].endswith('.jamendo.com'):
+        if len(split) > 5 and split[0] == 'http:' and split[2].endswith('.jamendo.com'):
 
             track_num = split[4]
             image_url = jamapi.get_album_image_url_from_track(track_num)

--- a/plugins/jamendo/jamapi.py
+++ b/plugins/jamendo/jamapi.py
@@ -44,7 +44,6 @@ def get_json(url):
 
 # Gets a list of jamtree.Artist objects matching the specified criteria
 class get_artist_list(threading.Thread):
-
     def __init__(self, search_term, order_by, num_results, callback):
         threading.Thread.__init__(self)
         self.search_term = search_term
@@ -53,8 +52,11 @@ class get_artist_list(threading.Thread):
         self.callback = callback
 
     def run(self):
-        url = "http://api.jamendo.com/get2/name+id/artist/json/?searchquery=%s&order=%s&n=%s" % (self.search_term, self.order_by, self.num_results)
-        #print('get_artist_list: %s' % url)
+        url = (
+            "http://api.jamendo.com/get2/name+id/artist/json/?searchquery=%s&order=%s&n=%s"
+            % (self.search_term, self.order_by, self.num_results)
+        )
+        # print('get_artist_list: %s' % url)
         results = get_json(url)
         artists = []
         for result in results:
@@ -65,11 +67,11 @@ class get_artist_list(threading.Thread):
 
         self.callback(artists)
 
+
 # Gets a list of jamtree.Album objects matching the specified criteria
 
 
 class get_album_list(threading.Thread):
-
     def __init__(self, search_term, order_by, num_results, callback):
         threading.Thread.__init__(self)
         self.search_term = search_term
@@ -78,7 +80,10 @@ class get_album_list(threading.Thread):
         self.callback = callback
 
     def run(self):
-        url = "http://api.jamendo.com/get2/name+id/album/json/?searchquery=%s&order=%s&n=%s" % (self.search_term, self.order_by, self.num_results)
+        url = (
+            "http://api.jamendo.com/get2/name+id/album/json/?searchquery=%s&order=%s&n=%s"
+            % (self.search_term, self.order_by, self.num_results)
+        )
         results = get_json(url)
         albums = []
         for result in results:
@@ -90,11 +95,11 @@ class get_album_list(threading.Thread):
 
         self.callback(albums)
 
+
 # Gets a list of jamtree.Artist objects matching the specified criteria
 
 
 class get_artist_list_by_genre(threading.Thread):
-
     def __init__(self, search_term, order_by, num_results, callback):
         threading.Thread.__init__(self)
         self.search_term = search_term
@@ -103,7 +108,10 @@ class get_artist_list_by_genre(threading.Thread):
         self.callback = callback
 
     def run(self):
-        url = "http://api.jamendo.com/get2/name+id/artist/json/?tag_idstr=%s&order=%s&n=%s" % (self.search_term, self.order_by, self.num_results)
+        url = (
+            "http://api.jamendo.com/get2/name+id/artist/json/?tag_idstr=%s&order=%s&n=%s"
+            % (self.search_term, self.order_by, self.num_results)
+        )
         results = get_json(url)
         artists = []
         for result in results:
@@ -114,11 +122,11 @@ class get_artist_list_by_genre(threading.Thread):
 
         self.callback(artists)
 
+
 # Gets a list of jamtree.Track objects matching the specified criteria
 
 
 class get_track_list(threading.Thread):
-
     def __init__(self, search_term, order_by, num_results, callback):
         threading.Thread.__init__(self)
         self.search_term = search_term
@@ -127,10 +135,12 @@ class get_track_list(threading.Thread):
         self.callback = callback
 
     def run(self):
-        url = "http://api.jamendo.com/get2/id+name+stream+album_id+album_name/" \
-            "track/json/?searchquery=%s&order=%s&n=%s&streamencoding=ogg2" % (
-                self.search_term, self.order_by, self.num_results)
-        #print('get_track_list: %s' % url)
+        url = (
+            "http://api.jamendo.com/get2/id+name+stream+album_id+album_name/"
+            "track/json/?searchquery=%s&order=%s&n=%s&streamencoding=ogg2"
+            % (self.search_term, self.order_by, self.num_results)
+        )
+        # print('get_track_list: %s' % url)
         tracks = get_json(url)
         track_list = []
         for track in tracks:
@@ -145,7 +155,6 @@ class get_track_list(threading.Thread):
 
 # Gets a list of jamtree.Album objects for the specified jamtree.Artist
 class get_albums(threading.Thread):
-
     def __init__(self, artist, callback, add_to_playlist=False):
         threading.Thread.__init__(self)
         self._artist = artist
@@ -153,8 +162,11 @@ class get_albums(threading.Thread):
         self._add_to_playlist = add_to_playlist
 
     def run(self):
-        url = "http://api.jamendo.com/get2/id+name/album/json/?artist_id=%s" % self._artist.id
-        #print('get_albums: %s' % url)
+        url = (
+            "http://api.jamendo.com/get2/id+name/album/json/?artist_id=%s"
+            % self._artist.id
+        )
+        # print('get_albums: %s' % url)
         albumresults = get_json(url)
         for albumresult in albumresults:
             item = jamtree.Album(albumresult['id'], albumresult['name'].strip())
@@ -165,7 +177,6 @@ class get_albums(threading.Thread):
 
 # Gets a list of jamtree.Track objects for the specified jamtree.Album
 class get_tracks(threading.Thread):
-
     def __init__(self, album, callback, add_to_playlist=False):
         threading.Thread.__init__(self)
         self._album = album
@@ -173,18 +184,25 @@ class get_tracks(threading.Thread):
         self._add_to_playlist = add_to_playlist
 
     def run(self):
-        url = "http://api.jamendo.com/get2/id+name+stream/track/json/?album_id=%s&streamencoding=ogg2" % self._album.id
-        #print('get_tracks: %s' % url)
+        url = (
+            "http://api.jamendo.com/get2/id+name+stream/track/json/?album_id=%s&streamencoding=ogg2"
+            % self._album.id
+        )
+        # print('get_tracks: %s' % url)
         tracks = get_json(url)
         for track in tracks:
             item = jamtree.Track(track['id'], track['name'].strip(), track['stream'])
             self._album.add_track(item)
         self._callback(self._album, self._add_to_playlist)
 
+
 # Gets the URL for an album image based on a track id
 
 
 def get_album_image_url_from_track(track_id):
-    url = "http://api.jamendo.com/get2/album_image/track/json/?id=%s&album_imagesize=400" % track_id
+    url = (
+        "http://api.jamendo.com/get2/album_image/track/json/?id=%s&album_imagesize=400"
+        % track_id
+    )
     imageurl = get_json(url)
     return "".join(imageurl)

--- a/plugins/jamendo/jamtree.py
+++ b/plugins/jamendo/jamtree.py
@@ -26,7 +26,6 @@
 
 
 class TreeItem(object):
-
     def __init__(self, id, name, has_been_expanded=False):
         self._id = id
         self._name = name
@@ -63,7 +62,6 @@ class TreeItem(object):
 
 
 class Artist(TreeItem):
-
     def __init__(self, id, name, has_been_expanded=False):
         TreeItem.__init__(self, id, name, has_been_expanded)
         self._albums = []
@@ -81,7 +79,6 @@ class Artist(TreeItem):
 
 
 class Album(TreeItem):
-
     def __init__(self, id, name, has_been_expanded=False):
         TreeItem.__init__(self, id, name, has_been_expanded)
         self._tracks = []
@@ -107,7 +104,6 @@ class Album(TreeItem):
 
 
 class Track(TreeItem):
-
     def __init__(self, id, name, url):
         TreeItem.__init__(self, id, name)
         self._url = url

--- a/plugins/jamendo/menu.py
+++ b/plugins/jamendo/menu.py
@@ -4,12 +4,18 @@ from xlgui.widgets import menu
 
 
 class JamendoMenu(menu.Menu):
-
     def __init__(self, parent):
         menu.Menu.__init__(self, parent)
 
-        self.add_item(menu.simple_menu_item('append', [], _('Append to Current'), 'gtk-add',
-                                            callback=lambda *args: parent.add_to_playlist()))
+        self.add_item(
+            menu.simple_menu_item(
+                'append',
+                [],
+                _('Append to Current'),
+                'gtk-add',
+                callback=lambda *args: parent.add_to_playlist(),
+            )
+        )
 
         # self.add_item(menu.simple_menu_item('download', ['append'], _('Download to Library'), 'gtk-save',
         #                        callback=lambda *args: parent.add_to_playlist()))

--- a/plugins/keybinder/__init__.py
+++ b/plugins/keybinder/__init__.py
@@ -40,7 +40,6 @@ KEYS = [
 
 
 class KeybinderPlugin(object):
-
     def __init__(self):
         self.__exaile = None
 
@@ -54,8 +53,12 @@ class KeybinderPlugin(object):
         elif not guiutil.platform_is_x11():
             broken = True
         if broken:
-            raise Exception(_('Keybinder is not supported on this platform! '
-                              'It is only supported on X servers.'))
+            raise Exception(
+                _(
+                    'Keybinder is not supported on this platform! '
+                    'It is only supported on X servers.'
+                )
+            )
         self.__exaile = exaile
 
     def on_exaile_loaded(self):
@@ -79,15 +82,18 @@ class KeybinderPlugin(object):
 
 plugin_class = KeybinderPlugin
 
-def start_stop_playback (PLAYER, QUEUE):
+
+def start_stop_playback(PLAYER, QUEUE):
     '''Toggles pause if playing/paused, starts playback if stopped'''
     if PLAYER.is_paused() or PLAYER.is_playing():
         PLAYER.toggle_pause()
     else:
         QUEUE.play(track=QUEUE.get_current())
 
+
 def on_media_key(key, exaile):
     from xl.player import PLAYER, QUEUE
+
     {
         'XF86AudioPlay': lambda: start_stop_playback(PLAYER, QUEUE),
         'XF86AudioStop': PLAYER.stop,

--- a/plugins/lastfmcovers/__init__.py
+++ b/plugins/lastfmcovers/__init__.py
@@ -16,17 +16,13 @@
 #
 
 from urllib import quote_plus
+
 try:
     import xml.etree.cElementTree as ETree
 except ImportError:
     import xml.etree.ElementTree as ETree
 
-from xl import (
-    common,
-    covers,
-    event,
-    providers
-)
+from xl import common, covers, event, providers
 
 # Last.fm API Key for Exaile
 # if you reuse this code in a different application, please
@@ -57,6 +53,7 @@ class LastFMCoverSearch(covers.CoverSearchMethod):
     """
         Searches Last.fm for covers
     """
+
     name = 'lastfm'
     title = 'Last.fm'
     type = 'remote'  # fetches remotely as opposed to locally
@@ -72,9 +69,11 @@ class LastFMCoverSearch(covers.CoverSearchMethod):
         """
         # TODO: handle multi-valued fields better
         try:
-            (artist, album, title) = track.get_tag_raw('artist')[0], \
-                track.get_tag_raw('album')[0], \
-                track.get_tag_raw('title')[0]
+            (artist, album, title) = (
+                track.get_tag_raw('artist')[0],
+                track.get_tag_raw('album')[0],
+                track.get_tag_raw('title')[0],
+            )
         except TypeError:
             return []
 
@@ -83,9 +82,7 @@ class LastFMCoverSearch(covers.CoverSearchMethod):
 
         for type, value in (('album', album), ('track', title)):
             url = self.url.format(
-                type=type,
-                value=quote_plus(value.encode("utf-8")),
-                api_key=API_KEY
+                type=type, value=quote_plus(value.encode("utf-8")), api_key=API_KEY
             )
             try:
                 data = common.get_url_contents(url, self.user_agent)
@@ -98,9 +95,9 @@ class LastFMCoverSearch(covers.CoverSearchMethod):
                 continue
 
             for element in xml.getiterator(type):
-                if (element.find('artist').text == artist.encode("utf-8")):
+                if element.find('artist').text == artist.encode("utf-8"):
                     for sub_element in element.findall('image'):
-                        if (sub_element.attrib['size'] == 'extralarge'):
+                        if sub_element.attrib['size'] == 'extralarge':
                             url = sub_element.text
                             if url:
                                 return [url]

--- a/plugins/lastfmdynamic/__init__.py
+++ b/plugins/lastfmdynamic/__init__.py
@@ -34,6 +34,7 @@ from xl.dynamic import DynamicSource
 from xl import providers
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 LFMS = None
@@ -64,7 +65,10 @@ class LastfmSource(DynamicSource):
 
     def get_results(self, artist):
         ar = urllib.quote_plus(artist.encode('utf-8'))
-        url = 'http://ws.audioscrobbler.com/2.0/?method=artist.getsimilar&artist=%s&api_key=' + API_KEY
+        url = (
+            'http://ws.audioscrobbler.com/2.0/?method=artist.getsimilar&artist=%s&api_key='
+            + API_KEY
+        )
         try:
             f = urllib.urlopen(url % ar).read()
         except IOError:

--- a/plugins/lastfmlove/__init__.py
+++ b/plugins/lastfmlove/__init__.py
@@ -17,27 +17,15 @@ from gi.repository import Gtk
 
 import logging
 import os.path
-from threading import (
-    Thread,
-    Timer
-)
+from threading import Thread, Timer
 
 import pylast
 
-from xl import (
-    common,
-    event,
-    player,
-    providers,
-    settings
-)
+from xl import common, event, player, providers, settings
 from xl.nls import gettext as _
 from xlgui import icons
 from xlgui.widgets.menu import MenuItem
-from xlgui.widgets.playlist_columns import (
-    Column,
-    ColumnMenuItem
-)
+from xlgui.widgets.playlist_columns import Column, ColumnMenuItem
 
 import lastfmlove_preferences
 from cellrenderertoggleimage import CellRendererToggleImage
@@ -46,14 +34,13 @@ LASTFMLOVER = None
 logger = logging.getLogger(__name__)
 
 basedir = os.path.dirname(os.path.realpath(__file__))
-icons.MANAGER.add_icon_name_from_directory('love',
-                                           os.path.join(basedir, 'icons'))
-icons.MANAGER.add_icon_name_from_directory('send-receive',
-                                           os.path.join(basedir, 'icons'))
+icons.MANAGER.add_icon_name_from_directory('love', os.path.join(basedir, 'icons'))
+icons.MANAGER.add_icon_name_from_directory(
+    'send-receive', os.path.join(basedir, 'icons')
+)
 
 
 class LastFMPlugin(object):
-
     def enable(self, exaile):
         """
             Handles the deferred enable call
@@ -101,7 +88,7 @@ class LoveColumn(Column):
         lastfm_track = pylast.Track(
             track.get_tag_display('artist'),
             track.get_tag_display('title'),
-            self.last_fm_lover.network
+            self.last_fm_lover.network,
         )
         cellrenderer.props.active = lastfm_track in self.last_fm_lover.loved_tracks
 
@@ -140,8 +127,7 @@ class LoveMenuItem(MenuItem):
             Sets up the menu item
         """
         item = Gtk.ImageMenuItem.new_with_mnemonic(_('_Love This Track'))
-        item.set_image(Gtk.Image.new_from_icon_name(
-            'love', Gtk.IconSize.MENU))
+        item.set_image(Gtk.Image.new_from_icon_name('love', Gtk.IconSize.MENU))
 
         if self.get_tracks_function is not None:
             tracks = self.get_tracks_function()
@@ -157,7 +143,7 @@ class LoveMenuItem(MenuItem):
             lastfm_track = pylast.Track(
                 track.get_tag_display('artist'),
                 track.get_tag_display('title'),
-                self.__lastfmlover.network
+                self.__lastfmlover.network,
             )
 
             if lastfm_track in self.__lastfmlover.loved_tracks:
@@ -207,9 +193,7 @@ class LastFMLover(object):
             return []
 
         self.tray_menu_item = LoveMenuItem(
-            self,
-            after=['rating'],
-            get_tracks_function=get_tracks_function
+            self, after=['rating'], get_tracks_function=get_tracks_function
         )
 
         self.setup_network()
@@ -245,7 +229,7 @@ class LastFMLover(object):
                 api_key=settings.get_option('plugin/lastfmlove/api_key', 'K'),
                 api_secret=settings.get_option('plugin/lastfmlove/api_secret', 'S'),
                 username=settings.get_option('plugin/ascrobbler/user', ''),
-                password_hash=settings.get_option('plugin/ascrobbler/password', '')
+                password_hash=settings.get_option('plugin/ascrobbler/password', ''),
             )
             self.user = self.network.get_user(self.network.username)
         except Exception as e:
@@ -272,7 +256,7 @@ class LastFMLover(object):
 
         self.timer = Timer(
             settings.get_option('plugin/lastfmlove/refresh_interval', 3600),
-            self.get_loved_tracks
+            self.get_loved_tracks,
         )
         self.timer.daemon = True
         self.timer.start()
@@ -302,7 +286,7 @@ class LastFMLover(object):
         lastfm_track = pylast.Track(
             track.get_tag_display('artist'),
             track.get_tag_display('title'),
-            self.network
+            self.network,
         )
 
         if lastfm_track in self.loved_tracks:

--- a/plugins/lastfmlove/cellrenderertoggleimage.py
+++ b/plugins/lastfmlove/cellrenderertoggleimage.py
@@ -12,6 +12,7 @@ class CellRendererToggleImage(Gtk.CellRendererToggle):
     """
         Renders a toggleable state as an image
     """
+
     __gproperties__ = {
         'icon-name': (
             GObject.TYPE_STRING,
@@ -20,13 +21,13 @@ class CellRendererToggleImage(Gtk.CellRendererToggle):
             'property only has an effect if not overridden '
             'the "pixbuf" property.',
             '',
-            GObject.PARAM_READWRITE
+            GObject.PARAM_READWRITE,
         ),
         'pixbuf': (
             GdkPixbuf.Pixbuf,
             'pixbuf',
             'The pixbuf to render.',
-            GObject.PARAM_READWRITE
+            GObject.PARAM_READWRITE,
         ),
         'icon-size': (
             GObject.TYPE_UINT,
@@ -35,15 +36,15 @@ class CellRendererToggleImage(Gtk.CellRendererToggle):
             0,
             65535,
             Gtk.IconSize.SMALL_TOOLBAR,
-            GObject.PARAM_READWRITE
+            GObject.PARAM_READWRITE,
         ),
         'render-prelit': (
             GObject.TYPE_BOOLEAN,
             'render prelit',
             'Whether to render prelit states or not',
             True,
-            GObject.PARAM_READWRITE
-        )
+            GObject.PARAM_READWRITE,
+        ),
     }
 
     def __init__(self):
@@ -102,7 +103,9 @@ class CellRendererToggleImage(Gtk.CellRendererToggle):
         """
         # Get pixbuf from raw or name in that order
         if self.__pixbuf is None:
-            pixbuf = icons.MANAGER.pixbuf_from_icon_name(self.__icon_name, self.__icon_size)
+            pixbuf = icons.MANAGER.pixbuf_from_icon_name(
+                self.__icon_name, self.__icon_size
+            )
             if pixbuf is None:
                 return
             self.__pixbuf = pixbuf
@@ -114,22 +117,17 @@ class CellRendererToggleImage(Gtk.CellRendererToggle):
         self.__insensitive_pixbuf = self.__pixbuf.copy()
         # Render insensitive state
         self.__pixbuf.saturate_and_pixelate(
-            dest=self.__insensitive_pixbuf,
-            saturation=1,
-            pixelate=True
+            dest=self.__insensitive_pixbuf, saturation=1, pixelate=True
         )
 
         if self.__render_prelit:
             self.__prelit_pixbuf = self.__pixbuf.copy()
             # Desaturate the active pixbuf
             self.__pixbuf.saturate_and_pixelate(
-                dest=self.__prelit_pixbuf,
-                saturation=0,
-                pixelate=False
+                dest=self.__prelit_pixbuf, saturation=0, pixelate=False
             )
 
-    def do_render(self, window, widget, background_area,
-                  cell_area, expose_area, flags):
+    def do_render(self, window, widget, background_area, cell_area, expose_area, flags):
         """
             Renders a custom toggle image
         """
@@ -155,13 +153,9 @@ class CellRendererToggleImage(Gtk.CellRendererToggle):
             area_x, area_y, area_width, area_height = cell_area
 
             # Make sure to properly align the pixbuf
-            x = area_x + \
-                area_width * self.props.xalign - \
-                self.__pixbuf_width / 2
+            x = area_x + area_width * self.props.xalign - self.__pixbuf_width / 2
 
-            y = area_y + \
-                area_height * self.props.yalign - \
-                self.__pixbuf_height / 2
+            y = area_y + area_height * self.props.yalign - self.__pixbuf_height / 2
 
             context = window.cairo_create()
             context.set_source_pixbuf(pixbuf, x, y)

--- a/plugins/lastfmlove/lastfmlove_preferences.py
+++ b/plugins/lastfmlove/lastfmlove_preferences.py
@@ -23,10 +23,7 @@ import os.path
 import pylast
 
 from xl.nls import gettext as _
-from xl import (
-    common,
-    settings
-)
+from xl import common, settings
 from xlgui import icons
 from xlgui.preferences import widgets
 from xlgui.widgets import dialogs
@@ -34,8 +31,7 @@ from xlgui.widgets import dialogs
 name = _('Last.fm Loved Tracks')
 basedir = os.path.dirname(os.path.realpath(__file__))
 ui = os.path.join(basedir, "lastfmlove_preferences.ui")
-icons.MANAGER.add_icon_name_from_directory('lastfm',
-                                           os.path.join(basedir, 'icons'))
+icons.MANAGER.add_icon_name_from_directory('lastfm', os.path.join(basedir, 'icons'))
 icon = 'lastfm'
 
 
@@ -58,11 +54,9 @@ class RequestAccessPermissionButton(widgets.Button):
 
         self.message = dialogs.MessageBar(
             parent=preferences.builder.get_object('preferences_box'),
-            buttons=Gtk.ButtonsType.CLOSE
+            buttons=Gtk.ButtonsType.CLOSE,
         )
-        self.errors = {
-            pylast.STATUS_INVALID_API_KEY: _('The API key is invalid.')
-        }
+        self.errors = {pylast.STATUS_INVALID_API_KEY: _('The API key is invalid.')}
 
     @common.threaded
     def check_connection(self):
@@ -77,19 +71,19 @@ class RequestAccessPermissionButton(widgets.Button):
                 api_key=api_key,
                 api_secret=settings.get_option('plugin/lastfmlove/api_secret', 'S'),
                 username=settings.get_option('plugin/ascrobbler/user', ''),
-                password_hash=settings.get_option('plugin/ascrobbler/password', '')
+                password_hash=settings.get_option('plugin/ascrobbler/password', ''),
             )
         except pylast.WSError as e:
             GLib.idle_add(
                 self.message.show_error,
                 self.errors[int(e.get_id())],
-                _('Please make sure the entered data is correct.')
+                _('Please make sure the entered data is correct.'),
             )
         else:
             application_launched = Gtk.show_uri(
                 Gdk.Screen.get_default(),
                 'http://www.last.fm/api/auth?api_key={0}'.format(api_key),
-                Gdk.CURRENT_TIME
+                Gdk.CURRENT_TIME,
             )
 
             if not application_launched:
@@ -97,9 +91,11 @@ class RequestAccessPermissionButton(widgets.Button):
                 GLib.idle_add(
                     self.message.show_warning,
                     _('Could not start web browser'),
-                    _('Please copy the following URL and '
-                      'open it with your web browser:\n'
-                      '<b><a href="{url}">{url}</a></b>').format(url=url)
+                    _(
+                        'Please copy the following URL and '
+                        'open it with your web browser:\n'
+                        '<b><a href="{url}">{url}</a></b>'
+                    ).format(url=url),
                 )
 
     def on_clicked(self, button):

--- a/plugins/librivox/__init__.py
+++ b/plugins/librivox/__init__.py
@@ -27,18 +27,8 @@ import os
 
 import librivoxsearch as LS
 import about_window as AW
-from xl import (
-    common,
-    event,
-    providers,
-    settings,
-    trax,
-)
-from xlgui import (
-    guiutil,
-    icons,
-    main
-)
+from xl import common, event, providers, settings, trax
+from xlgui import guiutil, icons, main
 from xlgui.widgets.common import DragTreeView
 from xlgui.widgets.notebook import NotebookPage
 
@@ -65,8 +55,7 @@ def disable(exaile):
     providers.unregister('main-panel', LVPANEL)
 
 
-class LVPanel():
-
+class LVPanel:
     def on_search(self, widget):
         self.run_search(widget)
 
@@ -106,16 +95,19 @@ class LVPanel():
 
     def __init__(self, exaile):
 
-        self.name = 'librivox'   # needed for panel provider
+        self.name = 'librivox'  # needed for panel provider
         self._panel = None
 
         self._user_agent = exaile.get_user_agent_string('librivox')
 
         self.librivoxdir = os.path.dirname(__file__)
         self.abicon = GdkPixbuf.Pixbuf.new_from_file(self.librivoxdir + '/ebook.png')
-        self.clock_icon = GdkPixbuf.Pixbuf.new_from_file(self.librivoxdir + '/clock.png')
+        self.clock_icon = GdkPixbuf.Pixbuf.new_from_file(
+            self.librivoxdir + '/clock.png'
+        )
         self.chapter_icon = icons.MANAGER.pixbuf_from_icon_name(
-            'audio-x-generic', Gtk.IconSize.SMALL_TOOLBAR)
+            'audio-x-generic', Gtk.IconSize.SMALL_TOOLBAR
+        )
         self.gui_init(exaile)
         self.connect_events()
         self.getting_info = False
@@ -153,6 +145,7 @@ class LVPanel():
         self.cell = Gtk.CellRendererText()
         if settings.get_option('gui/ellipsize_text_in_panels', False):
             from gi.repository import Pango
+
             self.cell.set_property('ellipsize-set', True)
             self.cell.set_property('ellipsize', Pango.EllipsizeMode.END)
         self.cellpb = Gtk.CellRendererPixbuf()
@@ -163,7 +156,11 @@ class LVPanel():
         self.treeview.append_column(self.column)
         self.treeview.connect("row-expanded", self.on_row_exp)
 
-        self.treeview.drag_source_set(Gdk.ModifierType.BUTTON1_MASK, [Gtk.TargetEntry.new('text/uri-list', 0, 0)], Gdk.DragAction.COPY)
+        self.treeview.drag_source_set(
+            Gdk.ModifierType.BUTTON1_MASK,
+            [Gtk.TargetEntry.new('text/uri-list', 0, 0)],
+            Gdk.DragAction.COPY,
+        )
         self.treeview.connect("drag-data-get", self.drag_data_get)
         self.scrlw.add(self.treeview)
 
@@ -172,9 +169,13 @@ class LVPanel():
 
         self.popup_menu = Gtk.Menu()
         self.add_to_pl = Gtk.ImageMenuItem.new_with_label("Append to Current")
-        self.add_to_pl.set_image(Gtk.Image.new_from_icon_name('list-add', Gtk.IconSize.MENU))
+        self.add_to_pl.set_image(
+            Gtk.Image.new_from_icon_name('list-add', Gtk.IconSize.MENU)
+        )
         self.about_book = Gtk.ImageMenuItem.new_with_label("About the Book")
-        self.about_book.set_image(Gtk.Image.new_from_icon_name('help-about', Gtk.IconSize.MENU))
+        self.about_book.set_image(
+            Gtk.Image.new_from_icon_name('help-about', Gtk.IconSize.MENU)
+        )
         self.popup_menu.add(self.add_to_pl)
         self.popup_menu.add(self.about_book)
         self.popup_menu.show_all()
@@ -192,9 +193,9 @@ class LVPanel():
         tracks = []
         for chapter in chapters:
             chapter_track = trax.Track(chapter[1])
-            chapter_track.set_tags(artist='Librivox.org',
-                                   title=chapter[0],
-                                   album='Audiobook')
+            chapter_track.set_tags(
+                artist='Librivox.org', title=chapter[0], album='Audiobook'
+            )
             tracks.append(chapter_track)
         return tracks
 
@@ -240,7 +241,9 @@ class LVPanel():
         self.treestore.clear()
         for book in books:
             self.rowlvl1 = self.treestore.append(None, [book.title, self.abicon])
-            self.rowlvl2 = self.treestore.append(self.rowlvl1, ["Loading...", self.clock_icon])
+            self.rowlvl2 = self.treestore.append(
+                self.rowlvl1, ["Loading...", self.clock_icon]
+            )
 
     def drag_data_get(self, treeview, context, selection, info, timestamp):
         path = self.treeview.get_cursor()[0]
@@ -276,7 +279,7 @@ class LVPanel():
 
                 if drop_info:
                     PLpath, position = drop_info
-                    if (position == Gtk.TreeViewDropPosition.AFTER):
+                    if position == Gtk.TreeViewDropPosition.AFTER:
                         after = True
                     else:
                         after = False
@@ -365,7 +368,7 @@ class LVPanel():
         return self._panel
 
 
-class Status():
+class Status:
     '''Status bar'''
 
     def __init__(self):

--- a/plugins/librivox/about_window.py
+++ b/plugins/librivox/about_window.py
@@ -18,8 +18,7 @@ from gi.repository import Gtk
 from gi.repository import Pango
 
 
-class AboutWindow():
-
+class AboutWindow:
     def __init__(self):
 
         self.book = None
@@ -55,7 +54,9 @@ class AboutWindow():
 
         self.closebutton = Gtk.Button("Close")
         self.closebutton.connect("pressed", self.closebutton_pressed)
-        self.closeimage = Gtk.Image.new_from_icon_name('window-close', Gtk.IconSize.MENU)
+        self.closeimage = Gtk.Image.new_from_icon_name(
+            'window-close', Gtk.IconSize.MENU
+        )
         self.closebutton.set_image(self.closeimage)
         self.hbox.pack_end(self.closebutton, False, False)
 

--- a/plugins/librivox/librivoxsearch.py
+++ b/plugins/librivox/librivoxsearch.py
@@ -18,6 +18,7 @@ import urllib
 from xml.etree import ElementTree
 from xl import common
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,8 +27,7 @@ logger = logging.getLogger(__name__)
 search_url = 'https://librivox.org/api/feed/audiobooks/?title='
 
 
-class Book():
-
+class Book:
     def __init__(self, title, rssurl, user_agent):
         self.title = title
         self.rssurl = rssurl
@@ -64,7 +64,9 @@ class Book():
         for item in items:
             title = item.find("title").text
             link = item.find("link").text
-            duration = item.find("{http://www.itunes.com/dtds/podcast-1.0.dtd}duration").text
+            duration = item.find(
+                "{http://www.itunes.com/dtds/podcast-1.0.dtd}duration"
+            ).text
             if duration is None:
                 duration = 'Unknown length'
             link = link.replace("_64kb.mp3", ".ogg")

--- a/plugins/list.py
+++ b/plugins/list.py
@@ -18,6 +18,7 @@ def scan():
     main = good - extra
     return locals()
 
+
 plugins = scan()
 
 
@@ -25,6 +26,7 @@ def parse(argv):
     if len(argv) == 1:
         return plugins['all']
     return plugins[argv[1]]
+
 
 if __name__ == '__main__':
     names = sorted(parse(sys.argv))

--- a/plugins/lyricsmania/__init__.py
+++ b/plugins/lyricsmania/__init__.py
@@ -20,10 +20,7 @@ except ImportError:
 
 import re
 
-from xl.lyrics import (
-    LyricSearchMethod,
-    LyricsNotFoundException
-)
+from xl.lyrics import LyricSearchMethod, LyricsNotFoundException
 from xl import common, providers
 
 
@@ -40,8 +37,7 @@ def enable(exaile):
 
 
 def disable(exaile):
-    providers.unregister('lyrics', providers.get_provider('lyrics',
-                                                          'lyricsmania'))
+    providers.unregister('lyrics', providers.get_provider('lyrics', 'lyricsmania'))
 
 
 class LyricsMania(LyricSearchMethod):
@@ -54,8 +50,10 @@ class LyricsMania(LyricSearchMethod):
 
     def find_lyrics(self, track):
         try:
-            (artist, title) = track.get_tag_raw('artist')[0].encode("utf-8"), \
-                track.get_tag_raw('title')[0].encode("utf-8")
+            (artist, title) = (
+                track.get_tag_raw('artist')[0].encode("utf-8"),
+                track.get_tag_raw('title')[0].encode("utf-8"),
+            )
         except TypeError:
             raise LyricsNotFoundException
 

--- a/plugins/lyricwiki/__init__.py
+++ b/plugins/lyricwiki/__init__.py
@@ -6,10 +6,7 @@ import HTMLParser
 import re
 import urllib
 
-from xl.lyrics import (
-    LyricSearchMethod,
-    LyricsNotFoundException
-)
+from xl.lyrics import LyricSearchMethod, LyricsNotFoundException
 from xl import common, providers
 
 
@@ -39,8 +36,10 @@ class LyricWiki(LyricSearchMethod):
 
     def find_lyrics(self, track):
         try:
-            (artist, title) = track.get_tag_raw('artist')[0].encode("utf-8"), \
-                track.get_tag_raw('title')[0].encode("utf-8")
+            (artist, title) = (
+                track.get_tag_raw('artist')[0].encode("utf-8"),
+                track.get_tag_raw('title')[0].encode("utf-8"),
+            )
         except TypeError:
             raise LyricsNotFoundException
 
@@ -64,7 +63,9 @@ class LyricWiki(LyricSearchMethod):
         lyrics = soup.findAll(attrs={"class": "lyricbox"})
         if lyrics:
             with_div = lyrics[0].renderContents().replace('<br />', '\n')
-            string = '\n'.join(self.remove_div(with_div).replace('\n\n\n', '').split('\n'))
+            string = '\n'.join(
+                self.remove_div(with_div).replace('\n\n\n', '').split('\n')
+            )
             lyrics = re.sub(r' Send.*?Ringtone to your Cell ', '', string)
         else:
             raise LyricsNotFoundException

--- a/plugins/mainmenubutton/__init__.py
+++ b/plugins/mainmenubutton/__init__.py
@@ -65,6 +65,7 @@ def on_gui_loaded(*args):
 class MainMenuButton(Gtk.ToggleButton, notebook.NotebookAction):
     """
     """
+
     __gsignals__ = {}
 
     name = 'main-menu'
@@ -103,7 +104,9 @@ class MainMenuButton(Gtk.ToggleButton, notebook.NotebookAction):
 
         self.connect('toggled', self.on_toggled)
 
-        self.notebook_page_removed_connection = panel_notebook.connect('page-removed', self.on_notebook_page_removed)
+        self.notebook_page_removed_connection = panel_notebook.connect(
+            'page-removed', self.on_notebook_page_removed
+        )
 
     def destroy(self):
         """
@@ -127,11 +130,7 @@ class MainMenuButton(Gtk.ToggleButton, notebook.NotebookAction):
 
         allocation = self.get_allocation()
 
-        return (
-            x + allocation.x + allocation.width,
-            y + allocation.y,
-            False
-        )
+        return (x + allocation.x + allocation.width, y + allocation.y, False)
 
     def do_button_press_event(self, e):
         """
@@ -155,8 +154,9 @@ class MainMenuButton(Gtk.ToggleButton, notebook.NotebookAction):
         """
             Pops out the menu upon button toggle
         """
-        self.menu.popup(None, None, self.get_menu_position, None, 0,
-                        Gtk.get_current_event_time())
+        self.menu.popup(
+            None, None, self.get_menu_position, None, 0, Gtk.get_current_event_time()
+        )
 
     def on_menu_deactivate(self, menu):
         """

--- a/plugins/massstorage/__init__.py
+++ b/plugins/massstorage/__init__.py
@@ -30,6 +30,7 @@ from xl.devices import Device
 import dbus
 import logging
 import os
+
 logger = logging.getLogger(__name__)
 
 PROVIDER = None
@@ -48,7 +49,6 @@ def disable(exaile):
 
 
 class MassStorageDevice(Device):
-
     def __init__(self, mountpoints, name=""):
         if len(mountpoints) == 0:
             raise ValueError("Must specify at least one mount point")
@@ -59,15 +59,17 @@ class MassStorageDevice(Device):
         self.mountpoints = []
 
     def connect(self):
-        self.mountpoints = [str(x) for x in self._mountpoints if
-                            str(x) is not "" and os.path.exists(unicode(x))]
+        self.mountpoints = [
+            str(x)
+            for x in self._mountpoints
+            if str(x) is not "" and os.path.exists(unicode(x))
+        ]
         if self.mountpoints == []:
             raise IOError("Device is not mounted.")
         for mountpoint in self.mountpoints:
             library = self.library_class(mountpoint)
             self.collection.add_library(library)
-        self.transfer = collection.TransferQueue(
-            self.collection.get_libraries()[0])
+        self.transfer = collection.TransferQueue(self.collection.get_libraries()[0])
         self.connected = True  # set this here so the UI can react
 
     def disconnect(self):
@@ -104,7 +106,8 @@ class MassStorageHandler(Handler):
         if "portable_audio_player" in capabilities:
             try:
                 if "storage" in device.GetProperty(
-                        "portable_audio_player.access_method.protocols"):
+                    "portable_audio_player.access_method.protocols"
+                ):
                     return 10
             except dbus.exceptions.DBusException as e:
                 if not e.get_dbus_name() == "org.freedesktop.Hal.NoSuchProperty":
@@ -118,9 +121,10 @@ class MassStorageHandler(Handler):
             dev_obj = hal.bus.get_object("org.freedesktop.Hal", udi)
             device = dbus.Interface(dev_obj, "org.freedesktop.Hal.Device")
             if device.PropertyExists(
-                    "portable_audio_player.access_method.protocols") and \
-                    "storage" in device.GetProperty(
-                    "portable_audio_player.access_method.protocols"):
+                "portable_audio_player.access_method.protocols"
+            ) and "storage" in device.GetProperty(
+                "portable_audio_player.access_method.protocols"
+            ):
                 ret.append(udi)
         return ret
 
@@ -128,14 +132,14 @@ class MassStorageHandler(Handler):
         mass_obj = hal.bus.get_object("org.freedesktop.Hal", udi)
         mass = dbus.Interface(mass_obj, "org.freedesktop.Hal.Device")
         if "storage" not in mass.GetProperty(
-                "portable_audio_player.access_method.protocols"):
+            "portable_audio_player.access_method.protocols"
+        ):
             return
 
         u = mass.GetProperty("portable_audio_player.storage_device")
         mountpoints = [HalMountpoint(hal, u)]
 
-        name = mass.GetProperty("info.vendor") + " " + \
-            mass.GetProperty("info.product")
+        name = mass.GetProperty("info.vendor") + " " + mass.GetProperty("info.product")
         massdev = MassStorageDevice(mountpoints, name)
 
         return massdev

--- a/plugins/minimode/__init__.py
+++ b/plugins/minimode/__init__.py
@@ -79,6 +79,7 @@ class MiniMode(Gtk.Window):
     """
         Mini Mode main window
     """
+
     __gsignals__ = {'show': 'override'}
 
     def __init__(self, exaile):
@@ -100,19 +101,24 @@ class MiniMode(Gtk.Window):
         self.border_frame.add(self.box)
         self.add(self.border_frame)
 
-        self.accelerator = Accelerator('<Primary><Alt>M', _('Mini Mode'),
-                                       self.on_menuitem_activate)
+        self.accelerator = Accelerator(
+            '<Primary><Alt>M', _('Mini Mode'), self.on_menuitem_activate
+        )
 
         self.menuitem = menu.simple_menu_item(
-            'minimode', ['clear-playlist'], icon_name='exaile-minimode',
-            callback=self.accelerator)
-        
+            'minimode',
+            ['clear-playlist'],
+            icon_name='exaile-minimode',
+            callback=self.accelerator,
+        )
+
         providers.register('menubar-view-menu', self.menuitem)
         providers.register('mainwindow-accelerators', self.accelerator)
 
         self.mainbutton = Gtk.Button(label=_('Mini Mode'))
-        self.mainbutton.set_image(Gtk.Image.new_from_icon_name(
-            'exaile-minimode', Gtk.IconSize.BUTTON))
+        self.mainbutton.set_image(
+            Gtk.Image.new_from_icon_name('exaile-minimode', Gtk.IconSize.BUTTON)
+        )
         self.mainbutton.connect('clicked', self.on_mainbutton_clicked)
         action_area = exaile.gui.main.info_area.get_action_area()
         action_area.pack_end(self.mainbutton, False, False, 6)
@@ -129,14 +135,16 @@ class MiniMode(Gtk.Window):
             'plugin/minimode/use_alpha': False,
             'plugin/minimode/transparency': 0.3,
             'plugin/minimode/horizontal_position': 10,
-            'plugin/minimode/vertical_position': 10
+            'plugin/minimode/vertical_position': 10,
         }
 
-        exaile.gui.main.connect('main-visible-toggle',
-                                self.on_main_visible_toggle)
+        exaile.gui.main.connect('main-visible-toggle', self.on_main_visible_toggle)
         event.add_ui_callback(self.on_option_set, 'plugin_minimode_option_set')
-        self.on_option_set('plugin_minimode_option_set', settings,
-                           'plugin/minimode/button_in_mainwindow')
+        self.on_option_set(
+            'plugin_minimode_option_set',
+            settings,
+            'plugin/minimode/button_in_mainwindow',
+        )
 
     def destroy(self):
         """
@@ -192,8 +200,7 @@ class MiniMode(Gtk.Window):
                 elif option == 'plugin/minimode/display_window_decorations':
                     if value:
                         option = 'plugin/minimode/window_decoration_type'
-                        value = settings.get_option(option,
-                                                    self.__defaults[option])
+                        value = settings.get_option(option, self.__defaults[option])
 
                         if value == 'full':
                             self.set_decorated(True)
@@ -207,7 +214,9 @@ class MiniMode(Gtk.Window):
                 elif option == 'plugin/minimode/use_alpha':
                     if value:
                         option = 'plugin/minimode/transparency'
-                        opacity = 1 - settings.get_option(option, self.__defaults[option])
+                        opacity = 1 - settings.get_option(
+                            option, self.__defaults[option]
+                        )
                         self.set_opacity(opacity)
                 elif option == 'plugin/minimode/horizontal_position':
                     h = value
@@ -290,5 +299,6 @@ class MiniMode(Gtk.Window):
             else:
                 self.mainbutton.hide()
                 self.mainbutton.set_no_show_all(True)
+
 
 # vim: et sts=4 sw=4

--- a/plugins/minimode/controls.py
+++ b/plugins/minimode/controls.py
@@ -21,30 +21,15 @@ from gi.repository import Pango
 
 import logging
 
-from xl import (
-    event,
-    player,
-    providers,
-    settings
-)
-from xl.formatter import (
-    Formatter,
-    TrackFormatter,
-    ProgressTextFormatter
-)
-from xl.player.adapters import (
-    PlaybackAdapter,
-    QueueAdapter
-)
+from xl import event, player, providers, settings
+from xl.formatter import Formatter, TrackFormatter, ProgressTextFormatter
+from xl.player.adapters import PlaybackAdapter, QueueAdapter
 from xl.nls import gettext as _
 from xlgui.guiutil import gtk_widget_replace
 from xlgui.widgets.common import AttachedWindow
 from xlgui.widgets.info import TrackToolTip
 from xlgui.widgets.playback import SeekProgressBar
-from xlgui.widgets.playlist import (
-    PlaylistModel,
-    PlaylistView
-)
+from xlgui.widgets.playlist import PlaylistModel, PlaylistView
 from xlgui.widgets.rating import RatingWidget
 
 logger = logging.getLogger(__name__)
@@ -54,6 +39,7 @@ def suppress(signal):
     """
         Decorator which prevents the emission of a GObject signal
     """
+
     def wrapper(function):
         def wrapped_function(self, *args, **kwargs):
             def on_event(sender, *args):
@@ -63,7 +49,9 @@ def suppress(signal):
             handler_id = self.connect(signal, on_event)
             function(self, *args, **kwargs)
             self.disconnect(handler_id)
+
         return wrapped_function
+
     return wrapper
 
 
@@ -72,6 +60,7 @@ class ControlBox(Gtk.Box, providers.ProviderHandler):
         A box for minimode controls which
         updates itself based on settings
     """
+
     __gsignals__ = {'show': 'override'}
 
     def __init__(self):
@@ -81,8 +70,7 @@ class ControlBox(Gtk.Box, providers.ProviderHandler):
         self.__dirty = True
         self.__controls = {}
 
-        event.add_ui_callback(self.on_option_set,
-                              'plugin_minimode_option_set')
+        event.add_ui_callback(self.on_option_set, 'plugin_minimode_option_set')
 
     def destroy(self):
         """
@@ -131,11 +119,17 @@ class ControlBox(Gtk.Box, providers.ProviderHandler):
         """
         selected_controls = settings.get_option(
             'plugin/minimode/selected_controls',
-            ['previous', 'play_pause', 'next', 'playlist_button',
-             'progress_bar', 'restore'])
+            [
+                'previous',
+                'play_pause',
+                'next',
+                'playlist_button',
+                'progress_bar',
+                'restore',
+            ],
+        )
 
-        added_controls = [c for c in selected_controls
-                          if c not in self]
+        added_controls = [c for c in selected_controls if c not in self]
 
         for name in added_controls:
             try:
@@ -146,8 +140,7 @@ class ControlBox(Gtk.Box, providers.ProviderHandler):
             else:
                 self[name] = provider
 
-        removed_controls = [c.name for c in self
-                            if c.name not in selected_controls]
+        removed_controls = [c.name for c in self if c.name not in selected_controls]
 
         for name in removed_controls:
             del self[name]
@@ -183,6 +176,7 @@ class ControlBox(Gtk.Box, providers.ProviderHandler):
             else:
                 self.__dirty = True
 
+
 # Control definitions
 
 
@@ -190,6 +184,7 @@ class BaseControl(object):
     """
         Base control provider
     """
+
     name = None
     title = None
     description = None
@@ -200,6 +195,7 @@ class ButtonControl(Gtk.Button, BaseControl):
     """
         Basic button control
     """
+
     __gsignals__ = {'clicked': 'override'}
 
     def __init__(self):
@@ -223,6 +219,7 @@ class PreviousButtonControl(ButtonControl):
     """
         Button which allows for going to the previous track
     """
+
     name = 'previous'
     title = _('Previous')
     description = _('Go to the previous track')
@@ -244,6 +241,7 @@ class NextButtonControl(ButtonControl):
     """
         Button which allows for going to the next track
     """
+
     name = 'next'
     title = _('Next')
     description = _('Go to the next track')
@@ -266,6 +264,7 @@ class PlayPauseButtonControl(ButtonControl, PlaybackAdapter):
         Button which allows for starting,
         pausing and resuming of playback
     """
+
     name = 'play_pause'
     title = _('Play/Pause')
     description = _('Start, pause or resume the playback')
@@ -333,6 +332,7 @@ class StopButtonControl(ButtonControl):
         Button which allows for stopping the playback
         and toggling the SPAT feature
     """
+
     name = 'stop'
     title = _('Stop')
     description = _('Stop the playback')
@@ -341,7 +341,7 @@ class StopButtonControl(ButtonControl):
         'leave-notify-event': 'override',
         'focus-out-event': 'override',
         'key-press-event': 'override',
-        'key-release-event': 'override'
+        'key-release-event': 'override',
     }
 
     def __init__(self):
@@ -350,10 +350,12 @@ class StopButtonControl(ButtonControl):
         self.set_image_from_icon_name('media-playback-stop')
         self.set_tooltip_text(_('Stop playback'))
 
-        self.add_events(Gdk.EventMask.LEAVE_NOTIFY_MASK |
-                        Gdk.EventMask.POINTER_MOTION_MASK |
-                        Gdk.EventMask.KEY_PRESS_MASK |
-                        Gdk.EventMask.KEY_RELEASE_MASK)
+        self.add_events(
+            Gdk.EventMask.LEAVE_NOTIFY_MASK
+            | Gdk.EventMask.POINTER_MOTION_MASK
+            | Gdk.EventMask.KEY_PRESS_MASK
+            | Gdk.EventMask.KEY_RELEASE_MASK
+        )
 
         self._queue_spat = False
         self._hovered = False
@@ -382,7 +384,9 @@ class StopButtonControl(ButtonControl):
         """
         if self._queue_spat:
             p = player.QUEUE.current_playlist
-            p.spat_position = -1 if p.current_position == p.spat_position else p.current_position
+            p.spat_position = (
+                -1 if p.current_position == p.spat_position else p.current_position
+            )
         else:
             player.PLAYER.stop()
 
@@ -438,6 +442,7 @@ class VolumeButtonControl(Gtk.VolumeButton, BaseControl):
     """
         Button which allows for changing the volume
     """
+
     name = 'volume'
     title = _('Volume')
     description = _('Change the volume')
@@ -454,12 +459,14 @@ class VolumeButtonControl(Gtk.VolumeButton, BaseControl):
 
         # Slightly beautify the control buttons
         plus_button = self.get_plus_button()
-        plus_button.set_image(Gtk.Image.new_from_icon_name(
-            'list-add', Gtk.IconSize.BUTTON))
+        plus_button.set_image(
+            Gtk.Image.new_from_icon_name('list-add', Gtk.IconSize.BUTTON)
+        )
         plus_button.set_label('')
         minus_button = self.get_minus_button()
-        minus_button.set_image(Gtk.Image.new_from_icon_name(
-            'list-remove', Gtk.IconSize.BUTTON))
+        minus_button.set_image(
+            Gtk.Image.new_from_icon_name('list-remove', Gtk.IconSize.BUTTON)
+        )
         minus_button.set_label('')
 
         event.add_ui_callback(self.on_option_set, 'player_option_set')
@@ -502,6 +509,7 @@ class RestoreButtonControl(ButtonControl):
     """
         Button which allows for restoring the main window
     """
+
     name = 'restore'
     title = _('Restore')
     description = _('Restore the main window')
@@ -532,8 +540,9 @@ class RestoreButtonControl(ButtonControl):
             pass
         else:
             key, modifier = Gtk.accelerator_parse('<Primary><Alt>M')
-            self.add_accelerator('clicked', accel_group, key, modifier,
-                                 Gtk.AccelFlags.VISIBLE)
+            self.add_accelerator(
+                'clicked', accel_group, key, modifier, Gtk.AccelFlags.VISIBLE
+            )
 
 
 class RatingControl(RatingWidget, BaseControl):
@@ -541,6 +550,7 @@ class RatingControl(RatingWidget, BaseControl):
         Control which allows for viewing and
         changing the rating of the current track
     """
+
     name = 'rating'
     title = _('Rating')
     description = _('Select rating of the current track')
@@ -581,10 +591,10 @@ class TrackSelectorControl(Gtk.ComboBox, BaseControl, QueueAdapter):
         self.set_cell_data_func(renderer, self.data_func)
         self.set_size_request(200, 0)
 
-        event.add_ui_callback(self.on_option_set,
-                              'plugin_minimode_option_set')
-        self.on_option_set('plugin_minimode_option_set', settings,
-                           'plugin/minimode/track_title_format')
+        event.add_ui_callback(self.on_option_set, 'plugin_minimode_option_set')
+        self.on_option_set(
+            'plugin_minimode_option_set', settings, 'plugin/minimode/track_title_format'
+        )
 
     def destroy(self):
         """
@@ -708,8 +718,7 @@ class TrackSelectorControl(Gtk.ComboBox, BaseControl, QueueAdapter):
         """
         if option == 'plugin/minimode/track_title_format':
             self.formatter.set_property(
-                'format',
-                settings.get_option(option, _('$tracknumber - $title'))
+                'format', settings.get_option(option, _('$tracknumber - $title'))
             )
 
 
@@ -735,16 +744,16 @@ class PlaylistButtonControl(Gtk.ToggleButton, BaseControl, QueueAdapter):
         self.add(box)
 
         self.formatter = TrackFormatter(
-            settings.get_option('plugin/minimode/track_title_format',
-                                '$tracknumber - $title'))
+            settings.get_option(
+                'plugin/minimode/track_title_format', '$tracknumber - $title'
+            )
+        )
 
         self.view = PlaylistView(player.QUEUE.current_playlist, player.PLAYER)
         self.popup = AttachedWindow(self)
         self.popup.set_default_size(
-            settings.get_option('plugin/minimode/'
-                                'playlist_button_popup_width', 350),
-            settings.get_option('plugin/minimode/'
-                                'playlist_button_popup_height', 400)
+            settings.get_option('plugin/minimode/' 'playlist_button_popup_width', 350),
+            settings.get_option('plugin/minimode/' 'playlist_button_popup_height', 400),
         )
         scrollwindow = Gtk.ScrolledWindow()
         scrollwindow.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
@@ -757,8 +766,9 @@ class PlaylistButtonControl(Gtk.ToggleButton, BaseControl, QueueAdapter):
 
         accel_group = Gtk.AccelGroup()
         key, modifier = Gtk.accelerator_parse('<Primary>J')
-        accel_group.connect(key, modifier, Gtk.AccelFlags.VISIBLE,
-                            self.on_accelerator_activate)
+        accel_group.connect(
+            key, modifier, Gtk.AccelFlags.VISIBLE, self.on_accelerator_activate
+        )
         self.popup.add_accel_group(accel_group)
 
         self.tooltip = TrackToolTip(self, player.PLAYER)
@@ -770,21 +780,22 @@ class PlaylistButtonControl(Gtk.ToggleButton, BaseControl, QueueAdapter):
         self._drag_motion_timeout_id = None
         self._drag_leave_timeout_id = None
 
-        self.drag_dest_set(Gtk.DestDefaults.ALL, self.view.targets,
-                           Gdk.DragAction.COPY | Gdk.DragAction.DEFAULT |
-                           Gdk.DragAction.MOVE)
+        self.drag_dest_set(
+            Gtk.DestDefaults.ALL,
+            self.view.targets,
+            Gdk.DragAction.COPY | Gdk.DragAction.DEFAULT | Gdk.DragAction.MOVE,
+        )
 
         self.connect('drag-motion', self.on_drag_motion)
         self.connect('drag-leave', self.on_drag_leave)
         self.connect('drag-data-received', self.on_drag_data_received)
         self.view.connect('drag-motion', self.on_drag_motion)
         self.view.connect('drag-leave', self.on_drag_leave)
-        event.add_ui_callback(self.on_track_tags_changed,
-                              'track_tags_changed')
-        event.add_ui_callback(self.on_option_set,
-                              'plugin_minimode_option_set')
-        self.on_option_set('plugin_minimode_option_set', settings,
-                           'plugin/minimode/track_title_format')
+        event.add_ui_callback(self.on_track_tags_changed, 'track_tags_changed')
+        event.add_ui_callback(self.on_option_set, 'plugin_minimode_option_set')
+        self.on_option_set(
+            'plugin_minimode_option_set', settings, 'plugin/minimode/track_title_format'
+        )
 
     def destroy(self):
         """
@@ -833,8 +844,7 @@ class PlaylistButtonControl(Gtk.ToggleButton, BaseControl, QueueAdapter):
             self.popup.hide()
             self.arrow.props.arrow_type = Gtk.ArrowType.RIGHT
 
-    def on_accelerator_activate(self, accel_group, acceleratable,
-                                keyval, modifier):
+    def on_accelerator_activate(self, accel_group, acceleratable, keyval, modifier):
         """
             Shows the current track
         """
@@ -848,7 +858,8 @@ class PlaylistButtonControl(Gtk.ToggleButton, BaseControl, QueueAdapter):
         # Defer display of the playlist
         if self._drag_motion_timeout_id is None:
             self._drag_motion_timeout_id = GLib.timeout_add(
-                500, lambda: self.set_active(True))
+                500, lambda: self.set_active(True)
+            )
 
         # Prevent hiding of the playlist
         if self._drag_leave_timeout_id is not None:
@@ -869,10 +880,10 @@ class PlaylistButtonControl(Gtk.ToggleButton, BaseControl, QueueAdapter):
 
         # Defer hiding of the playlist
         self._drag_leave_timeout_id = GLib.timeout_add(
-            500, lambda: self.set_active(False))
+            500, lambda: self.set_active(False)
+        )
 
-    def on_drag_data_received(self, widget, context, x, y,
-                              selection, info, time):
+    def on_drag_data_received(self, widget, context, x, y, selection, info, time):
         """
             Handles dropped data
         """
@@ -886,8 +897,7 @@ class PlaylistButtonControl(Gtk.ToggleButton, BaseControl, QueueAdapter):
             GLib.source_remove(self._drag_leave_timeout_id)
             self._drag_leave_timeout_id = None
 
-        self.view.emit('drag-data-received', context, x, y,
-                       selection, info, time)
+        self.view.emit('drag-data-received', context, x, y, selection, info, time)
 
     def on_popup_show(self, widget):
         if not self.get_active():
@@ -901,18 +911,22 @@ class PlaylistButtonControl(Gtk.ToggleButton, BaseControl, QueueAdapter):
         """
             Saves the window size after resizing
         """
-        width = settings.get_option('plugin/minimode/'
-                                    'playlist_button_popup_width', 350)
-        height = settings.get_option('plugin/minimode/'
-                                     'playlist_button_popup_height', 400)
+        width = settings.get_option(
+            'plugin/minimode/' 'playlist_button_popup_width', 350
+        )
+        height = settings.get_option(
+            'plugin/minimode/' 'playlist_button_popup_height', 400
+        )
 
         if event.width != width:
-            settings.set_option('plugin/minimode/'
-                                'playlist_button_popup_width', event.width)
+            settings.set_option(
+                'plugin/minimode/' 'playlist_button_popup_width', event.width
+            )
 
         if event.height != height:
-            settings.set_option('plugin/minimode/'
-                                'playlist_button_popup_height', event.height)
+            settings.set_option(
+                'plugin/minimode/' 'playlist_button_popup_height', event.height
+            )
 
     def on_queue_current_playlist_changed(self, event, queue, playlist):
         """
@@ -949,8 +963,7 @@ class PlaylistButtonControl(Gtk.ToggleButton, BaseControl, QueueAdapter):
         """
         if option == 'plugin/minimode/track_title_format':
             self.formatter.set_property(
-                'format',
-                settings.get_option(option, _('$tracknumber - $title'))
+                'format', settings.get_option(option, _('$tracknumber - $title'))
             )
 
 
@@ -965,10 +978,10 @@ class ProgressButtonFormatter(Formatter):
 
         self.track_formatter = TrackFormatter('')
         self.progress_formatter = ProgressTextFormatter(
-            self.props.format, player.PLAYER)
+            self.props.format, player.PLAYER
+        )
 
-        event.add_ui_callback(self.on_option_set,
-                              'plugin_minimode_option_set')
+        event.add_ui_callback(self.on_option_set, 'plugin_minimode_option_set')
 
     def format(self, current_time=None, total_time=None):
         """
@@ -991,34 +1004,35 @@ class ProgressButtonFormatter(Formatter):
         """
             Retrieves the current user format
         """
-        return settings.get_option('plugin/minimode/progress_button_title_format',
-                                   _('$title ($current_time / $total_time)'))
+        return settings.get_option(
+            'plugin/minimode/progress_button_title_format',
+            _('$title ($current_time / $total_time)'),
+        )
 
     def on_option_set(self, event, settings, option):
         """
             Updates the internal format on setting change
         """
         if option == 'gui/progress_bar_text_format':
-            GLib.idle_add(self.set_property,
-                          'format',
-                          self.get_option_value()
-                          )
+            GLib.idle_add(self.set_property, 'format', self.get_option_value())
 
-Gtk.rc_parse_string('''
+
+Gtk.rc_parse_string(
+    '''
     style "progress-button" {
         GtkToggleButton::default-border = {0, 0, 0, 0}
         GtkToggleButton::default-outside-border = {0, 0, 0, 0}
         GtkToggleButton::inner-border = {0, 0, 0, 0}
     }
     widget "*.progressbutton" style "progress-button"
-''')
+'''
+)
 
 
 class ProgressButtonControl(PlaylistButtonControl):
     name = 'progress_button'
     title = _('Progress button')
-    description = _('Playback progress and access '
-                    'to the current playlist')
+    description = _('Playback progress and access ' 'to the current playlist')
     # Required to make overrides work
     __gsignals__ = {}
 
@@ -1037,9 +1051,7 @@ class ProgressButtonControl(PlaylistButtonControl):
 
         if player.PLAYER.current is not None:
             self.progressbar.on_playback_track_start(
-                'playback_track_start',
-                player.PLAYER,
-                player.PLAYER.current
+                'playback_track_start', player.PLAYER, player.PLAYER.current
             )
 
         self.tooltip = TrackToolTip(self, player.PLAYER)
@@ -1061,8 +1073,9 @@ class ProgressButtonControl(PlaylistButtonControl):
         elif event.button == Gdk.BUTTON_MIDDLE:
             event = event.copy()
             event.button = Gdk.BUTTON_PRIMARY
-            x, y = self.translate_coordinates(self.progressbar,
-                                              int(event.x), int(event.y))
+            x, y = self.translate_coordinates(
+                self.progressbar, int(event.x), int(event.y)
+            )
             event.x, event.y = float(x), float(y)
             self.progressbar.emit('button-press-event', event)
 
@@ -1072,22 +1085,21 @@ class ProgressButtonControl(PlaylistButtonControl):
         elif event.button == Gdk.BUTTON_MIDDLE:
             event = event.copy()
             event.button = Gdk.BUTTON_PRIMARY
-            x, y = self.translate_coordinates(self.progressbar,
-                                              int(event.x), int(event.y))
+            x, y = self.translate_coordinates(
+                self.progressbar, int(event.x), int(event.y)
+            )
             event.x, event.y = float(x), float(y)
             self.progressbar.emit('button-release-event', event)
 
     def do_motion_notify_event(self, event):
         event = event.copy()
-        x, y = self.translate_coordinates(self.progressbar,
-                                          int(event.x), int(event.y))
+        x, y = self.translate_coordinates(self.progressbar, int(event.x), int(event.y))
         event.x, event.y = float(x), float(y)
         self.progressbar.emit('motion-notify-event', event)
 
     def do_leave_notify_event(self, event):
         event = event.copy()
-        x, y = self.translate_coordinates(self.progressbar,
-                                          int(event.x), int(event.y))
+        x, y = self.translate_coordinates(self.progressbar, int(event.x), int(event.y))
         event.x, event.y = float(x), float(y)
         self.progressbar.emit('leave-notify-event', event)
 
@@ -1107,17 +1119,14 @@ class ProgressBarControl(SeekProgressBar, BaseControl):
 
         if player.PLAYER.current is not None:
             self.on_playback_track_start(
-                'playback_track_start',
-                player.PLAYER,
-                player.PLAYER.current
+                'playback_track_start', player.PLAYER, player.PLAYER.current
             )
 
             if player.PLAYER.is_paused():
                 self.on_playback_toggle_pause(
-                    'playback_toggle_pause',
-                    player.PLAYER,
-                    player.PLAYER.current
+                    'playback_toggle_pause', player.PLAYER, player.PLAYER.current
                 )
+
 
 control_types = [
     PreviousButtonControl,

--- a/plugins/minimode/minimode_preferences.py
+++ b/plugins/minimode/minimode_preferences.py
@@ -24,8 +24,9 @@ from xlgui.preferences import widgets
 name = _('Mini Mode')
 basedir = os.path.dirname(os.path.realpath(__file__))
 ui = os.path.join(basedir, "minimode_preferences.ui")
-icons.MANAGER.add_icon_name_from_directory('exaile-minimode',
-                                           os.path.join(basedir, 'icons'))
+icons.MANAGER.add_icon_name_from_directory(
+    'exaile-minimode', os.path.join(basedir, 'icons')
+)
 icon = 'exaile-minimode'
 
 
@@ -54,8 +55,7 @@ class DisplayWindowDecorationsPreference(widgets.CheckPreference):
     default = True
 
 
-class WindowDecorationTypePreference(widgets.ComboPreference,
-                                     widgets.CheckConditional):
+class WindowDecorationTypePreference(widgets.ComboPreference, widgets.CheckConditional):
     name = 'plugin/minimode/window_decoration_type'
     default = 'full'
     condition_preference_name = 'plugin/minimode/display_window_decorations'
@@ -82,12 +82,20 @@ class TransparencyPreference(widgets.ScalePreference, widgets.CheckConditional):
 
 class SelectedControlsPreference(widgets.SelectionListPreference):
     name = 'plugin/minimode/selected_controls'
-    default = ['previous', 'play_pause', 'next', 'playlist_button',
-               'progress_bar', 'restore']
+    default = [
+        'previous',
+        'play_pause',
+        'next',
+        'playlist_button',
+        'progress_bar',
+        'restore',
+    ]
 
     def __init__(self, preferences, widget):
-        self.items = [self.Item(p.name, p.title, p.description, p.fixed)
-                      for p in providers.get('minimode-controls')]
+        self.items = [
+            self.Item(p.name, p.title, p.description, p.fixed)
+            for p in providers.get('minimode-controls')
+        ]
         widgets.SelectionListPreference.__init__(self, preferences, widget)
 
 
@@ -117,6 +125,6 @@ class TrackTitleFormatPreference(widgets.ComboEntryPreference):
         # TRANSLATORS: Mini mode track selector title preset
         _('$title by $artist'),
         # TRANSLATORS: Mini mode track selector title preset
-        _('$title ($__length)')
+        _('$title ($__length)'),
     ]
     default = _('$tracknumber - $title')

--- a/plugins/mono/__init__.py
+++ b/plugins/mono/__init__.py
@@ -37,7 +37,7 @@ class Mono(ElementBin):
 
     def __init__(self):
         ElementBin.__init__(self, name=self.name)
-        #self.elements[50] = Gst.ElementFactory.make('audioconvert', None)
+        # self.elements[50] = Gst.ElementFactory.make('audioconvert', None)
         self.elements[60] = cf = Gst.ElementFactory.make('capsfilter', None)
         cf.props.caps = Gst.Caps.from_string('audio/x-raw,channels=1')
         self.setup_elements()

--- a/plugins/moodbar/__init__.py
+++ b/plugins/moodbar/__init__.py
@@ -24,10 +24,7 @@ from __future__ import division, print_function
 
 import os.path
 
-from gi.repository import (
-    Gdk,
-    GLib,
-)
+from gi.repository import Gdk, GLib
 
 import xl.event
 from xl.nls import gettext as _
@@ -56,20 +53,30 @@ class MoodbarPlugin:
         self.exaile = exaile
         self.cache = ExaileMoodbarCache(os.path.join(xl.xdg.get_cache_dir(), 'moods'))
 
-        xl.event.add_ui_callback(self._on_preview_device_enabled, 'preview_device_enabled')
-        xl.event.add_ui_callback(self._on_preview_device_disabling, 'preview_device_disabling')
+        xl.event.add_ui_callback(
+            self._on_preview_device_enabled, 'preview_device_enabled'
+        )
+        xl.event.add_ui_callback(
+            self._on_preview_device_disabling, 'preview_device_disabling'
+        )
         previewdevice = exaile.plugins.enabled_plugins.get('previewdevice', None)
         if previewdevice:
             self.on_preview_device_enabled('', previewdevice)
 
     def on_gui_loaded(self):
-        self.main_controller = MoodbarController(self, xl.player.PLAYER, self.exaile.gui.main.progress_bar)
+        self.main_controller = MoodbarController(
+            self, xl.player.PLAYER, self.exaile.gui.main.progress_bar
+        )
 
     def disable(self, exaile):
         if not self.main_controller:  # Disabled more than once or before gui_loaded
             return
-        xl.event.remove_callback(self._on_preview_device_enabled, 'preview_device_enabled')
-        xl.event.remove_callback(self._on_preview_device_disabling, 'preview_device_disabling')
+        xl.event.remove_callback(
+            self._on_preview_device_enabled, 'preview_device_enabled'
+        )
+        xl.event.remove_callback(
+            self._on_preview_device_disabling, 'preview_device_disabling'
+        )
         self.main_controller.destroy()
         if self.preview_controller:
             self.preview_controller.destroy()
@@ -79,11 +86,14 @@ class MoodbarPlugin:
     # Preview Device events
 
     def _on_preview_device_enabled(self, event, plugin, _=None):
-        self.preview_controller = MoodbarController(self, plugin.player, plugin.progress_bar)
+        self.preview_controller = MoodbarController(
+            self, plugin.player, plugin.progress_bar
+        )
 
     def _on_preview_device_disabling(self, event, plugin, _=None):
         self.preview_controller.destroy()
         self.preview_controller = None
+
 
 plugin_class = MoodbarPlugin
 
@@ -96,7 +106,6 @@ def format_time(seconds, time_format=_("{minutes}:{seconds:02}")):
 
 
 class MoodbarController:
-
     def __init__(self, plugin, player, orig_seekbar):
         self.plugin = plugin
         self.player = player
@@ -104,19 +113,31 @@ class MoodbarController:
         self.timer = self.seeking = False
 
         self.moodbar = moodbar = Moodbar()
-        moodbar.add_events(Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.BUTTON1_MOTION_MASK | Gdk.EventMask.BUTTON_RELEASE_MASK)
+        moodbar.add_events(
+            Gdk.EventMask.BUTTON_PRESS_MASK
+            | Gdk.EventMask.BUTTON1_MOTION_MASK
+            | Gdk.EventMask.BUTTON_RELEASE_MASK
+        )
         xlgui.guiutil.gtk_widget_replace(self.orig_seekbar, moodbar)
         moodbar.show()
         # TODO: If currently playing, this needs to run now as well:
-        xl.event.add_ui_callback(self._on_playback_track_start, 'playback_track_start', self.player)
-        xl.event.add_ui_callback(self._on_playback_track_end, 'playback_track_end', self.player)
+        xl.event.add_ui_callback(
+            self._on_playback_track_start, 'playback_track_start', self.player
+        )
+        xl.event.add_ui_callback(
+            self._on_playback_track_end, 'playback_track_end', self.player
+        )
         moodbar.connect('button-press-event', self._on_moodbar_button_press)
         moodbar.connect('motion-notify-event', self._on_moodbar_motion)
         moodbar.connect('button-release-event', self._on_moodbar_button_release)
 
     def destroy(self):
-        xl.event.remove_callback(self._on_playback_track_end, 'playback_track_start', self.player)
-        xl.event.remove_callback(self._on_playback_track_end, 'playback_track_end', self.player)
+        xl.event.remove_callback(
+            self._on_playback_track_end, 'playback_track_start', self.player
+        )
+        xl.event.remove_callback(
+            self._on_playback_track_end, 'playback_track_end', self.player
+        )
         if self.timer:
             GLib.source_remove(self.timer)
         assert self.orig_seekbar
@@ -134,10 +155,12 @@ class MoodbarController:
         self._on_timer()
         self.timer = GLib.timeout_add_seconds(1, self._on_timer)
         if not data and uri.startswith('file://'):
+
             def callback(uri, data):
                 if cache:
                     cache.put(uri, data)
                 self.moodbar.set_mood(data)
+
             self.plugin.generator.generate_async(uri, callback)
 
     def _on_timer(self):

--- a/plugins/moodbar/generator.py
+++ b/plugins/moodbar/generator.py
@@ -30,7 +30,6 @@ class MoodbarGeneratorError(Exception):
 
 
 class MoodbarGenerator(object):
-
     def check(self):
         """Check whether the generator works.
 
@@ -57,14 +56,14 @@ class MoodbarGenerator(object):
         :type uri: bytes
         :type callback: Callable[[bytes, bytes], None]
         """
-        thread = threading.Thread(name=self.__class__.__name__,
-                                  target=self.generate, args=(uri, callback))
+        thread = threading.Thread(
+            name=self.__class__.__name__, target=self.generate, args=(uri, callback)
+        )
         thread.daemon = True
         thread.start()
 
 
 class SpectrumMoodbarGenerator(MoodbarGenerator):
-
     def check(self):
         try:
             with open(os.devnull, 'wb') as devnull:
@@ -73,7 +72,9 @@ class SpectrumMoodbarGenerator(MoodbarGenerator):
             # executable exists but returned an error code
             pass
         except Exception:
-            raise MoodbarGeneratorError("Failed to run moodbar; make sure it is installed")
+            raise MoodbarGeneratorError(
+                "Failed to run moodbar; make sure it is installed"
+            )
 
     def generate(self, uri, callback=None):
         path = Gio.File.new_for_uri(uri).get_path()

--- a/plugins/moodbar/widget.py
+++ b/plugins/moodbar/widget.py
@@ -20,18 +20,17 @@ from __future__ import division, print_function, unicode_literals
 import collections
 
 import gi
+
 gi.require_version('PangoCairo', '1.0')
 
-from gi.repository import (
-    Gtk,
-    Pango,
-    PangoCairo,
-)
+from gi.repository import Gtk, Pango, PangoCairo
 
 import painter
 
 
-Extents = collections.namedtuple('Extents', 'x_bearing y_bearing width height x_advance y_advance')
+Extents = collections.namedtuple(
+    'Extents', 'x_bearing y_bearing width height x_advance y_advance'
+)
 
 
 class Moodbar(Gtk.DrawingArea):

--- a/plugins/mpris2/__init__.py
+++ b/plugins/mpris2/__init__.py
@@ -119,7 +119,6 @@ MPRIS_INTROSPECTION = '''\
 
 
 class MprisPlugin:
-
     def enable(self, exaile):
         self.handler = MprisHandler(exaile)
 
@@ -129,6 +128,7 @@ class MprisPlugin:
 
     def teardown(self, exaile):
         self.handler.teardown()
+
 
 plugin_class = MprisPlugin
 
@@ -145,19 +145,37 @@ class MprisHandler:
         self.connection = None
         self.object = None
         self.registrations = []
-        Gio.bus_own_name(Gio.BusType.SESSION, 'org.mpris.MediaPlayer2.exaile',
-                         Gio.BusNameOwnerFlags.NONE, self._on_bus_acquired, None, None)
+        Gio.bus_own_name(
+            Gio.BusType.SESSION,
+            'org.mpris.MediaPlayer2.exaile',
+            Gio.BusNameOwnerFlags.NONE,
+            self._on_bus_acquired,
+            None,
+            None,
+        )
 
     def _on_bus_acquired(self, connection, name):
         self.connection = connection
         self.object = obj = mprisobject.MprisObject(self.exaile, connection)
         helper = dbushelper.DBusHelper(obj)
-        self.registrations.append(connection.register_object(
-            '/org/mpris/MediaPlayer2', self.root_interface,
-            helper.method_call, helper.get_property, helper.set_property))
-        self.registrations.append(connection.register_object(
-            '/org/mpris/MediaPlayer2', self.player_interface,
-            helper.method_call, helper.get_property, helper.set_property))
+        self.registrations.append(
+            connection.register_object(
+                '/org/mpris/MediaPlayer2',
+                self.root_interface,
+                helper.method_call,
+                helper.get_property,
+                helper.set_property,
+            )
+        )
+        self.registrations.append(
+            connection.register_object(
+                '/org/mpris/MediaPlayer2',
+                self.player_interface,
+                helper.method_call,
+                helper.get_property,
+                helper.set_property,
+            )
+        )
 
     def disconnect(self):
         # XXX: Should probably cancel bus_own_name if it's still running.

--- a/plugins/mpris2/dbushelper.py
+++ b/plugins/mpris2/dbushelper.py
@@ -64,7 +64,9 @@ class DBusHelper:
     def __init__(self, obj):
         self.object = obj
 
-    def method_call(self, connection, sender, path, interface, method, args, invocation):
+    def method_call(
+        self, connection, sender, path, interface, method, args, invocation
+    ):
         self._check_method(method)
         result = getattr(self.object, method)(*args)
         # If the method returns nothing, return empty tuple. If the method
@@ -92,6 +94,7 @@ class DBusHelper:
     def _check_method(self, meth):
         """Check that `meth` is a valid property of `self.object`"""
         import types
+
         if meth and meth[0].isupper() and not meth.endswith('_'):
             classprop = getattr(self.object.__class__, meth, None)
             if isinstance(classprop, types.MethodType):

--- a/plugins/mpris2/mprisobject.py
+++ b/plugins/mpris2/mprisobject.py
@@ -7,7 +7,7 @@
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# but WITHOUT ANY WARRANTY',' without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
@@ -81,7 +81,7 @@ class MprisObject(object):
             for obj, sig, handler in conns)
 
     def teardown(self):
-        """Quick destroy; just clean up our mess"""
+        """Quick destroy',' just clean up our mess"""
         f = self.cover_file
         if f:
             f.close()
@@ -137,7 +137,7 @@ class MprisObject(object):
             meta['xesam:artist'] = Variant('as', v)
         v = track.get_tag_raw('genre')
         if v:
-            # TODO: I've seen a client expect 'radio' on streams;
+            # TODO: I've seen a client expect 'radio' on streams','
             # is that common usage?
             meta['xesam:genre'] = Variant('as', v)
         try:
@@ -217,14 +217,14 @@ class MprisObject(object):
     @property
     def SupportedMimeTypes(self):
         # Taken from exaile.desktop
-        mimetypes = 'audio/musepack;application/musepack;application/x-ape;' \
-            'audio/ape;audio/x-ape;audio/x-musepack;application/x-musepack;' \
-            'audio/x-mp3;application/x-id3;audio/mpeg;audio/x-mpeg;' \
-            'audio/x-mpeg-3;audio/mpeg3;audio/mp3;audio/x-m4a;audio/mpc;' \
-            'audio/x-mpc;audio/mp;audio/x-mp;application/ogg;' \
-            'application/x-ogg;audio/vorbis;audio/x-vorbis;audio/ogg;' \
-            'audio/x-ogg;audio/x-flac;application/x-flac;audio/flac'
-        return Variant('as', mimetypes.split(';'))
+        mimetypes = ['audio/musepack','application/musepack','application/x-ape',
+            'audio/ape','audio/x-ape','audio/x-musepack','application/x-musepack',
+            'audio/x-mp3','application/x-id3','audio/mpeg','audio/x-mpeg',
+            'audio/x-mpeg-3','audio/mpeg3','audio/mp3','audio/x-m4a','audio/mpc',
+            'audio/x-mpc','audio/mp','audio/x-mp','application/ogg',
+            'application/x-ogg','audio/vorbis','audio/x-vorbis','audio/ogg',
+            'audio/x-ogg','audio/x-flac','application/x-flac','audio/flac']
+        return Variant('as', mimetypes)
 
     @property
     def SupportedUriSchemes(self):

--- a/plugins/mpris2/mprisobject.py
+++ b/plugins/mpris2/mprisobject.py
@@ -29,10 +29,7 @@ from __future__ import division
 
 import tempfile
 
-from gi.repository import (
-    Gio,
-    GLib,
-)
+from gi.repository import Gio, GLib
 
 import xl.covers
 import xl.event
@@ -43,7 +40,6 @@ Variant = GLib.Variant
 
 
 class MprisObject(object):
-
     def __init__(self, exaile, connection):
         self.exaile = exaile
         self.connection = connection
@@ -74,11 +70,11 @@ class MprisObject(object):
 
     def _init_gui(self):
         conns = [
-            (self.exaile.gui.main, 'notify::is-fullscreen', self._on_notify_fullscreen),
+            (self.exaile.gui.main, 'notify::is-fullscreen', self._on_notify_fullscreen)
         ]
         self.signal_connections.extend(
-            (obj, obj.connect(sig, handler))
-            for obj, sig, handler in conns)
+            (obj, obj.connect(sig, handler)) for obj, sig, handler in conns
+        )
 
     def teardown(self):
         """Quick destroy',' just clean up our mess"""
@@ -91,19 +87,28 @@ class MprisObject(object):
         if f:
             f.close()
         self.cover_file = f = tempfile.NamedTemporaryFile(
-            prefix='exaile.mpris2.cover.', suffix='.tmp')
+            prefix='exaile.mpris2.cover.', suffix='.tmp'
+        )
         uri = Gio.File.new_for_path(f.name).get_uri()
         return f, uri
 
     def _emit(self, interface, signame, *args):
-        self.connection.emit_signal(None, '/org/mpris/MediaPlayer2', interface,
-                                    signame, Variant.new_tuple(*args))
+        self.connection.emit_signal(
+            None,
+            '/org/mpris/MediaPlayer2',
+            interface,
+            signame,
+            Variant.new_tuple(*args),
+        )
 
     def _emit_propchange(self, interface, changed_props={}, invalidated_props=[]):
-        self._emit('org.freedesktop.DBus.Properties', 'PropertiesChanged',
-                   Variant('s', interface),
-                   Variant('a{sv}', changed_props),
-                   Variant('as', invalidated_props))
+        self._emit(
+            'org.freedesktop.DBus.Properties',
+            'PropertiesChanged',
+            Variant('s', interface),
+            Variant('a{sv}', changed_props),
+            Variant('as', invalidated_props),
+        )
 
     def _get_metadata(self):
         track = xl.player.PLAYER.current
@@ -114,9 +119,7 @@ class MprisObject(object):
 
         # mpris
 
-        meta = {
-            'mpris:trackid': Variant('o', '/org/exaile/track/%d' % id(track)),
-        }
+        meta = {'mpris:trackid': Variant('o', '/org/exaile/track/%d' % id(track))}
         v = track.get_tag_raw('__length')
         if v:
             meta['mpris:length'] = Variant('x', v * 1e6)
@@ -159,33 +162,38 @@ class MprisObject(object):
         return meta
 
     def _on_notify_fullscreen(self, obj, param):
-        self._emit_propchange('org.mpris.MediaPlayer2', {
-            'FullScreen': self.FullScreen,
-        })
+        self._emit_propchange('org.mpris.MediaPlayer2', {'FullScreen': self.FullScreen})
 
     def _on_playback_track_start(self, event, player, track):
-        self._emit_propchange('org.mpris.MediaPlayer2.Player', {
-            'Metadata': self.Metadata,
-            'PlaybackStatus': Variant('s', 'Playing'),
-        })
+        self._emit_propchange(
+            'org.mpris.MediaPlayer2.Player',
+            {'Metadata': self.Metadata, 'PlaybackStatus': Variant('s', 'Playing')},
+        )
 
     def _on_playback_track_end(self, event, player, track):
-        self._emit_propchange('org.mpris.MediaPlayer2.Player', {
-            'Metadata': Variant('a{sv}', {}),
-            'PlaybackStatus': Variant('s', 'Stopped'),
-        })
+        self._emit_propchange(
+            'org.mpris.MediaPlayer2.Player',
+            {
+                'Metadata': Variant('a{sv}', {}),
+                'PlaybackStatus': Variant('s', 'Stopped'),
+            },
+        )
 
     def _on_playback_toggle_pause(self, event, player, track):
-        self._emit_propchange('org.mpris.MediaPlayer2.Player', {
-            'PlaybackStatus': Variant('s',
-                                      'Paused' if xl.player.PLAYER.is_paused() else 'Playing'),
-        })
+        self._emit_propchange(
+            'org.mpris.MediaPlayer2.Player',
+            {
+                'PlaybackStatus': Variant(
+                    's', 'Paused' if xl.player.PLAYER.is_paused() else 'Playing'
+                )
+            },
+        )
 
     def _on_player_option_set(self, event, settings, option):
         if option == 'player/volume':
-            self._emit_propchange('org.mpris.MediaPlayer2.Player', {
-                'Volume': self.Volume,
-            })
+            self._emit_propchange(
+                'org.mpris.MediaPlayer2.Player', {'Volume': self.Volume}
+            )
 
     def _return_true(self):  # Positive reply for the "Can*" properties
         return Variant('b', True)
@@ -217,13 +225,36 @@ class MprisObject(object):
     @property
     def SupportedMimeTypes(self):
         # Taken from exaile.desktop
-        mimetypes = ['audio/musepack','application/musepack','application/x-ape',
-            'audio/ape','audio/x-ape','audio/x-musepack','application/x-musepack',
-            'audio/x-mp3','application/x-id3','audio/mpeg','audio/x-mpeg',
-            'audio/x-mpeg-3','audio/mpeg3','audio/mp3','audio/x-m4a','audio/mpc',
-            'audio/x-mpc','audio/mp','audio/x-mp','application/ogg',
-            'application/x-ogg','audio/vorbis','audio/x-vorbis','audio/ogg',
-            'audio/x-ogg','audio/x-flac','application/x-flac','audio/flac']
+        mimetypes = [
+            'audio/musepack',
+            'application/musepack',
+            'application/x-ape',
+            'audio/ape',
+            'audio/x-ape',
+            'audio/x-musepack',
+            'application/x-musepack',
+            'audio/x-mp3',
+            'application/x-id3',
+            'audio/mpeg',
+            'audio/x-mpeg',
+            'audio/x-mpeg-3',
+            'audio/mpeg3',
+            'audio/mp3',
+            'audio/x-m4a',
+            'audio/mpc',
+            'audio/x-mpc',
+            'audio/mp',
+            'audio/x-mp',
+            'application/ogg',
+            'application/x-ogg',
+            'audio/vorbis',
+            'audio/x-vorbis',
+            'audio/ogg',
+            'audio/x-ogg',
+            'audio/x-flac',
+            'application/x-flac',
+            'audio/flac',
+        ]
         return Variant('as', mimetypes)
 
     @property
@@ -242,7 +273,9 @@ class MprisObject(object):
 
     # Player properties
 
-    CanControl = CanGoNext = CanGoPrevious = CanPause = CanPlay = CanSeek = property(_return_true)
+    CanControl = CanGoNext = CanGoPrevious = CanPause = CanPlay = CanSeek = property(
+        _return_true
+    )
 
     @property
     def LoopStatus(self):
@@ -262,9 +295,7 @@ class MprisObject(object):
         playlist = xl.player.QUEUE.current_playlist
         playlist.set_repeat_mode(state)
         # TODO: Connect to actual event in playlist
-        self._emit_propchange('org.mpris.MediaPlayer2.Player', {
-            'LoopStatus': value,
-        })
+        self._emit_propchange('org.mpris.MediaPlayer2.Player', {'LoopStatus': value})
 
     @property
     def MaximumRate(self):
@@ -307,9 +338,9 @@ class MprisObject(object):
         playlist = xl.player.QUEUE.current_playlist
         playlist.set_shuffle_mode('track' if value_b else 'disabled')
         # TODO: Connect to actual event in playlist
-        self._emit_propchange('org.mpris.MediaPlayer2.Player', {
-            'Shuffle': Variant('b', value_b),
-        })
+        self._emit_propchange(
+            'org.mpris.MediaPlayer2.Player', {'Shuffle': Variant('b', value_b)}
+        )
 
     @property
     def Volume(self):
@@ -352,7 +383,6 @@ class MprisObject(object):
             queue = xl.player.QUEUE
             queue.play(queue.get_current())
 
-
     def Previous(self):
         if xl.player.PLAYER.is_playing():
             xl.player.QUEUE.prev()
@@ -365,8 +395,9 @@ class MprisObject(object):
             return
         xl.player.PLAYER.seek(position / 1e6)
         # TODO: Can we get this event from Exaile?
-        self._emit('org.mpris.MediaPlayer2.Player', 'Seeked',
-                   GLib.Variant('x', position))
+        self._emit(
+            'org.mpris.MediaPlayer2.Player', 'Seeked', GLib.Variant('x', position)
+        )
 
     def Stop(self):
         xl.player.PLAYER.stop()

--- a/plugins/multialarmclock/cellrenderers.py
+++ b/plugins/multialarmclock/cellrenderers.py
@@ -25,9 +25,12 @@ class CellRendererDays(Gtk.CellRendererText):
     '''Custom Cell Renderer for showing a ListView of 7 days with checkboxes, based off pygtk FAQ example'''
 
     __gtype_name__ = 'CellRendererDays'
-    __gproperties__ = {'days': (object, 'days', 'List of enabled days', GObject.PARAM_READWRITE)}
-    __gsignals__ = {'days-changed': (GObject.SignalFlags.RUN_FIRST, None,
-                                     (str, object))}
+    __gproperties__ = {
+        'days': (object, 'days', 'List of enabled days', GObject.PARAM_READWRITE)
+    }
+    __gsignals__ = {
+        'days-changed': (GObject.SignalFlags.RUN_FIRST, None, (str, object))
+    }
     property_names = __gproperties__.keys()
 
     def __init__(self):
@@ -36,7 +39,15 @@ class CellRendererDays(Gtk.CellRendererText):
         self.view = None
         self.view_window = None
 
-        for day in ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']:
+        for day in [
+            'Sunday',
+            'Monday',
+            'Tuesday',
+            'Wednesday',
+            'Thursday',
+            'Friday',
+            'Saturday',
+        ]:
             self.model.append([True, day])
 
         self.set_property('text', 'Edit me')
@@ -82,7 +93,9 @@ class CellRendererDays(Gtk.CellRendererText):
         '''Get property overload'''
         return getattr(self, pspec.name)
 
-    def do_start_editing(self, event, treeview, path, background_area, cell_area, flags):
+    def do_start_editing(
+        self, event, treeview, path, background_area, cell_area, flags
+    ):
         '''Called when user starts editing the cell'''
 
         if not self.get_property('editable'):
@@ -123,7 +136,11 @@ class CellRendererDays(Gtk.CellRendererText):
     def _key_pressed(self, view, event):
         '''Key pressed event handler, finish editing on Return'''
         # event == None for day selected via doubleclick
-        if not event or event.type == Gdk.EventType.KEY_PRESS and Gdk.keyval_name(event.keyval) == 'Return':
+        if (
+            not event
+            or event.type == Gdk.EventType.KEY_PRESS
+            and Gdk.keyval_name(event.keyval) == 'Return'
+        ):
             self._done()
             return True
 

--- a/plugins/multialarmclock/macprefs.py
+++ b/plugins/multialarmclock/macprefs.py
@@ -23,8 +23,7 @@ name = _('Multi-Alarm Clock')
 basedir = os.path.dirname(os.path.realpath(__file__))
 ui = os.path.join(basedir, "malrmclk.ui")
 
-icons.MANAGER.add_icon_name_from_directory('clock',
-                                           os.path.join(basedir, 'icons'))
+icons.MANAGER.add_icon_name_from_directory('clock', os.path.join(basedir, 'icons'))
 icon = 'clock'
 
 

--- a/plugins/musicbrainzcovers/__init__.py
+++ b/plugins/musicbrainzcovers/__init__.py
@@ -16,20 +16,14 @@
 import logging
 import urllib2
 
-from xl import (
-    common,
-    covers,
-    providers
-)
+from xl import common, covers, providers
 
 import musicbrainzngs
 
 logger = logging.getLogger(__name__)
 
 musicbrainzngs.set_useragent(
-    'Exaile_MusicBrainz_Covers',
-    '1.0.0',
-    'https://exaile.org/'
+    'Exaile_MusicBrainz_Covers', '1.0.0', 'https://exaile.org/'
 )
 
 
@@ -51,6 +45,7 @@ class MusicBrainzCoverSearch(covers.CoverSearchMethod):
     """
         Searches MusicBrainz for an album cover
     """
+
     name = 'musicbrainz'
     title = 'MusicBrainz'
     __caa_url = 'http://coverartarchive.org/release/{mbid}/front-{size}'
@@ -72,7 +67,7 @@ class MusicBrainzCoverSearch(covers.CoverSearchMethod):
             release=album,
             artistname=artist,
             format='CD',
-            limit=3  # Unlimited search is slow
+            limit=3,  # Unlimited search is slow
         )
 
         if result['release-list']:

--- a/plugins/notify/__init__.py
+++ b/plugins/notify/__init__.py
@@ -51,7 +51,6 @@ BODY_ALBUM = _('by {album}')
 
 
 class NotifierSettings(object):
-
     def __inner_preference(klass):
         """Function will make a property for a given subclass of Preference"""
 
@@ -65,7 +64,8 @@ class NotifierSettings(object):
         if hasattr(klass, 'pre_migration_name'):
             if xl_settings.get_option(klass.name, None) is None:
                 old_value = xl_settings.get_option(
-                    klass.pre_migration_name, klass.default or None)
+                    klass.pre_migration_name, klass.default or None
+                )
                 if old_value is not None:
                     xl_settings.set_option(klass.name, old_value)
                     xl_settings.MANAGER.remove_option(klass.name)
@@ -92,8 +92,7 @@ class Notifier(PlaybackAdapter):
         notification = Notify.Notification.new("", None, None)
 
         if 'sound' in caps:
-            notification.set_hint('suppress-sound',
-                                  GLib.Variant.new_boolean(True))
+            notification.set_hint('suppress-sound', GLib.Variant.new_boolean(True))
         self.settings.can_show_markup = 'body-markup' in caps
 
         notification.set_urgency(Notify.Urgency.LOW)
@@ -101,7 +100,8 @@ class Notifier(PlaybackAdapter):
 
         # default action is invoked on clicking the notification
         notification.add_action(
-            "default", "this should never be displayed", self.__on_default_action)
+            "default", "this should never be displayed", self.__on_default_action
+        )
 
         self.notification = notification
         PlaybackAdapter.__init__(self, xl_player.PLAYER)
@@ -141,7 +141,8 @@ class Notifier(PlaybackAdapter):
         tray_icon = self.__exaile.gui.tray_icon
         if tray_icon:
             self.__tray_connection = tray_icon.connect(
-                'query-tooltip', self.__on_query_tooltip)
+                'query-tooltip', self.__on_query_tooltip
+            )
         else:
             LOGGER.warning("Tried to connect to non-existing tray icon")
 
@@ -153,7 +154,8 @@ class Notifier(PlaybackAdapter):
         if state and not self.__tray_connection:
             if tray_icon:
                 self.__tray_connection = tray_icon.connect(
-                    'query-tooltip', self.__on_query_tooltip)
+                    'query-tooltip', self.__on_query_tooltip
+                )
             else:
                 self.__try_connect_tray()
         elif not state and self.__tray_connection:
@@ -162,8 +164,7 @@ class Notifier(PlaybackAdapter):
             self.__tray_connection = None
 
     def on_option_set(self, _event, settings, option):
-        if option == notifyprefs.TrayHover.name or \
-                option == 'gui/use_tray':
+        if option == notifyprefs.TrayHover.name or option == 'gui/use_tray':
             has_tray = settings.get_option('gui/use_tray')
             shall_show_tray_hover = self.settings.tray_hover and has_tray
             self.__set_tray_hover_state(shall_show_tray_hover)
@@ -177,7 +178,9 @@ class Notifier(PlaybackAdapter):
                 new_icon = icons.MANAGER.pixbuf_from_icon_name('exaile', size)
                 self.notification.set_image_from_pixbuf(new_icon)
 
-    def __maybe_show_notification(self, summary=None, body='', icon_name=None, force_show=False):
+    def __maybe_show_notification(
+        self, summary=None, body='', icon_name=None, force_show=False
+    ):
         # If summary is none, don't update the Notification
         if summary is not None:
             try:
@@ -186,9 +189,11 @@ class Notifier(PlaybackAdapter):
                 LOGGER.exception("Could not set new notification status.")
                 return
         # decide whether to show the notification or not
-        if self.settings.show_when_focused or \
-                not self.__exaile.gui.main.window.is_active() or \
-                force_show:
+        if (
+            self.settings.show_when_focused
+            or not self.__exaile.gui.main.window.is_active()
+            or force_show
+        ):
             try:
                 self.notification.show()
             except GLib.Error:
@@ -224,7 +229,8 @@ class Notifier(PlaybackAdapter):
             icon_name = media_icon
         elif self.settings.show_covers:
             cover_data = covers.MANAGER.get_cover(
-                track, set_only=True, use_default=True)
+                track, set_only=True, use_default=True
+            )
             size = DEFAULT_ICON_SIZE if self.settings.resize_covers else None
             new_icon = pixbuf_from_data(cover_data, size)
             self.notification.set_image_from_pixbuf(new_icon)
@@ -261,7 +267,6 @@ class Notifier(PlaybackAdapter):
 
 
 class NotifyPlugin(object):
-
     def __init__(self):
         self.__notifier = None
         self.__exaile = None
@@ -285,11 +290,14 @@ class NotifyPlugin(object):
             # Test it on window manager sessions (e.g. Weston) without
             # libnotify support, not on a Desktop Environment (such as
             # GNOME, KDE) to reproduce.
-            available, name, vendor, version, spec_version = \
-                Notify.get_server_info()
+            available, name, vendor, version, spec_version = Notify.get_server_info()
             if available:
-                LOGGER.info("Connected with notify server %s (version %s) by %s",
-                            name, version, vendor)
+                LOGGER.info(
+                    "Connected with notify server %s (version %s) by %s",
+                    name,
+                    version,
+                    vendor,
+                )
                 LOGGER.info("Supported spec version: %s", spec_version)
                 # This is another synchronous, blocking call:
                 caps = Notify.get_server_caps()
@@ -302,7 +310,8 @@ class NotifyPlugin(object):
                 LOGGER.error(
                     "Failed to retrieve capabilities from notify server. "
                     "This may happen if the desktop environment does not support "
-                    "the org.freedesktop.Notifications DBus interface.")
+                    "the org.freedesktop.Notifications DBus interface."
+                )
                 can_continue = False
         self.__handle_init(can_continue, caps)
 
@@ -317,8 +326,7 @@ class NotifyPlugin(object):
 
         if can_continue:  # check again, might have changed
             if exaile.loading:
-                xl_event.add_ui_callback(
-                    self.__init_notifier, 'gui_loaded', None, caps)
+                xl_event.add_ui_callback(self.__init_notifier, 'gui_loaded', None, caps)
             else:
                 self.__init_notifier(caps)
         else:

--- a/plugins/osd/__init__.py
+++ b/plugins/osd/__init__.py
@@ -24,11 +24,7 @@ from gi.repository import Gdk
 from gi.repository import GLib
 from gi.repository import Gtk
 
-from xl import (
-    event,
-    player,
-    settings as xl_settings
-)
+from xl import event, player, settings as xl_settings
 from xl.nls import gettext as _
 from xlgui.widgets import info
 from xlgui import guiutil
@@ -50,7 +46,9 @@ def do_assert(is_bool):
         raise AssertionError()
 
 
-def _sanitize_window_geometry(window, current_allocation, padding, width_fill, height_fill):
+def _sanitize_window_geometry(
+    window, current_allocation, padding, width_fill, height_fill
+):
     """
         Sanitizes (x-offset, y-offset, width, height) of the given window,
         to make the window show on the screen.
@@ -77,8 +75,7 @@ def _sanitize_window_geometry(window, current_allocation, padding, width_fill, h
 
     if cural.x != newal.x or cural.y != newal.y:
         if cural.width != newal.width or cural.height != newal.height:
-            window.get_window().move_resize(
-                newal.x, newal.y, newal.width, newal.height)
+            window.get_window().move_resize(newal.x, newal.y, newal.width, newal.height)
         else:
             window.move(newal.x, newal.y)
     else:
@@ -124,7 +121,9 @@ class OSDPlugin(object):
             # Setting opacity on Windows crashes with segfault,
             # see https://bugzilla.gnome.org/show_bug.cgi?id=674449
             self.__options['use_alpha'] = False
-            LOGGER.warn("OSD: Disabling alpha channel because it is not supported on Windows.")
+            LOGGER.warn(
+                "OSD: Disabling alpha channel because it is not supported on Windows."
+            )
         else:
             self.__options['use_alpha'] = True
 
@@ -182,11 +181,21 @@ class OSDPlugin(object):
         do_assert(self.__window is None)
         self.__window = OSDWindow(self.__css_provider, self.__options, be_editable)
         # Trigger initial setup through options.
-        for option in ('format', 'background', 'display_duration',
-                       'show_progress', 'position', 'width', 'height',
-                       'border_radius'):
-            self.__on_option_set('plugin_osd_option_set', xl_settings,
-                                 'plugin/osd/{option}'.format(option=option))
+        for option in (
+            'format',
+            'background',
+            'display_duration',
+            'show_progress',
+            'position',
+            'width',
+            'height',
+            'border_radius',
+        ):
+            self.__on_option_set(
+                'plugin_osd_option_set',
+                xl_settings,
+                'plugin/osd/{option}'.format(option=option),
+            )
         self.__window.restore_geometry_and_show()
 
     def __on_option_set(self, _event, settings, option):
@@ -194,14 +203,18 @@ class OSDPlugin(object):
             Updates appearance on setting change
         """
         if option == 'plugin/osd/format':
-            self.__window.info_area.set_info_format(settings.get_option(
-                option, osd_preferences.FormatPreference.default))
+            self.__window.info_area.set_info_format(
+                settings.get_option(option, osd_preferences.FormatPreference.default)
+            )
         elif option == 'plugin/osd/background':
             if not self.__options['background']:
                 self.__options['background'] = Gdk.RGBA()
             rgba = self.__options['background']
-            rgba.parse(settings.get_option(
-                option, osd_preferences.BackgroundPreference.default))
+            rgba.parse(
+                settings.get_option(
+                    option, osd_preferences.BackgroundPreference.default
+                )
+            )
             if self.__options['use_alpha'] is True:
                 if rgba.alpha > 0.995:
                     # Bug: We need to set opacity to some value < 1 here
@@ -215,17 +228,24 @@ class OSDPlugin(object):
             GLib.idle_add(self.__update_css_provider)
         elif option == 'plugin/osd/border_radius':
             value = settings.get_option(
-                option, osd_preferences.BorderRadiusPreference.default)
+                option, osd_preferences.BorderRadiusPreference.default
+            )
             self.__window.set_border_width(max(6, value // 2))
             self.__options['border_radius'] = value
             GLib.idle_add(self.__update_css_provider)
             self.__window.emit('size-allocate', self.__window.get_allocation())
         elif option == 'plugin/osd/display_duration':
-            self.__options['display_duration'] = int(settings.get_option(
-                option, osd_preferences.DisplayDurationPreference.default))
+            self.__options['display_duration'] = int(
+                settings.get_option(
+                    option, osd_preferences.DisplayDurationPreference.default
+                )
+            )
         elif option == 'plugin/osd/show_progress':
-            self.__window.info_area.set_display_progress(settings.get_option(
-                option, osd_preferences.ShowProgressPreference.default))
+            self.__window.info_area.set_display_progress(
+                settings.get_option(
+                    option, osd_preferences.ShowProgressPreference.default
+                )
+            )
         elif option == 'plugin/osd/position':
             position = Point._make(settings.get_option(option, [20, 20]))
             self.__window.geometry['x'] = position.x
@@ -247,7 +267,9 @@ class OSDPlugin(object):
         else:
             color_str = guiutil.css_from_rgba_without_alpha(bgcolor)
         data_str = "window { background-color: %s; border-radius: %spx; }" % (
-            color_str, str(radius))
+            color_str,
+            str(radius),
+        )
         self.__css_provider.load_from_data(data_str)
         return False
 
@@ -326,7 +348,9 @@ class OSDWindow(Gtk.Window):
         self.connect('screen-changed', self.__on_screen_changed)
 
         style_context = self.get_style_context()
-        style_context.add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        style_context.add_provider(
+            css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
 
         # Init child widgets
         self.info_area = info.TrackInfoPane(player.PLAYER)
@@ -372,9 +396,12 @@ class OSDWindow(Gtk.Window):
             self.set_type_hint(Gdk.WindowTypeHint.NORMAL)
             self.set_title(_("Move or resize OSD"))
             # This is often ignored, but we could try:
-            self.connect('realize', lambda _widget:
-                         self.get_window().set_decorations(
-                             Gdk.WMDecoration.RESIZEH | Gdk.WMDecoration.TITLE))
+            self.connect(
+                'realize',
+                lambda _widget: self.get_window().set_decorations(
+                    Gdk.WMDecoration.RESIZEH | Gdk.WMDecoration.TITLE
+                ),
+            )
         else:
             # On X11 (at least XWayland), this will make the window be not movable,
             # but makes sure the user can still type.
@@ -386,10 +413,17 @@ class OSDWindow(Gtk.Window):
         self.__autohide = not allow_resize_move
 
     def __on_window_state_event(self, _widget, win_state):
-        illegal_states = Gdk.WindowState.FULLSCREEN | Gdk.WindowState.ICONIFIED | \
-            Gdk.WindowState.TILED | Gdk.WindowState.MAXIMIZED | Gdk.WindowState.BELOW
-        if win_state.changed_mask & illegal_states and \
-                win_state.new_window_state & illegal_states:
+        illegal_states = (
+            Gdk.WindowState.FULLSCREEN
+            | Gdk.WindowState.ICONIFIED
+            | Gdk.WindowState.TILED
+            | Gdk.WindowState.MAXIMIZED
+            | Gdk.WindowState.BELOW
+        )
+        if (
+            win_state.changed_mask & illegal_states
+            and win_state.new_window_state & illegal_states
+        ):
             # Just returning Gdk.EVENT_STOP doesn't stop the window manager
             # from changing window state.
             # TODO: This often does not work at all.
@@ -433,8 +467,11 @@ class OSDWindow(Gtk.Window):
 
         gdk_display = self.get_window().get_display()
         # Keep showing the OSD in case the pointer is still over the OSD
-        if Gtk.get_major_version() > 3 or \
-                Gtk.get_major_version() == 3 and Gtk.get_minor_version() >= 20:
+        if (
+            Gtk.get_major_version() > 3
+            or Gtk.get_major_version() == 3
+            and Gtk.get_minor_version() >= 20
+        ):
             gdk_seat = gdk_display.get_default_seat()
             gdk_device = gdk_seat.get_pointer()
         else:
@@ -473,7 +510,8 @@ class OSDWindow(Gtk.Window):
         # (re)start hide process
         if self.__autohide:
             self.__hide_id = GLib.timeout_add_seconds(
-                self.__options['display_duration'], self.__start_fadeout)
+                self.__options['display_duration'], self.__start_fadeout
+            )
         Gtk.Window.present(self)
 
     def restore_geometry_and_show(self):
@@ -529,8 +567,10 @@ class OSDWindow(Gtk.Window):
             # does not support transparency
             visual = screen.get_system_visual()
             self.__options['use_alpha'] = False
-            LOGGER.warn("OSD: Disabling alpha channel because the Gtk+ "
-                        "backend does not support it.")
+            LOGGER.warn(
+                "OSD: Disabling alpha channel because the Gtk+ "
+                "backend does not support it."
+            )
         self.set_visual(visual)
 
     '''

--- a/plugins/osd/osd_preferences.py
+++ b/plugins/osd/osd_preferences.py
@@ -68,9 +68,11 @@ class BackgroundPreference(widgets.RGBAButtonPreference):
 
 class FormatPreference(widgets.TextViewPreference):
     name = 'plugin/osd/format'
-    default = _('<span font_desc="Sans 11" foreground="#fff">$title</span>\n'
-                'by $artist\n'
-                'from $album')
+    default = _(
+        '<span font_desc="Sans 11" foreground="#fff">$title</span>\n'
+        'by $artist\n'
+        'from $album'
+    )
 
 
 class BorderRadiusPreference(widgets.SpinPreference):

--- a/plugins/playlistanalyzer/__init__.py
+++ b/plugins/playlistanalyzer/__init__.py
@@ -38,7 +38,6 @@ from analyzer_dialog import AnalyzerDialog
 
 
 class PlaylistAnalyzerPlugin(object):
-
     def __init__(self):
         self.menu_items = []
         self.dialog = None
@@ -52,13 +51,18 @@ class PlaylistAnalyzerPlugin(object):
     def on_gui_loaded(self):
 
         # register menu items
-        item = menu.simple_menu_item('pz-run', [], _('Analyze playlists'),
-                                     callback=self.on_analyze_playlists)
+        item = menu.simple_menu_item(
+            'pz-run', [], _('Analyze playlists'), callback=self.on_analyze_playlists
+        )
         item.register('menubar-tools-menu')
         self.menu_items.append(item)
 
-        item = menu.simple_menu_item('pz-run', ['export-files'], _('Analyze playlist'),
-                                     callback=self.on_analyze_playlist)
+        item = menu.simple_menu_item(
+            'pz-run',
+            ['export-files'],
+            _('Analyze playlist'),
+            callback=self.on_analyze_playlist,
+        )
         item.register('playlist-panel-context-menu')
         self.menu_items.append(item)
 
@@ -86,9 +90,13 @@ class PlaylistAnalyzerPlugin(object):
         if self._get_track_groups is None:
 
             if 'grouptagger' not in self.exaile.plugins.enabled_plugins:
-                raise ValueError("GroupTagger plugin must be loaded to use the GroupTagger tag")
+                raise ValueError(
+                    "GroupTagger plugin must be loaded to use the GroupTagger tag"
+                )
 
-            self._get_track_groups = self.exaile.plugins.enabled_plugins['grouptagger'].get_track_groups
+            self._get_track_groups = self.exaile.plugins.enabled_plugins[
+                'grouptagger'
+            ].get_track_groups
 
         return self._get_track_groups(track)
 
@@ -161,21 +169,27 @@ class PlaylistAnalyzerPlugin(object):
         try:
             contents = contents % kwargs
         except Exception:
-            raise RuntimeError("Format string error in template (probably has unescaped % in it)")
+            raise RuntimeError(
+                "Format string error in template (probably has unescaped % in it)"
+            )
 
         outfile = Gio.File.new_for_uri(uri)
         parent_dir = outfile.get_parent()
         if parent_dir:
             parent_dir = parent_dir.get_child("d3.min.js")
 
-        with closing(outfile.replace(None, False, Gio.FileCreateFlags.NONE, None)) as fp:
+        with closing(
+            outfile.replace(None, False, Gio.FileCreateFlags.NONE, None)
+        ) as fp:
             fp.write(str(contents))
 
         # copy d3 to the destination
         # -> TODO: add checkbox to indicate whether it should write d3 there or not
         if parent_dir:
             with open(self.d3_loc, 'rb') as d3fp:
-                with closing(parent_dir.replace(None, False, Gio.FileCreateFlags.NONE, None)) as pfp:
+                with closing(
+                    parent_dir.replace(None, False, Gio.FileCreateFlags.NONE, None)
+                ) as pfp:
                     pfp.write(d3fp.read())
 
 

--- a/plugins/playlistanalyzer/analyzer_dialog.py
+++ b/plugins/playlistanalyzer/analyzer_dialog.py
@@ -41,6 +41,7 @@ import json
 import re
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 from presets import DEFAULT_PRESETS
@@ -57,7 +58,6 @@ class AnalyzerDialog(object):
 
     ui_widgets = [
         'window',
-
         'description_label',
         'info_bar',
         'playlists_list',
@@ -82,8 +82,9 @@ class AnalyzerDialog(object):
 
         guiutil.initialize_from_xml(self)
 
-        self.info_bar = dialogs.MessageBar(self.info_bar, type=Gtk.MessageType.ERROR,
-                                           buttons=Gtk.ButtonsType.CLOSE)
+        self.info_bar = dialogs.MessageBar(
+            self.info_bar, type=Gtk.MessageType.ERROR, buttons=Gtk.ButtonsType.CLOSE
+        )
 
         self.__build_template_list()
         self.__build_playlist_list(selected_playlist)
@@ -109,11 +110,15 @@ class AnalyzerDialog(object):
         self.__sorted_tags = sorted(td, key=tag_data_key)
 
         # setup the selected template
-        guiutil.persist_selection(self.template_list, 0, 'plugin/playlistanalyzer/last_tmpl')
+        guiutil.persist_selection(
+            self.template_list, 0, 'plugin/playlistanalyzer/last_tmpl'
+        )
 
     def __initialize_presets(self):
 
-        presets = settings.get_option('plugin/playlistanalyzer/presets', DEFAULT_PRESETS)
+        presets = settings.get_option(
+            'plugin/playlistanalyzer/presets', DEFAULT_PRESETS
+        )
 
         for preset in presets:
             self.preset_model.append(preset)
@@ -161,7 +166,9 @@ class AnalyzerDialog(object):
 
     def __build_tag_combo(self, idx):
 
-        model = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_PYOBJECT, GObject.TYPE_STRING)
+        model = Gtk.ListStore(
+            GObject.TYPE_STRING, GObject.TYPE_PYOBJECT, GObject.TYPE_STRING
+        )
         widget = Gtk.ComboBox.new_with_model(model)
         cell = Gtk.CellRendererText()
         widget.pack_start(cell, True)
@@ -332,8 +339,13 @@ class AnalyzerDialog(object):
             output_fname = '%s%sanalysis.html' % (pname, ' ' if ' ' in pname else '-')
 
         # get output file
-        output_uri = dialogs.save(self.window, output_fname, 'plugin/playlist_analyzer/dlg_location',
-                                  None, _("Save analysis"))
+        output_uri = dialogs.save(
+            self.window,
+            output_fname,
+            'plugin/playlist_analyzer/dlg_location',
+            None,
+            _("Save analysis"),
+        )
 
         if output_uri is None:
             return
@@ -355,7 +367,7 @@ class AnalyzerDialog(object):
                 'tagdata': json.dumps(tagdata),
                 'playlist_names': [pl.name for pl in playlists],
                 'data': json.dumps(self.plugin.generate_data(tracks, tagdata)),
-                'title': self._get_title()
+                'title': self._get_title(),
             }
 
             self.plugin.write_to_file(tmpl_data['fname'], output_uri, **kwargs)

--- a/plugins/podcasts/__init__.py
+++ b/plugins/podcasts/__init__.py
@@ -54,13 +54,13 @@ class PodcastPanel(panel.Panel):
     def __init__(self, parent):
         panel.Panel.__init__(self, parent, 'podcasts', _('Podcasts'))
         self.podcasts = []
-        self.podcast_playlists = playlist.PlaylistManager(
-            'podcast_plugin_playlists')
+        self.podcast_playlists = playlist.PlaylistManager('podcast_plugin_playlists')
 
         self._setup_widgets()
         self._connect_events()
-        self.podcast_file = os.path.join(xdg.get_plugin_data_dir(),
-                                         'podcasts_plugin.db')
+        self.podcast_file = os.path.join(
+            xdg.get_plugin_data_dir(), 'podcasts_plugin.db'
+        )
         self._load_podcasts()
 
     def _setup_widgets(self):
@@ -90,9 +90,7 @@ class PodcastPanel(panel.Panel):
             GLib.timeout_add_seconds(timeout, self._set_status, '', 0)
 
     def _connect_events(self):
-        self.builder.connect_signals({
-            'on_add_button_clicked': self.on_add_podcast,
-        })
+        self.builder.connect_signals({'on_add_button_clicked': self.on_add_podcast})
 
         self.tree.connect('row-activated', self._on_row_activated)
         self.tree.connect('button-press-event', self._on_button_press)
@@ -118,8 +116,9 @@ class PodcastPanel(panel.Panel):
         self._load_podcasts()
 
     def on_add_podcast(self, *e):
-        dialog = dialogs.TextEntryDialog(_('Enter the URL of the '
-                                           'podcast to add'), _('Open Podcast'))
+        dialog = dialogs.TextEntryDialog(
+            _('Enter the URL of the ' 'podcast to add'), _('Open Podcast')
+        )
         dialog.set_transient_for(self.parent)
         dialog.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
 
@@ -168,9 +167,11 @@ class PodcastPanel(panel.Panel):
                 for link in e.get('enclosures', []):
                     tr = trax.Track(link.href)
                     date = e['updated_parsed']
-                    tr.set_tags(artist=title,
-                                title='%s: %s' % (e['title'], link.href.split('/')[-1]),
-                                date="%d-%02d-%02d" % (date.tm_year, date.tm_mon, date.tm_mday))
+                    tr.set_tags(
+                        artist=title,
+                        title='%s: %s' % (e['title'], link.href.split('/')[-1]),
+                        date="%d-%02d-%02d" % (date.tm_year, date.tm_mon, date.tm_mday),
+                    )
                     tracks.append(tr)
 
             pl.extend(tracks)

--- a/plugins/previewdevice/__init__.py
+++ b/plugins/previewdevice/__init__.py
@@ -29,13 +29,7 @@ from gi.repository import Gtk
 
 import os
 
-from xl import (
-    event,
-    providers,
-    player,
-    settings,
-    xdg
-)
+from xl import event, providers, player, settings, xdg
 
 from xl.nls import gettext as _
 
@@ -45,6 +39,7 @@ from xlgui.widgets import menu, playback
 import previewprefs
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -52,9 +47,11 @@ class SecondaryOutputPlugin(object):
     '''Implements logic for plugin'''
 
     __play_image = Gtk.Image.new_from_icon_name(
-        'media-playback-start', Gtk.IconSize.BUTTON)
+        'media-playback-start', Gtk.IconSize.BUTTON
+    )
     __pause_image = Gtk.Image.new_from_icon_name(
-        'media-playback-pause', Gtk.IconSize.BUTTON)
+        'media-playback-pause', Gtk.IconSize.BUTTON
+    )
 
     def get_preferences_pane(self):
         return previewprefs
@@ -71,15 +68,13 @@ class SecondaryOutputPlugin(object):
         # Initialize the player objects needed
         #
 
-        self.player = player.player.ExailePlayer('preview_device',
-                                                 disable_autoswitch=True)
+        self.player = player.player.ExailePlayer(
+            'preview_device', disable_autoswitch=True
+        )
         self.queue = player.queue.PlayQueue(
             self.player,
-            location=os.path.join(
-                xdg.get_data_dir(),
-                'preview_device_queue.state'
-            ),
-            name='Preview Device Queue'
+            location=os.path.join(xdg.get_data_dir(), 'preview_device_queue.state'),
+            name='Preview Device Queue',
         )
 
         #
@@ -121,8 +116,7 @@ class SecondaryOutputPlugin(object):
         self.playpause_button.set_relief(Gtk.ReliefStyle.NONE)
         self._on_playback_end(None, None, None)
         self.playpause_button.connect(
-            'button-press-event',
-            self._on_playpause_button_clicked
+            'button-press-event', self._on_playpause_button_clicked
         )
 
         self.progress_bar = playback.SeekProgressBar(self.player, use_markers=False)
@@ -151,20 +145,21 @@ class SecondaryOutputPlugin(object):
             '',
             _('Preview Player'),
             lambda *e: self.hooked,
-            self._on_view
+            self._on_view,
         )
 
         providers.register('menubar-view-menu', self.menu)
 
-        self.preview_menuitem = menu.simple_menu_item('_preview', ['enqueue'],
-                                                      _('Preview'), callback=self._on_preview,
-                                                      condition_fn=lambda n, p, c: not c['selection-empty'])
+        self.preview_menuitem = menu.simple_menu_item(
+            '_preview',
+            ['enqueue'],
+            _('Preview'),
+            callback=self._on_preview,
+            condition_fn=lambda n, p, c: not c['selection-empty'],
+        )
 
         # TODO: Setup on other context menus
-        self.preview_provides = [
-            'track-panel-menu',
-            'playlist-context-menu',
-        ]
+        self.preview_provides = ['track-panel-menu', 'playlist-context-menu']
 
         for provide in self.preview_provides:
             providers.register(provide, self.preview_menuitem)
@@ -300,8 +295,9 @@ class SecondaryOutputPlugin(object):
         """
 
         if event.button == Gdk.BUTTON_PRIMARY:
-            if event.type == Gdk.EventType.BUTTON_PRESS and \
-                    (self.player.is_paused() or self.player.is_playing()):
+            if event.type == Gdk.EventType.BUTTON_PRESS and (
+                self.player.is_paused() or self.player.is_playing()
+            ):
                 self.player.toggle_pause()
             elif event.type == Gdk.EventType._2BUTTON_PRESS:
                 self.player.stop()
@@ -342,7 +338,8 @@ class SecondaryOutputPlugin(object):
 
         self.playpause_button.set_image(self.__pause_image)
         self.playpause_button.set_tooltip_text(
-            _('Pause Playback (double click to stop)'))
+            _('Pause Playback (double click to stop)')
+        )
 
     def _on_playback_end(self, type, player, object):
         """
@@ -355,8 +352,7 @@ class SecondaryOutputPlugin(object):
         """
             Called when there has been a playback error
         """
-        main.mainwindow().message.show_error(
-            _('Playback error encountered!'), message)
+        main.mainwindow().message.show_error(_('Playback error encountered!'), message)
 
     def _on_toggle_pause(self, type, player, object):
         """

--- a/plugins/previewdevice/previewprefs.py
+++ b/plugins/previewdevice/previewprefs.py
@@ -72,6 +72,7 @@ def __autoconfig():
             settings.set_option('preview_device/audiosink_device', device_id)
             break
 
+
 __autoconfig()
 
 
@@ -88,7 +89,9 @@ class PreviewDeviceCustomAudioSinkPreference(playback.CustomAudioSinkPreference)
     condition_preference_name = 'preview_device/audiosink'
 
 
-class PreviewDeviceSelectDeviceForSinkPreference(playback.SelectDeviceForSinkPreference):
+class PreviewDeviceSelectDeviceForSinkPreference(
+    playback.SelectDeviceForSinkPreference
+):
     name = 'preview_device/audiosink_device'
     condition_preference_name = 'preview_device/audiosink'
 

--- a/plugins/replaygain/__init__.py
+++ b/plugins/replaygain/__init__.py
@@ -34,6 +34,8 @@ try:
 
     def get_preferences_pane():
         return replaygainprefs
+
+
 except Exception:  # fail gracefully if we cant set up the UI
     pass
 
@@ -60,6 +62,7 @@ class ReplaygainVolume(ElementBin):
         Placed at 20 in the pipeline, since most elements should do their
         processing after it.
     """
+
     index = 20
     name = "rgvolume"
 
@@ -75,19 +78,21 @@ class ReplaygainVolume(ElementBin):
 
         # load settings
         for x in ("album-mode", "pre-amp", "fallback-gain"):
-            self._on_option_set("replaygain_option_set", None,
-                                "replaygain/%s" % x)
+            self._on_option_set("replaygain_option_set", None, "replaygain/%s" % x)
 
     def _on_option_set(self, name, object, data):
         if data == "replaygain/album-mode":
-            self.rgvol.set_property("album-mode",
-                                    settings.get_option("replaygain/album-mode", True))
+            self.rgvol.set_property(
+                "album-mode", settings.get_option("replaygain/album-mode", True)
+            )
         elif data == "replaygain/pre-amp":
-            self.rgvol.set_property("pre-amp",
-                                    settings.get_option("replaygain/pre-amp", 0))
+            self.rgvol.set_property(
+                "pre-amp", settings.get_option("replaygain/pre-amp", 0)
+            )
         elif data == "replaygain/fallback-gain":
-            self.rgvol.set_property("fallback-gain",
-                                    settings.get_option("replaygain/fallback-gain", 0))
+            self.rgvol.set_property(
+                "fallback-gain", settings.get_option("replaygain/fallback-gain", 0)
+            )
 
 
 class ReplaygainLimiter(ElementBin):
@@ -97,6 +102,7 @@ class ReplaygainLimiter(ElementBin):
         Placed at 80 in the pipeline so that other elements can come
         before it if necessary.
     """
+
     index = 80
     name = "rglimiter"
 
@@ -109,11 +115,12 @@ class ReplaygainLimiter(ElementBin):
         self.setup_elements()
 
         event.add_ui_callback(self._on_option_set, "replaygain_option_set")
-        self._on_option_set("replaygain_option_set", None,
-                            "replaygain/clipping-protection")
+        self._on_option_set(
+            "replaygain_option_set", None, "replaygain/clipping-protection"
+        )
 
     def _on_option_set(self, name, object, data):
         if data == "replaygain/clipping-protection":
-            self.rglimit.set_property("enabled",
-                                      settings.get_option("replaygain/clipping-protection",
-                                                          True))
+            self.rglimit.set_property(
+                "enabled", settings.get_option("replaygain/clipping-protection", True)
+            )

--- a/plugins/screensaverpause/__init__.py
+++ b/plugins/screensaverpause/__init__.py
@@ -58,6 +58,7 @@ import prefs
 def get_preferences_pane():
     return prefs
 
+
 matches = set()
 bus = None
 was_playing = None
@@ -83,8 +84,11 @@ def _enable(*a):
     global bus
     bus = dbus.SessionBus()
     for service in SERVICES:
-        matches.add(bus.add_signal_receiver(screensaver_active_changed,
-                                            signal_name='ActiveChanged', **service))
+        matches.add(
+            bus.add_signal_receiver(
+                screensaver_active_changed, signal_name='ActiveChanged', **service
+            )
+        )
 
 
 def disable(exaile):
@@ -97,6 +101,7 @@ def disable(exaile):
 
 def test():
     import dbus.mainloop.glib as dbgl
+
     dbgl.DBusGMainLoop(set_as_default=True)
 
     global bus
@@ -104,8 +109,9 @@ def test():
 
     for service in SERVICES:
         try:
-            proxy = bus.get_object(service['bus_name'], service['path'],
-                                   follow_name_owner_changes=True)
+            proxy = bus.get_object(
+                service['bus_name'], service['path'], follow_name_owner_changes=True
+            )
         except dbus.DBusException:
             continue
         break
@@ -118,12 +124,14 @@ def test():
     def active_changed(new_value):
         if not new_value:
             mainloop.quit()
+
     interface.connect_to_signal('ActiveChanged', screensaver_active_changed)
 
     # For some reason Lock never returns.
     interface.Lock(ignore_reply=True)
 
     mainloop.run()
+
 
 if __name__ == '__main__':
     test()

--- a/plugins/shutdown/__init__.py
+++ b/plugins/shutdown/__init__.py
@@ -25,19 +25,25 @@ from xlgui.widgets import dialogs, menu
 SHUTDOWN = None
 
 
-class Shutdown():
-
+class Shutdown:
     def __init__(self, exaile):
         self.exaile = exaile
         self.do_shutdown = False
 
         # add menuitem to tools menu
-        providers.register('menubar-tools-menu',
-                           menu.simple_separator('plugin-sep', ['track-properties']))
+        providers.register(
+            'menubar-tools-menu',
+            menu.simple_separator('plugin-sep', ['track-properties']),
+        )
 
-        item = menu.check_menu_item('shutdown', ['plugin-sep'], _('Shutdown after Playback'),
-                                    #   checked func                # callback func
-                                    lambda *x: self.do_shutdown, lambda w, n, p, c: self.on_toggled(w))
+        item = menu.check_menu_item(
+            'shutdown',
+            ['plugin-sep'],
+            _('Shutdown after Playback'),
+            #   checked func                # callback func
+            lambda *x: self.do_shutdown,
+            lambda w, n, p, c: self.on_toggled(w),
+        )
         providers.register('menubar-tools-menu', item)
 
         self.countdown = None
@@ -45,7 +51,8 @@ class Shutdown():
 
         self.message = dialogs.MessageBar(
             parent=exaile.gui.builder.get_object('player_box'),
-            buttons=Gtk.ButtonsType.CLOSE)
+            buttons=Gtk.ButtonsType.CLOSE,
+        )
         self.message.connect('response', self.on_response)
 
     def on_toggled(self, menuitem):
@@ -56,8 +63,10 @@ class Shutdown():
             self.do_shutdown = True
             event.add_ui_callback(self.on_playback_player_end, 'playback_player_end')
 
-            self.message.show_info(_('Shutdown scheduled'),
-                                   _('Computer will be shutdown at the end of playback.'))
+            self.message.show_info(
+                _('Shutdown scheduled'),
+                _('Computer will be shutdown at the end of playback.'),
+            )
         else:
             self.disable_shutdown()
 
@@ -107,7 +116,8 @@ class Shutdown():
         self.countdown = None
         if self.counter > 0:
             self.message.set_secondary_text(
-                _('The computer will be shut down in %d seconds.') % self.counter)
+                _('The computer will be shut down in %d seconds.') % self.counter
+            )
             self.message.show()
 
             self.counter -= 1
@@ -119,22 +129,27 @@ class Shutdown():
         bus = dbus.SystemBus()
 
         try:
-            proxy = bus.get_object('org.freedesktop.login1',
-                                   '/org/freedesktop/login1')
+            proxy = bus.get_object('org.freedesktop.login1', '/org/freedesktop/login1')
             proxy.PowerOff(False, dbus_interface='org.freedesktop.login1.Manager')
         except dbus.exceptions.DBusException:
             try:
-                proxy = bus.get_object('org.freedesktop.ConsoleKit',
-                                       '/org/freedesktop/ConsoleKit/Manager')
+                proxy = bus.get_object(
+                    'org.freedesktop.ConsoleKit', '/org/freedesktop/ConsoleKit/Manager'
+                )
                 proxy.Stop(dbus_interface='org.freedesktop.ConsoleKit.Manager')
             except dbus.exceptions.DBusException:
                 try:
-                    proxy = bus.get_object('org.freedesktop.Hal',
-                                           '/org/freedesktop/Hal/devices/computer')
-                    proxy.Shutdown(dbus_interface='org.freedesktop.Hal.Device.SystemPowerManagement')
+                    proxy = bus.get_object(
+                        'org.freedesktop.Hal', '/org/freedesktop/Hal/devices/computer'
+                    )
+                    proxy.Shutdown(
+                        dbus_interface='org.freedesktop.Hal.Device.SystemPowerManagement'
+                    )
                 except dbus.exceptions.DBusException:
-                    self.message.show_warning(_('Shutdown failed'),
-                                              _('Computer could not be shutdown using D-Bus.'))
+                    self.message.show_warning(
+                        _('Shutdown failed'),
+                        _('Computer could not be shutdown using D-Bus.'),
+                    )
 
     def destroy(self):
         """
@@ -151,7 +166,7 @@ class Shutdown():
 
 
 def enable(exaile):
-    if (exaile.loading):
+    if exaile.loading:
         event.add_callback(_enable, 'exaile_loaded')
     else:
         _enable(None, exaile, None)

--- a/plugins/somafm/__init__.py
+++ b/plugins/somafm/__init__.py
@@ -14,26 +14,19 @@
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 import logging
+
 logger = logging.getLogger(__name__)
 import os
 from urllib2 import urlparse
 import httplib
 import socket
+
 try:
     import xml.etree.cElementTree as ETree
 except ImportError:
     import xml.etree.ElementTree as ETree
-from xl import (
-    event,
-    main,
-    playlist,
-    xdg
-)
-from xl.radio import (
-    RadioStation,
-    RadioList,
-    RadioItem,
-)
+from xl import event, main, playlist, xdg
+from xl.radio import RadioStation, RadioList, RadioItem
 from xl.nls import gettext as _
 from xlgui.panel import radio
 
@@ -97,8 +90,7 @@ class SomaFMRadioStation(RadioStation):
             c = httplib.HTTPConnection(hostinfo.netloc)
 
         try:
-            c.request('GET', hostinfo.path, headers={'User-Agent':
-                                                     self.user_agent})
+            c.request('GET', hostinfo.path, headers={'User-Agent': self.user_agent})
             response = c.getresponse()
         except (socket.timeout, socket.error):
             raise radio.RadioException(_('Error connecting to SomaFM server.'))
@@ -128,8 +120,7 @@ class SomaFMRadioStation(RadioStation):
         """
         channellist = ETree.Element('channellist')
         for channel_id, channel_name in self.data.items():
-            ETree.SubElement(channellist, 'channel', id=channel_id,
-                             name=channel_name)
+            ETree.SubElement(channellist, 'channel', id=channel_id, name=channel_name)
 
         with open(self.cache_file, 'w') as h:
             h.write('<?xml version="1.0" encoding="UTF-8"?>')
@@ -158,8 +149,9 @@ class SomaFMRadioStation(RadioStation):
 
         for id, name in data.items():
             rlist = RadioList(name, station=self)
-            rlist.get_items = lambda no_cache, id = id: \
-                self._get_subrlists(id=id, no_cache=no_cache)
+            rlist.get_items = lambda no_cache, id=id: self._get_subrlists(
+                id=id, no_cache=no_cache
+            )
             rlists.append(rlist)
 
         sort_list = sorted([(item.name, item) for item in rlists])
@@ -215,9 +207,9 @@ class SomaFMRadioStation(RadioStation):
 
             rlist = RadioItem(display_name, station=self)
             rlist.format = format
-            rlist.get_playlist = lambda url = url,\
-                playlist_id = self.playlist_id:\
-                self._get_playlist(url, playlist_id)
+            rlist.get_playlist = lambda url=url, playlist_id=self.playlist_id: self._get_playlist(
+                url, playlist_id
+            )
 
             self.playlist_id += 1
             rlists.append(rlist)

--- a/plugins/streamripper/__init__.py
+++ b/plugins/streamripper/__init__.py
@@ -20,11 +20,7 @@ import os
 import shutil
 from gi.repository import Gtk
 
-from xl import (
-    event,
-    player,
-    settings
-)
+from xl import event, player, settings
 from xl.nls import gettext as _
 from xlgui.widgets import dialogs
 
@@ -40,7 +36,6 @@ def get_preferences_pane():
 
 
 class Streamripper(object):
-
     def __init__(self):
         self.savedir = None
 
@@ -52,8 +47,9 @@ class Streamripper(object):
             logger.warning('Streamripper can only record streams')
             return True
 
-        self.savedir = settings.get_option('plugin/streamripper/save_location',
-                                           os.getenv('HOME'))
+        self.savedir = settings.get_option(
+            'plugin/streamripper/save_location', os.getenv('HOME')
+        )
         options = []
         options.append('streamripper')
         options.append(player.PLAYER._pipe.get_property('uri'))
@@ -68,18 +64,24 @@ class Streamripper(object):
         options.append(self.savedir)
 
         try:
-            self.process = subprocess.Popen(options, 0, None, subprocess.PIPE,
-                                            subprocess.PIPE, subprocess.PIPE)
+            self.process = subprocess.Popen(
+                options, 0, None, subprocess.PIPE, subprocess.PIPE, subprocess.PIPE
+            )
         except OSError:
             logger.error('There was an error executing streamripper')
-            dialogs.error(self.exaile.gui.main.window, _('Error '
-                                                         'executing streamripper'))
+            dialogs.error(
+                self.exaile.gui.main.window, _('Error ' 'executing streamripper')
+            )
             return True
 
         if add_call:
             event.add_callback(self.quit_application, 'quit_application')
-            event.add_ui_callback(self.start_track, 'playback_track_start', player.PLAYER)
-            event.add_ui_callback(self.stop_playback, 'playback_player_end', player.PLAYER)
+            event.add_ui_callback(
+                self.start_track, 'playback_track_start', player.PLAYER
+            )
+            event.add_ui_callback(
+                self.stop_playback, 'playback_player_end', player.PLAYER
+            )
         return False
 
     def stop_ripping(self):
@@ -114,7 +116,6 @@ class Streamripper(object):
 
 
 class Button(Streamripper):
-
     def __init__(self, exaile):
         self.exaile = exaile
         self.button = Gtk.ToggleButton()
@@ -153,7 +154,7 @@ def enable(exaile):
         raise NotImplementedError('Streamripper is not available.')
         return False
 
-    if (exaile.loading):
+    if exaile.loading:
         event.add_callback(_enable, 'exaile_loaded')
     else:
         _enable(None, exaile, None)

--- a/plugins/wikipedia/__init__.py
+++ b/plugins/wikipedia/__init__.py
@@ -39,7 +39,7 @@ from gi.repository import WebKit2
 
 log = logging.getLogger(__name__)
 
-
+# fmt: off
 LANGUAGES = ["ab", "aa", "af", "ak", "sq", "am", "ar", "an", "hy", "as", "av",
              "ae", "ay", "az", "bm", "ba", "eu", "be", "bn", "bh", "bi", "bs", "br", "bg",
              "my", "ca", "ch", "ce", "ny", "cv", "kw", "co", "cr", "hr", "cs", "da", "dv",
@@ -54,7 +54,7 @@ LANGUAGES = ["ab", "aa", "af", "ak", "sq", "am", "ar", "an", "hy", "as", "av",
              "sw", "ss", "sv", "ta", "te", "th", "ti", "bo", "tk", "tl", "tn", "to", "tr",
              "ts", "tw", "ty", "uk", "ur", "ve", "vi", "vk", "vo", "wa", "cy", "wo", "fy",
              "xh", "yi", "yo", "za", "zu"]
-
+# fmt: on
 
 class WikipediaPlugin(object):
 

--- a/plugins/wikipedia/__init__.py
+++ b/plugins/wikipedia/__init__.py
@@ -21,18 +21,14 @@ import urllib2
 from gi.repository import Gtk
 from gi.repository import GLib
 
-from xl import (
-    common,
-    event,
-    providers,
-    settings
-)
+from xl import common, event, providers, settings
 from xl.nls import gettext as _
 from xlgui import panel
 
 import preferences
 
 import gi
+
 gi.require_version('WebKit2', '4.0')
 from gi.repository import WebKit2
 
@@ -55,6 +51,7 @@ LANGUAGES = ["ab", "aa", "af", "ak", "sq", "am", "ar", "an", "hy", "as", "av",
              "ts", "tw", "ty", "uk", "ur", "ve", "vi", "vk", "vo", "wa", "cy", "wo", "fy",
              "xh", "yi", "yo", "za", "zu"]
 # fmt: on
+
 
 class WikipediaPlugin(object):
 
@@ -83,7 +80,6 @@ plugin_class = WikipediaPlugin
 
 
 class BrowserPage(WebKit2.WebView):
-
     def __init__(self, builder, user_agent):
         WebKit2.WebView.__init__(self)
 
@@ -133,10 +129,14 @@ class BrowserPage(WebKit2.WebView):
             log.error(e)
             log.error(
                 "Error occurred when trying to retrieve Wikipedia page "
-                "for %s." % artist)
-            html = """
+                "for %s." % artist
+            )
+            html = (
+                """
                 <p style="color: red">No Wikipedia page found for <strong>%s</strong></p>
-                """ % artist
+                """
+                % artist
+            )
 
         GLib.idle_add(self.load_html, html, url)
 

--- a/plugins/winmmkeys/__init__.py
+++ b/plugins/winmmkeys/__init__.py
@@ -16,7 +16,6 @@
 
 
 class WinmmkeysPlugin:
-
     def enable(self, exaile):
         self.exaile = exaile
 
@@ -37,7 +36,6 @@ plugin_class = WinmmkeysPlugin
 
 
 class HotkeyHandler_PyHook:
-
     def __init__(self, exaile):
         import pyHook
         from xl.player import PLAYER, QUEUE
@@ -74,13 +72,15 @@ class HotkeyHandler_PyHook:
 
 
 class HotkeyHandler_Keyboard:
-
     def __init__(self, exaile):
         import keyboard
         from xl.player import PLAYER, QUEUE
+
         self.handlers = [
             # use lambda here because gi function isn't hashable
-            keyboard.add_hotkey('select media', lambda: exaile.gui.main.window.present()),
+            keyboard.add_hotkey(
+                'select media', lambda: exaile.gui.main.window.present()
+            ),
             keyboard.add_hotkey('stop media', PLAYER.stop),
             keyboard.add_hotkey('play/pause media', PLAYER.toggle_pause),
             keyboard.add_hotkey('next track', QUEUE.next),
@@ -93,6 +93,7 @@ class HotkeyHandler_Keyboard:
     def disable(self):
         if hasattr(self, 'handlers'):
             import keyboard
+
             for handler in self.handlers:
                 keyboard.remove_hotkey(handler)
             del self.handlers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ def _fname(ext):
     return ext, local_path, Gio.File.new_for_path(local_path).get_uri()
 
 _all_tracks = [
+    # fmt: off
     TrackData(*_fname('aac'),  size=9404,  writeable=True, has_cover=True, has_tags=True),
     TrackData(*_fname('aiff'), size=21340, writeable=True, has_cover=True, has_tags=True),
     TrackData(*_fname('au'),   size=16425, writeable=False, has_cover=False, has_tags=False),
@@ -58,6 +59,7 @@ _all_tracks = [
     TrackData(*_fname('wav'),  size=46124, writeable=False, has_cover=False, has_tags=False),
     TrackData(*_fname('wma'),  size=4929,  writeable=True, has_cover=False, has_tags=True),
     TrackData(*_fname('wv'),   size=32293, writeable=True, has_cover=False, has_tags=True),
+    # fmt: on
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import pytest
 from xl.trax.track import Track
 
 import logging
+
 logging.basicConfig(level=logging.DEBUG)
 
 
@@ -27,23 +28,34 @@ def exaile_test_cleanup():
     for key in Track._Track__tracksdict.keys():
         del Track._Track__tracksdict[key]
 
+
 #
 # Fixtures for test track data
 #
 
 
-TrackData = collections.namedtuple('TrackData', [
-    'ext', 'filename', 'uri', 'size', 'writeable',
-    'has_cover', 'has_tags'
-])
+TrackData = collections.namedtuple(
+    'TrackData',
+    ['ext', 'filename', 'uri', 'size', 'writeable', 'has_cover', 'has_tags'],
+)
 
 
 def _fname(ext):
     local_path = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), 'data', 'music', 'delerium',
-                     'chimera', '05 - Truly') + os.extsep + ext)
+        os.path.join(
+            os.path.dirname(__file__),
+            'data',
+            'music',
+            'delerium',
+            'chimera',
+            '05 - Truly',
+        )
+        + os.extsep
+        + ext
+    )
 
     return ext, local_path, Gio.File.new_for_path(local_path).get_uri()
+
 
 _all_tracks = [
     # fmt: off
@@ -106,8 +118,8 @@ def test_tracks():
     '''
         Returns an object that can be used to retrieve test track data
     '''
-    class _TestTracks:
 
+    class _TestTracks:
         def get(self, ext):
             return [x for x in _all_tracks if x.filename.endswith(ext)][0]
 

--- a/tests/xl/player/gst/test_fader.py
+++ b/tests/xl/player/gst/test_fader.py
@@ -11,7 +11,6 @@ FadingOut = FadeState.FadingOut
 
 
 class FakeStream(object):
-
     def __init__(self):
         self.reset()
 
@@ -35,16 +34,16 @@ class FakeStream(object):
 
 
 class FakeTrack(object):
-
     def __init__(self, start_off, stop_off, tracklen):
         self.tags = {
             '__startoffset': start_off,
             '__stopoffset': stop_off,
-            '__length': tracklen
+            '__length': tracklen,
         }
 
     def get_tag_raw(self, t):
         return self.tags[t]
+
 
 # TODO: monkeypatch instead
 timeout_args = [()]
@@ -57,6 +56,7 @@ def glib_timeout_add(*args):
 
 def glib_source_remove(src_id):
     pass
+
 
 GLib.timeout_add = glib_timeout_add
 GLib.source_remove = glib_source_remove

--- a/tests/xl/player/gst/test_fader.py
+++ b/tests/xl/player/gst/test_fader.py
@@ -68,6 +68,7 @@ TmEx = 2
 # Test data:
 #   Position, Volume, State, TmSt/TmEx/None, [call, [arg1...]]
 
+# fmt: off
 @pytest.mark.parametrize('test', [
 
     # Test don't manage the volume
@@ -140,6 +141,7 @@ TmEx = 2
     #     (61, 50,  FadingIn,  TmEx, 'execute'),
     # ],
 ])
+# fmt: on
 def test_fader(test):
 
     # Test fade_out_on_play
@@ -200,6 +202,8 @@ def test_calculate_fades():
     # fin, fout, start_off, stop_off, tracklen;
     # start, start+fade, end-fade, end
     calcs = [
+        # fmt: off
+        
         # one is zero/none
         (0, 4, 0, 0, 10,        0, 0, 6, 10),
         (None, 4, 0, 0, 10,     0, 0, 6, 10),
@@ -233,6 +237,8 @@ def test_calculate_fades():
         (4, 4, 4, 8, 10,        4, 6, 6, 8),
         (2, 4, 4, 7, 10,        4, 5, 5, 7),
         (4, 2, 4, 7, 10,        4, 6, 6, 7),
+        
+        # fmt: on
     ]
 
     i = 0

--- a/tests/xl/test_event.py
+++ b/tests/xl/test_event.py
@@ -18,11 +18,11 @@ def glib_idle_add(fn, *args):
     finally:
         on_ui_thread[0] = was_ui_thread
 
+
 GLib.idle_add = glib_idle_add
 
 
 class NormalCallback(object):
-
     def __init__(self):
         self.called = False
         event.add_callback(self.on_cb, 'test')
@@ -36,7 +36,6 @@ class NormalCallback(object):
 
 
 class UiCallback(object):
-
     def __init__(self):
         self.called = False
         event.add_ui_callback(self.on_cb, 'test')

--- a/tests/xl/trax/test_data.py
+++ b/tests/xl/trax/test_data.py
@@ -7,14 +7,16 @@ def test_mp3_exists(test_tracks):
 
 
 def test_all_tracks(test_track):
-    assert os.path.exists(test_track.filename), \
+    assert os.path.exists(test_track.filename), (
         "%s does not exist" % test_track.filename
+    )
 
     assert test_track.uri.startswith('file:///')
 
 
 def test_writable_tracks(writeable_track):
-    assert os.path.exists(writeable_track.filename), \
+    assert os.path.exists(writeable_track.filename), (
         "%s does not exist" % writeable_track.filename
+    )
 
     assert writeable_track.uri.startswith('file:///')

--- a/tests/xl/trax/test_migration.py
+++ b/tests/xl/trax/test_migration.py
@@ -30,28 +30,28 @@ def data(request, tmpdir):
     dbtype = request.param
     base = join(dirname(__file__), '..', '..', 'data', 'db')
     truth = {}
-    
+
     # uses pickle instead of JSON because of unicode issues...
     with open(join(base, 'music.db.pickle')) as fp:
         truth = pickle.load(fp)
-    
+
     if globals()[dbtype] is None:
         pytest.skip('Module %s does not exist' % dbtype)
     else:
         # copy the test data to a tempdir
         loc = str(tmpdir.mkdir(dbtype))
-        
+
         for f in glob.glob(join(base, dbtype, 'music.*')):
             shutil.copyfile(f, join(loc, basename(f)))
-        
+
         return truth, loc, dbtype
 
 
 def test_migration(data):
     truth, loc, dbtype = data
-    
+
     print(os.listdir(loc))
-    
+
     try:
         db = open_shelf(join(loc, 'music.db'))
     except Exception as e:
@@ -63,11 +63,11 @@ def test_migration(data):
             pytest.skip("Invalid dbm module")
             return
         raise
-    
+
     for k, v in truth.iteritems():
         assert k in db
         assert v == db[k]
-    
+
     assert os.listdir(loc) == ['music.db']
-    
+
     db.close()

--- a/tests/xl/trax/test_search.py
+++ b/tests/xl/trax/test_search.py
@@ -19,7 +19,6 @@ def get_search_result_track():
 
 
 class TestMatcher(object):
-
     def setup(self):
         self.mox = mox.Mox()
         self.strack = get_search_result_track()
@@ -61,7 +60,6 @@ class TestMatcher(object):
 
 
 class TestExactMatcher(object):
-
     def setup(self):
         self.str = get_search_result_track()
 
@@ -77,7 +75,6 @@ class TestExactMatcher(object):
 
 
 class TestInMatcher(object):
-
     def setup(self):
         self.str = get_search_result_track()
 
@@ -103,7 +100,6 @@ class TestInMatcher(object):
 
 
 class TestGtLtMatchers(object):
-
     def setup(self):
         self.str = get_search_result_track()
 
@@ -129,9 +125,7 @@ class TestGtLtMatchers(object):
 
 
 class TestMetaMatcherClasses(object):
-
     class _Matcher(object):
-
         def __init__(self, val):
             self.val = val
 
@@ -143,7 +137,6 @@ class TestMetaMatcherClasses(object):
 
 
 class TestNotMetaMatcher(TestMetaMatcherClasses):
-
     def test_true(self):
         matcher = self._Matcher(True)
         matcher = search._NotMetaMatcher(matcher)
@@ -156,7 +149,6 @@ class TestNotMetaMatcher(TestMetaMatcherClasses):
 
 
 class TestOrMetaMatcher(TestMetaMatcherClasses):
-
     def test_true_true(self):
         matcher_1 = self._Matcher(True)
         matcher_2 = self._Matcher(True)
@@ -183,7 +175,6 @@ class TestOrMetaMatcher(TestMetaMatcherClasses):
 
 
 class TestMultiMetaMatcher(TestMetaMatcherClasses):
-
     def test_true(self):
         matcher = [self._Matcher(True)] * 10
         matcher = search._MultiMetaMatcher(matcher)
@@ -196,7 +187,6 @@ class TestMultiMetaMatcher(TestMetaMatcherClasses):
 
 
 class TestManyMultiMetaMatcher(TestMetaMatcherClasses):
-
     def test_true(self):
         matcher = [self._Matcher(True)] * 10 + [self._Matcher(False)]
         for match in matcher:
@@ -213,7 +203,6 @@ class TestManyMultiMetaMatcher(TestMetaMatcherClasses):
 
 
 class TestTracksMatcher(object):
-
     def setup(self):
         self.str = get_search_result_track()
 
@@ -295,8 +284,7 @@ class TestTracksMatcher(object):
             assert not "We lost both parts of an or"
 
     def test_paren_matcher(self):
-        matcher = search.TracksMatcher("( foo | bar )",
-                                       keyword_tags=['artist'])
+        matcher = search.TracksMatcher("( foo | bar )", keyword_tags=['artist'])
         match = matcher
         # MultiMetaMatcher
         assert len(match.matchers) == 1
@@ -338,8 +326,7 @@ class TestTracksMatcher(object):
             assert not "We lost both parts of an or"
 
     def test_match_true(self):
-        matcher = search.TracksMatcher("foo",
-                                       keyword_tags=['artist'])
+        matcher = search.TracksMatcher("foo", keyword_tags=['artist'])
         self.str.track.set_tag_raw('artist', 'foo')
         assert matcher.match(self.str)
         assert self.str.on_tags == ['artist']
@@ -363,14 +350,12 @@ class TestTracksMatcher(object):
         assert self.str.on_tags == ['artist']
 
     def test_match_false(self):
-        matcher = search.TracksMatcher("foo",
-                                       keyword_tags=['artist'])
+        matcher = search.TracksMatcher("foo", keyword_tags=['artist'])
         self.str.track.set_tag_raw('artist', 'bar')
         assert not matcher.match(self.str)
 
 
 class TestSearchTracks(object):
-
     def test_search_tracks(self):
         matcher = search.TracksMatcher("foo", keyword_tags=['artist'])
         tracks = [track.Track(x) for x in ('foo', 'bar', 'baz', 'quux')]
@@ -398,18 +383,13 @@ class TestSearchTracks(object):
         tracks = [track.Track(x) for x in ('foo', 'bar', 'baz', 'quux')]
         tracks[0].set_tag_raw('artist', 'foooo')
         tracks[2].set_tag_raw('artist', 'foooooo')
-        gen = search.search_tracks_from_string(tracks, 'foo',
-                                               keyword_tags=['artist'])
+        gen = search.search_tracks_from_string(tracks, 'foo', keyword_tags=['artist'])
         assert gen.next().track == tracks[0]
         assert gen.next().track == tracks[2]
         with pytest.raises(StopIteration):
             gen.next()
 
-    @pytest.mark.parametrize("sstr", [
-        "motley crue",
-        u"mötley crüe",
-        u"motley crüe",
-    ])
+    @pytest.mark.parametrize("sstr", ["motley crue", u"mötley crüe", u"motley crüe"])
     def test_search_tracks_ignore_diacritic_from_string(self, sstr):
         '''Ensure that searching for tracks with diacritics return
            appropriately normalized results'''
@@ -418,8 +398,7 @@ class TestSearchTracks(object):
         tracks[1].set_tag_raw('artist', 'rubbish')
         tracks[2].set_tag_raw('artist', u'motley crüe')
 
-        gen = search.search_tracks_from_string(tracks, sstr,
-                                               keyword_tags=['artist'])
+        gen = search.search_tracks_from_string(tracks, sstr, keyword_tags=['artist'])
 
         assert gen.next().track == tracks[0]
         assert gen.next().track == tracks[2]
@@ -432,8 +411,7 @@ class TestSearchTracks(object):
         tracks[2].set_tag_raw('artist', u'中')
 
         # the weird character is normalized, so you can't search based on that
-        gen = search.search_tracks_from_string(tracks, u'中',
-                                               keyword_tags=['artist'])
+        gen = search.search_tracks_from_string(tracks, u'中', keyword_tags=['artist'])
 
         assert gen.next().track == tracks[2]
         with pytest.raises(StopIteration):

--- a/tests/xl/trax/test_track.py
+++ b/tests/xl/trax/test_track.py
@@ -35,8 +35,8 @@ class Test_MetadataCacher(object):
         self.mox.StubOutWithMock(GLib, 'timeout_add_seconds')
         self.mox.StubOutWithMock(GLib, 'source_remove')
         GLib.timeout_add_seconds(
-            self.TIMEOUT,
-            self.mc._MetadataCacher__cleanup).AndReturn(timeout_id)
+            self.TIMEOUT, self.mc._MetadataCacher__cleanup
+        ).AndReturn(timeout_id)
 
         self.mox.ReplayAll()
         self.mc.add('foo', 'bar')
@@ -48,8 +48,8 @@ class Test_MetadataCacher(object):
         self.mox.StubOutWithMock(GLib, 'timeout_add_seconds')
         self.mox.StubOutWithMock(GLib, 'source_remove')
         GLib.timeout_add_seconds(
-            mox.IsA(types.IntType),
-            mox.IsA(types.MethodType)).AndReturn(timeout_id)
+            mox.IsA(types.IntType), mox.IsA(types.MethodType)
+        ).AndReturn(timeout_id)
 
         self.mox.ReplayAll()
         self.mc.add('foo', 'bar')
@@ -61,9 +61,9 @@ class Test_MetadataCacher(object):
     def test_remove(self):
         timeout_id = 1
         self.mox.StubOutWithMock(GLib, 'timeout_add_seconds')
-        GLib.timeout_add_seconds(
-            self.TIMEOUT,
-            mox.IsA(types.MethodType)).AndReturn(timeout_id)
+        GLib.timeout_add_seconds(self.TIMEOUT, mox.IsA(types.MethodType)).AndReturn(
+            timeout_id
+        )
 
         self.mox.ReplayAll()
         self.mc.add('foo', 'bar')
@@ -80,7 +80,6 @@ def random_str(l=8):
 
 
 class TestTrack(object):
-
     def setup(self):
         self.mox = mox.Mox()
 
@@ -118,8 +117,7 @@ class TestTrack(object):
     def test_different_url_not_flyweighted(self, test_tracks):
         t1 = track.Track(test_tracks.get('.mp3').filename)
         t2 = track.Track(test_tracks.get('.ogg').filename)
-        assert t1 is not t2, "%s should not be %s" % (repr(t1),
-                                                      repr(t2))
+        assert t1 is not t2, "%s should not be %s" % (repr(t1), repr(t2))
 
     def test_none_url(self):
         with pytest.raises(ValueError):
@@ -128,21 +126,15 @@ class TestTrack(object):
     def test_pickles(self):
         tr = track.Track('/foo')
         tr.set_tag_raw('artist', 'bar')
-        assert tr._pickles() == {
-            '__loc': u'file:///foo',
-            'artist': [u'bar']
-        }
+        assert tr._pickles() == {'__loc': u'file:///foo', 'artist': [u'bar']}
 
     def test_unpickles(self):
-        tr1 = track.Track(_unpickles={'artist': [u'my_artist'],
-                                      '__loc': u'uri'})
+        tr1 = track.Track(_unpickles={'artist': [u'my_artist'], '__loc': u'uri'})
         assert tr1.get_loc_for_io() == u'uri'
 
     def test_unpickles_flyweight(self):
-        tr1 = track.Track(_unpickles={'artist': [u'my_artist'],
-                                      '__loc': u'uri'})
-        tr2 = track.Track(_unpickles={'artist': [u'my_artist'],
-                                      '__loc': u'uri'})
+        tr1 = track.Track(_unpickles={'artist': [u'my_artist'], '__loc': u'uri'})
+        tr2 = track.Track(_unpickles={'artist': [u'my_artist'], '__loc': u'uri'})
         assert tr1 is tr2
 
     def test_takes_nonurl(self, test_track):
@@ -180,8 +172,7 @@ class TestTrack(object):
         loc = test_track.filename
         tr = track.Track(loc)
         self.empty_track_of_tags(tr, ('__loc',))
-        trstr = "<Track u'Unknown (%s)' by u'' from u''>" \
-                % os.path.basename(loc)
+        trstr = "<Track u'Unknown (%s)' by u'' from u''>" % os.path.basename(loc)
         assert str(tr) == trstr
         tr.set_tag_raw('artist', 'art')
         tr.set_tag_raw('album', 'alb')
@@ -270,6 +261,7 @@ class TestTrack(object):
 
         if writeable_track.ext in ['aac', 'mp4']:
             from mutagen.mp4 import MP4Cover
+
             newcover = CoverImage(None, None, 'image/jpeg', MP4Cover(random_str()))
         else:
             newcover = CoverImage(3, 'cover', 'image/jpeg', bytes(random_str()))
@@ -378,8 +370,7 @@ class TestTrack(object):
 
     def test_expand_doubles(self):
         value = u'ßæĳŋœƕǆǉǌǳҥҵ'
-        assert track.Track.expand_doubles(value) == \
-            u'ssaeijngoehvdzljnjdzngts'
+        assert track.Track.expand_doubles(value) == u'ssaeijngoehvdzljnjdzngts'
 
     def test_lower(self):
         value = u'FooBar'
@@ -427,8 +418,7 @@ class TestTrack(object):
     def test_get_sort_tag_artist(self):
         tr = track.Track('/foo')
         value = u'The Hëllò Wóþλdâ'
-        retval = u'hello woþλda the hëllò wóþλdâ ' \
-                 u'The Hello Woþλda The Hëllò Wóþλdâ'
+        retval = u'hello woþλda the hëllò wóþλdâ ' u'The Hello Woþλda The Hëllò Wóþλdâ'
         tr.set_tag_raw('artist', value)
         assert tr.get_tag_sort('artist') == retval
 
@@ -490,8 +480,7 @@ class TestTrack(object):
     def test_get_display_tag_compilation(self):
         tr = track.Track('/foo')
         tr.set_tag_raw('__compilation', u'foo')
-        assert tr.get_tag_display('artist') == \
-            track._VARIOUSARTISTSSTR
+        assert tr.get_tag_display('artist') == track._VARIOUSARTISTSSTR
 
     def test_get_display_tag_discnumber(self):
         tr = track.Track('/foo')
@@ -542,8 +531,7 @@ class TestTrack(object):
     def test_get_display_tag_join_false(self):
         tr = track.Track('/foo')
         tr.set_tag_raw('artist', [u'foo', u'bar'])
-        assert tr.get_tag_display('artist', join=False) == \
-            [u'foo', u'bar']
+        assert tr.get_tag_display('artist', join=False) == [u'foo', u'bar']
 
     ## Sort tags
     def test_get_search_tag_loc(self):

--- a/tests/xl/trax/test_util.py
+++ b/tests/xl/trax/test_util.py
@@ -24,9 +24,7 @@ def test_is_valid_track_invalid():
 
 
 class TestGetTracksFromUri(object):
-
     class DummyClass:
-
         def __init__(self, parent, retval):
             self.parent = parent
             self.retval = retval
@@ -57,7 +55,7 @@ class TestGetTracksFromUri(object):
             pass
         else:
             raise NotImplementedError
-#        anything.query_exists(None).AndReturn(True)
+        #        anything.query_exists(None).AndReturn(True)
         anything.query_info('standard::type').AndReturn(anything)
         anything.get_file_type().AndReturn(file_type)
         return anything
@@ -80,8 +78,7 @@ class TestGetTracksFromUri(object):
         Gio.FileInfo().AndReturn(f_anything)
         f_anything.get_file_type().AndReturn(Gio.FileType.REGULAR)
         self.mox.ReplayAll()
-        assert xl.trax.util.get_tracks_from_uri(loc) == \
-            [xl.trax.track.Track(loc)]
+        assert xl.trax.util.get_tracks_from_uri(loc) == [xl.trax.track.Track(loc)]
         self.mox.VerifyAll()
 
     @unittest.skip("Test is borken because of moxing out error")
@@ -105,10 +102,10 @@ class TestGetTracksFromUri(object):
 
 
 class TestSortTracks(object):
-
     def setup(self):
-        self.tracks = [xl.trax.track.Track(url) for url in
-                       ('/tmp/foo', '/tmp/bar', '/tmp/baz')]
+        self.tracks = [
+            xl.trax.track.Track(url) for url in ('/tmp/foo', '/tmp/bar', '/tmp/baz')
+        ]
         for track, val in zip(self.tracks, 'aab'):
             track.set_tag_raw('artist', val)
         for track, val in zip(self.tracks, '212'):
@@ -117,32 +114,31 @@ class TestSortTracks(object):
         self.result = [self.tracks[1], self.tracks[0], self.tracks[2]]
 
     def test_sorted(self):
-        assert xl.trax.util.sort_tracks(self.fields,
-                                        self.tracks) == self.result
+        assert xl.trax.util.sort_tracks(self.fields, self.tracks) == self.result
 
     def test_reversed(self):
-        assert xl.trax.util.sort_tracks(self.fields,
-                                        self.tracks, reverse=True) == list(reversed(self.result))
+        assert xl.trax.util.sort_tracks(self.fields, self.tracks, reverse=True) == list(
+            reversed(self.result)
+        )
 
 
 class TestSortResultTracks(object):
-
     def setup(self):
-        tracks = [xl.trax.track.Track(url) for url in
-                  ('/tmp/foo', '/tmp/bar', '/tmp/baz')]
+        tracks = [
+            xl.trax.track.Track(url) for url in ('/tmp/foo', '/tmp/bar', '/tmp/baz')
+        ]
         for track, val in zip(tracks, 'aab'):
             track.set_tag_raw('artist', val)
         for track, val in zip(tracks, '212'):
             track.set_tag_raw('discnumber', val)
-        self.tracks = [xl.trax.search.SearchResultTrack(track)
-                       for track in tracks]
+        self.tracks = [xl.trax.search.SearchResultTrack(track) for track in tracks]
         self.fields = ('artist', 'discnumber')
         self.result = [self.tracks[1], self.tracks[0], self.tracks[2]]
 
     def test_sorted(self):
-        assert xl.trax.util.sort_result_tracks(self.fields,
-                                               self.tracks) == self.result
+        assert xl.trax.util.sort_result_tracks(self.fields, self.tracks) == self.result
 
     def test_reversed(self):
-        assert xl.trax.util.sort_result_tracks(self.fields,
-                                               self.tracks, True) == list(reversed(self.result))
+        assert xl.trax.util.sort_result_tracks(self.fields, self.tracks, True) == list(
+            reversed(self.result)
+        )

--- a/xl/devices.py
+++ b/xl/devices.py
@@ -76,6 +76,7 @@ class Device(object):
 
         must be subclassed for use
     """
+
     class_autoconnect = False
     library_class = collection.Library
 
@@ -84,7 +85,7 @@ class Device(object):
         self.collection = collection.Collection(name=self.name)
         self.playlists = []
         self._connected = False
-        self.transfer = None    # subclasses need to override this
+        self.transfer = None  # subclasses need to override this
         # if they want transferring
 
     def __get_connected(self):
@@ -141,14 +142,16 @@ class Device(object):
             Send tracks to the device
         """
         if not self.transfer:
-            raise TransferNotSupportedError("Device class does not "
-                                            "support transfer.")
+            raise TransferNotSupportedError(
+                "Device class does not " "support transfer."
+            )
         self.transfer.enqueue(tracks)
 
     def start_transfer(self):
         if not self.transfer:
-            raise TransferNotSupportedError("Device class does not "
-                                            "support transfer.")
+            raise TransferNotSupportedError(
+                "Device class does not " "support transfer."
+            )
         self.transfer.transfer()
 
 

--- a/xl/dynamic.py
+++ b/xl/dynamic.py
@@ -59,8 +59,7 @@ class DynamicManager(providers.ProviderHandler):
                 found, a random selection of those tracks is
                 returned.
         """
-        logger.debug(u"Searching for %s tracks related to %s",
-                     limit, track)
+        logger.debug(u"Searching for %s tracks related to %s", limit, track)
         artists = self.find_similar_artists(track)
         if artists == []:
             return []
@@ -71,7 +70,8 @@ class DynamicManager(providers.ProviderHandler):
             artist = artists[i][1].replace('"', '\\\"')
             i += 1
             searchres = search.search_tracks_from_string(
-                self.collection, 'artist=="%s"' % artist, case_sensitive=False)
+                self.collection, 'artist=="%s"' % artist, case_sensitive=False
+            )
             choices = [x.track for x in searchres]
             if choices == []:
                 continue
@@ -133,8 +133,7 @@ class DynamicManager(providers.ProviderHandler):
     def _save_info(self, track, info):
         if info == []:
             return
-        filename = os.path.join(self.cachedir,
-                                track.get_tag_raw('artist', join=True))
+        filename = os.path.join(self.cachedir, track.get_tag_raw('artist', join=True))
         with open(filename, 'w') as f:
             f.write("%s\n" % time.time())
             for item in info:
@@ -157,8 +156,7 @@ class DynamicManager(providers.ProviderHandler):
         curr = playlist.current
 
         starttime = time.time()
-        tracks = self.find_similar_tracks(curr, needed,
-                                          playlist)
+        tracks = self.find_similar_tracks(curr, needed, playlist)
 
         remainingtime = 5 - (time.time() - starttime)
 
@@ -175,7 +173,6 @@ MANAGER = DynamicManager()
 
 
 class DynamicSource(object):
-
     def __init__(self):
         pass
 
@@ -184,5 +181,6 @@ class DynamicSource(object):
 
     def _set_manager(self, manager):
         self.manager = manager
+
 
 # vim: et sts=4 sw=4

--- a/xl/externals/gi_composites.py
+++ b/xl/externals/gi_composites.py
@@ -33,8 +33,7 @@ class GtkTemplateWarning(UserWarning):
     pass
 
 
-def _connect_func(builder, obj, signal_name, handler_name,
-                  connect_object, flags, cls):
+def _connect_func(builder, obj, signal_name, handler_name, connect_object, flags, cls):
     '''Handles GtkBuilder signal connect events'''
 
     if connect_object is None:
@@ -47,9 +46,11 @@ def _connect_func(builder, obj, signal_name, handler_name,
     template_inst = builder.get_object(cls.__gtype_name__)
 
     if template_inst is None:  # This should never happen
-        errmsg = "Internal error: cannot find template instance! obj: %s; " \
-                 "signal: %s; handler: %s; connect_obj: %s; class: %s" % \
-                 (obj, signal_name, handler_name, connect_object, cls)
+        errmsg = (
+            "Internal error: cannot find template instance! obj: %s; "
+            "signal: %s; handler: %s; connect_obj: %s; class: %s"
+            % (obj, signal_name, handler_name, connect_object, cls)
+        )
         warnings.warn(errmsg, GtkTemplateWarning)
         return
 
@@ -86,7 +87,7 @@ def _register_template(cls, template_bytes):
             if hasattr(o, '_gtk_callback'):
                 bound_methods.add(name)
                 # Don't need to call this, as connect_func always gets called
-                #cls.bind_template_callback_full(name, o)
+                # cls.bind_template_callback_full(name, o)
         elif isinstance(o, _Child):
             cls.bind_template_child_full(name, True, 0)
             bound_widgets.add(name)
@@ -108,8 +109,10 @@ def _init_template(self, cls, base_init_template):
     # TODO: could disallow using a metaclass.. but this is good enough
     # .. if you disagree, feel free to fix it and issue a PR :)
     if self.__class__ is not cls:
-        raise TypeError("Inheritance from classes with @GtkTemplate decorators "
-                        "is not allowed at this time")
+        raise TypeError(
+            "Inheritance from classes with @GtkTemplate decorators "
+            "is not allowed at this time"
+        )
 
     connected_signals = set()
     self.__connected_template_signals__ = connected_signals
@@ -126,14 +129,18 @@ def _init_template(self, cls, base_init_template):
             #      it's not currently possible for us to know which
             #      one is broken either -- but the stderr should show
             #      something useful with a Gtk-CRITICAL message)
-            raise AttributeError("A missing child widget was set using "
-                                 "GtkTemplate.Child and the entire "
-                                 "template is now broken (widgets: %s)" %
-                                 ', '.join(self.__gtemplate_widgets__))
+            raise AttributeError(
+                "A missing child widget was set using "
+                "GtkTemplate.Child and the entire "
+                "template is now broken (widgets: %s)"
+                % ', '.join(self.__gtemplate_widgets__)
+            )
 
     for name in self.__gtemplate_methods__.difference(connected_signals):
-        errmsg = ("Signal '%s' was declared with @GtkTemplate.Callback " +
-                  "but was not present in template") % name
+        errmsg = (
+            "Signal '%s' was declared with @GtkTemplate.Callback "
+            + "but was not present in template"
+        ) % name
         warnings.warn(errmsg, GtkTemplateWarning)
 
 
@@ -248,7 +255,9 @@ class _GtkTemplate(object):
         # - Prefer the resource path first
 
         try:
-            template_bytes = Gio.resources_lookup_data(self.ui, Gio.ResourceLookupFlags.NONE)
+            template_bytes = Gio.resources_lookup_data(
+                self.ui, Gio.ResourceLookupFlags.NONE
+            )
         except GLib.GError:
             ui = self.ui
             if isinstance(ui, (list, tuple)):

--- a/xl/externals/sigint.py
+++ b/xl/externals/sigint.py
@@ -46,10 +46,9 @@ class InterruptibleLoopContext(object):
         # not already been one.
         if sys.platform != 'win32' and not InterruptibleLoopContext._loop_contexts:
             # Add a glib signal handler
-            source_id = GLib.unix_signal_add(GLib.PRIORITY_DEFAULT,
-                                             signal.SIGINT,
-                                             self._glib_sigint_handler,
-                                             None)
+            source_id = GLib.unix_signal_add(
+                GLib.PRIORITY_DEFAULT, signal.SIGINT, self._glib_sigint_handler, None
+            )
             InterruptibleLoopContext._signal_source_id = source_id
 
         InterruptibleLoopContext._loop_contexts.append(self)
@@ -60,8 +59,10 @@ class InterruptibleLoopContext(object):
 
         # if the context stack is empty and we have a GLib signal source,
         # remove the source from GLib and clear out the variable.
-        if not InterruptibleLoopContext._loop_contexts and \
-                InterruptibleLoopContext._signal_source_id is not None:
+        if (
+            not InterruptibleLoopContext._loop_contexts
+            and InterruptibleLoopContext._signal_source_id is not None
+        ):
             GLib.source_remove(InterruptibleLoopContext._signal_source_id)
             InterruptibleLoopContext._signal_source_id = None
 

--- a/xl/formatter.py
+++ b/xl/formatter.py
@@ -36,12 +36,7 @@ from gi.repository import GObject
 import re
 from string import Template, _TemplateMetaclass
 
-from xl import (
-    common,
-    providers,
-    settings,
-    trax
-)
+from xl import common, providers, settings, trax
 from xl.common import TimeSpan
 from xl.nls import gettext as _, ngettext
 
@@ -96,6 +91,7 @@ class ParameterTemplate(Template):
         * ``${bar:parameter1, parameter2}``
         * ``${qux:parameter1=argument1, parameter2}``
     """
+
     __metaclass__ = _ParameterTemplateMetaclass
     argpattern = r'[^,}=]|\,|\}|\='
 
@@ -149,8 +145,7 @@ class ParameterTemplate(Template):
             if mo.group('invalid') is not None:
                 return self.delimiter
 
-            raise ValueError('Unrecognized named group in pattern',
-                             self.pattern)
+            raise ValueError('Unrecognized named group in pattern', self.pattern)
 
         return self.pattern.sub(convert, self.template)
 
@@ -169,13 +164,14 @@ class Formatter(GObject.GObject):
         * ``padstring``: a string to use for padding, will be repeated as often as possible to achieve the desired length specified by ``pad``
             * Example: ``${identifier:pad=4, padstring=XY}`` for *identifier* having the value *a* will become *XYXa*
     """
+
     __gproperties__ = {
         'format': (
             GObject.TYPE_STRING,
             'format string',
             'String the formatting is based on',
             '',
-            GObject.PARAM_READWRITE
+            GObject.PARAM_READWRITE,
         )
     }
 
@@ -245,11 +241,13 @@ class Formatter(GObject.GObject):
 
             if groups['parameters'] is not None:
                 # Split parameters on unescaped comma
-                parameters = [p.lstrip()
-                              for p in re.split(r'(?<!\\),', groups['parameters'])]
+                parameters = [
+                    p.lstrip() for p in re.split(r'(?<!\\),', groups['parameters'])
+                ]
                 # Split arguments on unescaped equals sign
-                parameters = [(re.split(r'(?<!\\)=', p, 1) + [True])[:2]
-                              for p in parameters]
+                parameters = [
+                    (re.split(r'(?<!\\)=', p, 1) + [True])[:2] for p in parameters
+                ]
                 # Turn list of lists into a proper dictionary
                 parameters = dict(parameters)
 
@@ -357,19 +355,20 @@ class ProgressTextFormatter(Formatter):
         playlist = self._player.queue.current_playlist
 
         if playlist and playlist.current_position >= 0:
-            tracks = playlist[playlist.current_position:]
-            total_remaining_time = sum(t.get_tag_raw('__length') or 0
-                                       for t in tracks)
+            tracks = playlist[playlist.current_position :]
+            total_remaining_time = sum(t.get_tag_raw('__length') or 0 for t in tracks)
             total_remaining_time -= current_time
 
-        self._substitutions['current_time'] = \
-            LengthTagFormatter.format_value(current_time)
-        self._substitutions['remaining_time'] = \
-            LengthTagFormatter.format_value(remaining_time)
-        self._substitutions['total_time'] = \
-            LengthTagFormatter.format_value(total_time)
-        self._substitutions['total_remaining_time'] = \
-            LengthTagFormatter.format_value(total_remaining_time)
+        self._substitutions['current_time'] = LengthTagFormatter.format_value(
+            current_time
+        )
+        self._substitutions['remaining_time'] = LengthTagFormatter.format_value(
+            remaining_time
+        )
+        self._substitutions['total_time'] = LengthTagFormatter.format_value(total_time)
+        self._substitutions['total_remaining_time'] = LengthTagFormatter.format_value(
+            total_remaining_time
+        )
 
         return Formatter.format(self)
 
@@ -393,8 +392,9 @@ class TrackFormatter(Formatter):
             :rtype: string
         """
         if not isinstance(track, trax.Track):
-            raise TypeError('First argument to format() needs '
-                            'to be of type xl.trax.Track')
+            raise TypeError(
+                'First argument to format() needs ' 'to be of type xl.trax.Track'
+            )
 
         extractions = self.extract()
         self._substitutions = {}
@@ -496,6 +496,8 @@ class TrackNumberTagFormatter(NumberTagFormatter):
 
     def __init__(self):
         TagFormatter.__init__(self, 'tracknumber')
+
+
 providers.register('tag-formatting', TrackNumberTagFormatter())
 
 
@@ -506,6 +508,8 @@ class DiscNumberTagFormatter(NumberTagFormatter):
 
     def __init__(self):
         TagFormatter.__init__(self, 'discnumber')
+
+
 providers.register('tag-formatting', DiscNumberTagFormatter())
 
 
@@ -534,10 +538,11 @@ class ArtistTagFormatter(TagFormatter):
             :rtype: string
         """
         compilate = parameters.get('compilate', False)
-        value = track.get_tag_display(self.name,
-                                      artist_compilations=compilate)
+        value = track.get_tag_display(self.name, artist_compilations=compilate)
 
         return value
+
+
 providers.register('tag-formatting', ArtistTagFormatter())
 
 
@@ -613,16 +618,17 @@ class TimeTagFormatter(TagFormatter):
                 text += _('%dd ') % span.days
             if span.hours > 0 or text:  # always show hours when > 1 day
                 # TRANSLATORS: Time duration (hours:minutes:seconds)
-                text += _('%d:%02d:%02d') % (
-                    span.hours, span.minutes, span.seconds)
+                text += _('%d:%02d:%02d') % (span.hours, span.minutes, span.seconds)
             else:
                 # TRANSLATORS: Time duration (minutes:seconds)
                 text += _('%d:%02d') % (span.minutes, span.seconds)
 
         else:
-            raise ValueError('Invalid argument "%s" passed to parameter '
-                             '"format" for tag "__length", possible arguments are '
-                             '"short", "long" and "verbose"' % format)
+            raise ValueError(
+                'Invalid argument "%s" passed to parameter '
+                '"format" for tag "__length", possible arguments are '
+                '"short", "long" and "verbose"' % format
+            )
 
         return text
 
@@ -634,6 +640,8 @@ class LengthTagFormatter(TimeTagFormatter):
 
     def __init__(self):
         TimeTagFormatter.__init__(self, '__length')
+
+
 providers.register('tag-formatting', LengthTagFormatter())
 
 
@@ -644,6 +652,8 @@ class StartOffsetTagFormatter(TimeTagFormatter):
 
     def __init__(self):
         TimeTagFormatter.__init__(self, '__startoffset')
+
+
 providers.register('tag-formatting', StartOffsetTagFormatter())
 
 
@@ -654,6 +664,8 @@ class StopOffsetTagFormatter(TimeTagFormatter):
 
     def __init__(self):
         TimeTagFormatter.__init__(self, '__stopoffset')
+
+
 providers.register('tag-formatting', StopOffsetTagFormatter())
 
 
@@ -685,6 +697,8 @@ class RatingTagFormatter(TagFormatter):
         empty = '☆' * int(maximum - rating)
 
         return ('%s%s' % (filled, empty)).decode('utf-8')
+
+
 providers.register('tag-formatting', RatingTagFormatter())
 
 
@@ -706,6 +720,8 @@ class YearTagFormatter(TagFormatter):
             return value[0]
 
         return _("Unknown")
+
+
 providers.register('tag-formatting', YearTagFormatter())
 
 
@@ -764,6 +780,8 @@ class LastPlayedTagFormatter(DateTagFormatter):
 
     def __init__(self):
         DateTagFormatter.__init__(self, '__last_played')
+
+
 providers.register('tag-formatting', LastPlayedTagFormatter())
 
 
@@ -775,6 +793,8 @@ class DateAddedTagFormatter(DateTagFormatter):
 
     def __init__(self):
         DateTagFormatter.__init__(self, '__date_added')
+
+
 providers.register('tag-formatting', DateAddedTagFormatter())
 
 
@@ -802,6 +822,8 @@ class LocationTagFormatter(TagFormatter):
         if path is not None:
             return path
         return common.sanitize_url(track.get_tag_raw('__loc'))
+
+
 providers.register('tag-formatting', LocationTagFormatter())
 
 
@@ -859,6 +881,8 @@ class CommentTagFormatter(TagFormatter):
             value = ' '.join(value.splitlines())
 
         return value
+
+
 providers.register('tag-formatting', CommentTagFormatter())
 
 # vim: et sts=4 sw=4

--- a/xl/hal.py
+++ b/xl/hal.py
@@ -46,7 +46,9 @@ class UDisksPropertyWrapper(object):
         self.iface_type = iface_type
 
     def __getattr__(self, name):
-        return lambda *a, **k: self.obj.__getattr__(name)(*((self.iface_type,) + a), **k)
+        return lambda *a, **k: self.obj.__getattr__(name)(
+            *((self.iface_type,) + a), **k
+        )
 
     # def connect_on_changed(self, fn):
     #    '''Connect to the PropertiesChanged signal'''
@@ -145,8 +147,11 @@ class UDisksBase(providers.ProviderHandler):
             logger.info("Connected to %s", self.name)
             event.log_event("hal_connected", self, None)
         except Exception:
-            logger.info("Failed to connect to %s, automatic detection of "
-                        "devices will be disabled.", self.name)
+            logger.info(
+                "Failed to connect to %s, automatic detection of "
+                "devices will be disabled.",
+                self.name,
+            )
             return False
 
         self._state = 'addremove'
@@ -262,8 +267,9 @@ class UDisksBase(providers.ProviderHandler):
             if priority is None:
                 continue
             # Find highest priority, preferring old provider.
-            if priority > highest_prio or \
-                    (priority == highest_prio and provider is old):
+            if priority > highest_prio or (
+                priority == highest_prio and provider is old
+            ):
                 highest_prio = priority
                 highest = provider
         return old, highest
@@ -344,7 +350,9 @@ class UDisksBase(providers.ProviderHandler):
                     return True
 
             if i == 50:
-                logger.error("%s: Failed to acquire lock. Ignoring device event.", self.name)
+                logger.error(
+                    "%s: Failed to acquire lock. Ignoring device event.", self.name
+                )
                 return False
             i += 1
             time.sleep(.1)
@@ -357,7 +365,7 @@ class UDisks2(UDisksBase):
     paths = [
         ('/org/freedesktop/UDisks2/block_devices/', 'org.freedesktop.UDisks2.Block'),
         ('/org/freedesktop/UDisks2/drives/', 'org.freedesktop.UDisks2.Drive'),
-        ('/org/freedesktop/UDisks2', 'org.freedesktop.DBus.ObjectManager')
+        ('/org/freedesktop/UDisks2', 'org.freedesktop.DBus.ObjectManager'),
     ]
 
     def _connect(self):
@@ -369,11 +377,13 @@ class UDisks2(UDisksBase):
         obj.connect_to_signal('InterfacesRemoved', self._udisks_device_removed)
 
         # listen for PropertiesChanged events on any UDisks2 object
-        self.bus.add_signal_receiver(self._udisks2_properties_changed,
-                                     signal_name='PropertiesChanged',
-                                     dbus_interface='org.freedesktop.DBus.Properties',
-                                     bus_name='org.freedesktop.UDisks2',
-                                     path_keyword='path')
+        self.bus.add_signal_receiver(
+            self._udisks2_properties_changed,
+            signal_name='PropertiesChanged',
+            dbus_interface='org.freedesktop.DBus.Properties',
+            bus_name='org.freedesktop.UDisks2',
+            path_keyword='path',
+        )
 
         return obj
 
@@ -395,7 +405,7 @@ class UDisks(UDisksBase):
     root = 'org.freedesktop.UDisks'
     paths = [
         ('/org/freedesktop/UDisks/drives', 'org.freedesktop.UDisks.Device'),
-        ('/org/freedesktop/UDisks', 'org.freedesktop.UDisks')
+        ('/org/freedesktop/UDisks', 'org.freedesktop.UDisks'),
     ]
 
     def _connect(self):
@@ -433,8 +443,9 @@ class HAL(providers.ProviderHandler):
     def connect(self):
         try:
             self.bus = dbus.SystemBus()
-            hal_obj = self.bus.get_object('org.freedesktop.Hal',
-                                          '/org/freedesktop/Hal/Manager')
+            hal_obj = self.bus.get_object(
+                'org.freedesktop.Hal', '/org/freedesktop/Hal/Manager'
+            )
             self.hal = dbus.Interface(hal_obj, 'org.freedesktop.Hal.Manager')
             logger.debug("HAL Providers: %r", self.get_providers())
             for p in self.get_providers():
@@ -446,8 +457,10 @@ class HAL(providers.ProviderHandler):
             logger.debug("Connected to HAL")
             event.log_event("hal_connected", self, None)
         except Exception:
-            logger.warning("Failed to connect to HAL, "
-                           "autodetection of devices will be disabled.")
+            logger.warning(
+                "Failed to connect to HAL, "
+                "autodetection of devices will be disabled."
+            )
 
     def on_provider_added(self, provider):
         for udi in provider.get_udis(self):
@@ -477,8 +490,7 @@ class HAL(providers.ProviderHandler):
 
     def add_device(self, device_udi):
         if device_udi in self.hal_devices:
-            logger.warning(
-                "Device %s already in hal list, skipping.", device_udi)
+            logger.warning("Device %s already in hal list, skipping.", device_udi)
             return
 
         handler = self.get_handler(device_udi)
@@ -506,10 +518,8 @@ class HAL(providers.ProviderHandler):
             pass
 
     def setup_device_events(self):
-        self.bus.add_signal_receiver(self.add_device,
-                                     "DeviceAdded")
-        self.bus.add_signal_receiver(self.remove_device,
-                                     "DeviceRemoved")
+        self.bus.add_signal_receiver(self.add_device, "DeviceAdded")
+        self.bus.add_signal_receiver(self.remove_device, "DeviceRemoved")
 
 
 class Handler(object):
@@ -580,5 +590,6 @@ class UDisksProvider(object):
             :returns: 'remove' to remove the device from the provider, other
                       values ignored.
         '''
+
 
 # vim: et sts=4 sw=4

--- a/xl/logger_setup.py
+++ b/xl/logger_setup.py
@@ -40,9 +40,7 @@ MAX_LINE_LENGTH = 100
 
 
 class FilterLogger(logging.Logger):
-
     class Filter(logging.Filter):
-
         def filter(self, record):
             pass_record = True
 
@@ -67,7 +65,6 @@ class FilterLogger(logging.Logger):
 
 
 class SafePrettyPrinter(PrettyPrinter):
-
     def _repr(self, *args, **kwargs):
         try:
             return PrettyPrinter._repr(self, *args, **kwargs)
@@ -103,14 +100,14 @@ class VerboseExceptionFormatter(logging.Formatter):
             locals_lines = locals_lines[:MAX_VARS_LINES]
             locals_lines[-1] = '...'
         output_lines.extend(
-            line[:MAX_LINE_LENGTH - 3] + '...' if len(line) > MAX_LINE_LENGTH else line
-            for line in locals_lines)
+            line[: MAX_LINE_LENGTH - 3] + '...' if len(line) > MAX_LINE_LENGTH else line
+            for line in locals_lines
+        )
         output_lines.append('')
         return '\n'.join(output_lines)
 
 
-def start_logging(debug, quiet, debugthreads,
-                  module_filter, level_filter):
+def start_logging(debug, quiet, debugthreads, module_filter, level_filter):
     '''
         Starts logging, only should be called from xl.main
     '''
@@ -146,8 +143,7 @@ def start_logging(debug, quiet, debugthreads,
 
     # Logging to terminal
     handler = logging.StreamHandler()
-    handler.setFormatter(fmt_class(fmt=console_format,
-                                   datefmt=datefmt))
+    handler.setFormatter(fmt_class(fmt=console_format, datefmt=datefmt))
     logging.root.addHandler(handler)
     logging.root.setLevel(console_loglevel)
 
@@ -164,12 +160,11 @@ def start_logging(debug, quiet, debugthreads,
 
     # Logging to file; this also automatically rotates the logs
     logfile = logging.handlers.RotatingFileHandler(
-        os.path.join(logdir, 'exaile.log'),
-        mode='a', backupCount=5)
+        os.path.join(logdir, 'exaile.log'), mode='a', backupCount=5
+    )
     logfile.doRollover()  # each session gets its own file
     logfile.setLevel(file_loglevel)
-    logfile.setFormatter(fmt_class(fmt=file_format,
-                                   datefmt=datefmt))
+    logfile.setFormatter(fmt_class(fmt=file_format, datefmt=datefmt))
     logging.root.addHandler(logfile)
 
     # GTK3 supports sys.excepthook
@@ -192,6 +187,7 @@ def start_logging(debug, quiet, debugthreads,
         # Windows doesn't allow custom fault handler registration
         if hasattr(faulthandler, 'register'):
             import signal
+
             faulthandler.register(signal.SIGUSR2)
         faulthandler.enable()
 

--- a/xl/lyrics.py
+++ b/xl/lyrics.py
@@ -24,23 +24,14 @@
 # do so. If you do not wish to do so, delete this exception statement
 # from your version.
 
-from datetime import (
-    datetime,
-    timedelta
-)
+from datetime import datetime, timedelta
 import os
 import re
 import zlib
 import threading
 
 from xl.nls import gettext as _
-from xl import (
-    common,
-    event,
-    providers,
-    settings,
-    xdg
-)
+from xl import common, event, providers, settings, xdg
 
 
 class LyricsNotFoundException(Exception):
@@ -124,8 +115,7 @@ class LyricsManager(providers.ProviderHandler):
 
     def __init__(self):
         providers.ProviderHandler.__init__(self, "lyrics")
-        self.preferred_order = settings.get_option(
-            'lyrics/preferred_order', [])
+        self.preferred_order = settings.get_option('lyrics/preferred_order', [])
         self.cache = LyricsCache(os.path.join(xdg.get_cache_dir(), 'lyrics.cache'))
 
         event.add_callback(self.on_track_tags_changed, 'track_tags_changed')
@@ -139,10 +129,10 @@ class LyricsManager(providers.ProviderHandler):
             :return: the appropriate cache key
         """
         return (
-            track.get_loc_for_io() +
-            provider.display_name.encode('utf-8') +
-            track.get_tag_display('artist').encode('utf-8') +
-            track.get_tag_display('title').encode('utf-8')
+            track.get_loc_for_io()
+            + provider.display_name.encode('utf-8')
+            + track.get_tag_display('artist').encode('utf-8')
+            + track.get_tag_display('title').encode('utf-8')
         )
 
     def set_preferred_order(self, order):
@@ -262,7 +252,7 @@ class LyricsManager(providers.ProviderHandler):
             (lyrics, source, url, time) = self.cache[key]
             # return if they are not expired
             now = datetime.now()
-            if (now - time < timedelta(hours=cache_time) and not refresh):
+            if now - time < timedelta(hours=cache_time) and not refresh:
                 try:
                     lyrics = zlib.decompress(lyrics)
                 except zlib.error as e:
@@ -308,6 +298,7 @@ class LyricsManager(providers.ProviderHandler):
                 del self.cache[key]
             except KeyError:
                 pass
+
 
 MANAGER = LyricsManager()
 
@@ -364,4 +355,6 @@ class LocalLyricSearch(LyricSearchMethod):
         if not lyrics:
             raise LyricsNotFoundException()
         return (lyrics[0], self.name, "")
+
+
 providers.register('lyrics', LocalLyricSearch())

--- a/xl/main.py
+++ b/xl/main.py
@@ -49,6 +49,7 @@ def _do_heavy_imports():
     global Gio, Gtk, common, xdg
 
     import gi
+
     gi.require_version('Gdk', '3.0')
     gi.require_version('Gtk', '3.0')
     gi.require_version('Gst', '1.0')
@@ -57,6 +58,7 @@ def _do_heavy_imports():
 
     from gi.repository import Gio, Gtk
     from xl import common, xdg
+
 
 # placeholder, - xl.version can be slow to import, which would slow down
 # cli args. Thus we import __version__ later.
@@ -69,159 +71,369 @@ def create_argument_parser():
     """Create command-line argument parser for Exaile"""
 
     import argparse
+
     # argparse hard-codes "usage:" uncapitalized. We replace this with an
     # empty string and put "Usage:" in the actual usage string instead.
 
     class Formatter(argparse.HelpFormatter):
-
         def _format_usage(self, usage, actions, groups, prefix):
             return super(self.__class__, self)._format_usage(usage, actions, groups, "")
 
     p = argparse.ArgumentParser(
         usage=_("Usage: exaile [OPTION...] [LOCATION...]"),
-        description=_("Launch Exaile, optionally adding tracks specified by"
-                      " LOCATION to the active playlist."
-                      " If Exaile is already running, this attempts to use the existing"
-                      " instance instead of creating a new one."),
-        add_help=False, formatter_class=Formatter)
+        description=_(
+            "Launch Exaile, optionally adding tracks specified by"
+            " LOCATION to the active playlist."
+            " If Exaile is already running, this attempts to use the existing"
+            " instance instead of creating a new one."
+        ),
+        add_help=False,
+        formatter_class=Formatter,
+    )
 
     p.add_argument('locs', nargs='*', help=argparse.SUPPRESS)
 
     group = p.add_argument_group(_('Playback Options'))
-    group.add_argument("-n", "--next", dest="Next", action="store_true",
-                       default=False, help=_("Play the next track"))
-    group.add_argument("-p", "--prev", dest="Prev", action="store_true",
-                       default=False, help=_("Play the previous track"))
-    group.add_argument("-s", "--stop", dest="Stop", action="store_true",
-                       default=False, help=_("Stop playback"))
-    group.add_argument("-a", "--play", dest="Play", action="store_true",
-                       default=False, help=_("Play"))
-    group.add_argument("-u", "--pause", dest="Pause", action="store_true",
-                       default=False, help=_("Pause"))
-    group.add_argument("-t", "--play-pause", dest="PlayPause",
-                       action="store_true", default=False, help=_("Pause or resume playback"))
-    group.add_argument("--stop-after-current", dest="StopAfterCurrent",
-                       action="store_true", default=False,
-                       help=_("Stop playback after current track"))
+    group.add_argument(
+        "-n",
+        "--next",
+        dest="Next",
+        action="store_true",
+        default=False,
+        help=_("Play the next track"),
+    )
+    group.add_argument(
+        "-p",
+        "--prev",
+        dest="Prev",
+        action="store_true",
+        default=False,
+        help=_("Play the previous track"),
+    )
+    group.add_argument(
+        "-s",
+        "--stop",
+        dest="Stop",
+        action="store_true",
+        default=False,
+        help=_("Stop playback"),
+    )
+    group.add_argument(
+        "-a", "--play", dest="Play", action="store_true", default=False, help=_("Play")
+    )
+    group.add_argument(
+        "-u",
+        "--pause",
+        dest="Pause",
+        action="store_true",
+        default=False,
+        help=_("Pause"),
+    )
+    group.add_argument(
+        "-t",
+        "--play-pause",
+        dest="PlayPause",
+        action="store_true",
+        default=False,
+        help=_("Pause or resume playback"),
+    )
+    group.add_argument(
+        "--stop-after-current",
+        dest="StopAfterCurrent",
+        action="store_true",
+        default=False,
+        help=_("Stop playback after current track"),
+    )
 
     group = p.add_argument_group(_('Collection Options'))
-    group.add_argument("--add", dest="Add",
-                       # TRANSLATORS: Meta variable for --add and --export-playlist
-                       metavar=_("LOCATION"),
-                       help=_("Add tracks from LOCATION to the collection"))
+    group.add_argument(
+        "--add",
+        dest="Add",
+        # TRANSLATORS: Meta variable for --add and --export-playlist
+        metavar=_("LOCATION"),
+        help=_("Add tracks from LOCATION to the collection"),
+    )
 
     group = p.add_argument_group(_('Playlist Options'))
-    group.add_argument("--export-playlist", dest="ExportPlaylist",
-                       # TRANSLATORS: Meta variable for --add and --export-playlist
-                       metavar=_("LOCATION"),
-                       help=_('Export the current playlist to LOCATION'))
+    group.add_argument(
+        "--export-playlist",
+        dest="ExportPlaylist",
+        # TRANSLATORS: Meta variable for --add and --export-playlist
+        metavar=_("LOCATION"),
+        help=_('Export the current playlist to LOCATION'),
+    )
 
     group = p.add_argument_group(_('Track Options'))
-    group.add_argument("-q", "--query", dest="Query", action="store_true",
-                       default=False, help=_("Query player"))
-    group.add_argument("--format-query", dest="FormatQuery",
-                       # TRANSLATORS: Meta variable for --format-query
-                       metavar=_('FORMAT'),
-                       help=_('Retrieve the current playback state and track information as FORMAT'))
-    group.add_argument("--format-query-tags", dest="FormatQueryTags",
-                       # TRANSLATORS: Meta variable for --format-query-tags
-                       metavar=_('TAGS'),
-                       help=_('Tags to retrieve from the current track; use with --format-query'))
-    group.add_argument("--gui-query", dest="GuiQuery", action="store_true",
-                       default=False, help=_("Show a popup with data of the current track"))
-    group.add_argument("--get-title", dest="GetTitle", action="store_true",
-                       default=False, help=_("Print the title of current track"))
-    group.add_argument("--get-album", dest="GetAlbum", action="store_true",
-                       default=False, help=_("Print the album of current track"))
-    group.add_argument("--get-artist", dest="GetArtist", action="store_true",
-                       default=False, help=_("Print the artist of current track"))
-    group.add_argument("--get-length", dest="GetLength", action="store_true",
-                       default=False, help=_("Print the length of current track"))
-    group.add_argument('--set-rating', dest="SetRating", type=int,
-                       # TRANSLATORS: Variable for command line options with arguments
-                       metavar=_('N'),
-                       help=_('Set rating for current track to N%').replace("%", "%%"))
-    group.add_argument('--get-rating', dest='GetRating', action='store_true',
-                       default=False, help=_('Get rating for current track'))
-    group.add_argument("--current-position", dest="CurrentPosition",
-                       action="store_true", default=False,
-                       help=_("Print the current playback position as time"))
-    group.add_argument("--current-progress", dest="CurrentProgress",
-                       action="store_true", default=False,
-                       help=_("Print the current playback progress as percentage"))
+    group.add_argument(
+        "-q",
+        "--query",
+        dest="Query",
+        action="store_true",
+        default=False,
+        help=_("Query player"),
+    )
+    group.add_argument(
+        "--format-query",
+        dest="FormatQuery",
+        # TRANSLATORS: Meta variable for --format-query
+        metavar=_('FORMAT'),
+        help=_('Retrieve the current playback state and track information as FORMAT'),
+    )
+    group.add_argument(
+        "--format-query-tags",
+        dest="FormatQueryTags",
+        # TRANSLATORS: Meta variable for --format-query-tags
+        metavar=_('TAGS'),
+        help=_('Tags to retrieve from the current track; use with --format-query'),
+    )
+    group.add_argument(
+        "--gui-query",
+        dest="GuiQuery",
+        action="store_true",
+        default=False,
+        help=_("Show a popup with data of the current track"),
+    )
+    group.add_argument(
+        "--get-title",
+        dest="GetTitle",
+        action="store_true",
+        default=False,
+        help=_("Print the title of current track"),
+    )
+    group.add_argument(
+        "--get-album",
+        dest="GetAlbum",
+        action="store_true",
+        default=False,
+        help=_("Print the album of current track"),
+    )
+    group.add_argument(
+        "--get-artist",
+        dest="GetArtist",
+        action="store_true",
+        default=False,
+        help=_("Print the artist of current track"),
+    )
+    group.add_argument(
+        "--get-length",
+        dest="GetLength",
+        action="store_true",
+        default=False,
+        help=_("Print the length of current track"),
+    )
+    group.add_argument(
+        '--set-rating',
+        dest="SetRating",
+        type=int,
+        # TRANSLATORS: Variable for command line options with arguments
+        metavar=_('N'),
+        help=_('Set rating for current track to N%').replace("%", "%%"),
+    )
+    group.add_argument(
+        '--get-rating',
+        dest='GetRating',
+        action='store_true',
+        default=False,
+        help=_('Get rating for current track'),
+    )
+    group.add_argument(
+        "--current-position",
+        dest="CurrentPosition",
+        action="store_true",
+        default=False,
+        help=_("Print the current playback position as time"),
+    )
+    group.add_argument(
+        "--current-progress",
+        dest="CurrentProgress",
+        action="store_true",
+        default=False,
+        help=_("Print the current playback progress as percentage"),
+    )
 
     group = p.add_argument_group(_('Volume Options'))
-    group.add_argument("-i", "--increase-vol", dest="IncreaseVolume", type=int,
-                       # TRANSLATORS: Meta variable for --increase-vol and--decrease-vol
-                       metavar=_("N"),
-                       help=_("Increase the volume by N%").replace("%", "%%"))
-    group.add_argument("-l", "--decrease-vol", dest="DecreaseVolume", type=int,
-                       # TRANSLATORS: Meta variable for --increase-vol and--decrease-vol
-                       metavar=_("N"),
-                       help=_("Decrease the volume by N%").replace("%", "%%"))
-    group.add_argument("-m", "--toggle-mute", dest="ToggleMute",
-                       action="store_true", default=False,
-                       help=_("Mute or unmute the volume"))
-    group.add_argument("--get-volume", dest="GetVolume", action="store_true",
-                       default=False, help=_("Print the current volume percentage"))
+    group.add_argument(
+        "-i",
+        "--increase-vol",
+        dest="IncreaseVolume",
+        type=int,
+        # TRANSLATORS: Meta variable for --increase-vol and--decrease-vol
+        metavar=_("N"),
+        help=_("Increase the volume by N%").replace("%", "%%"),
+    )
+    group.add_argument(
+        "-l",
+        "--decrease-vol",
+        dest="DecreaseVolume",
+        type=int,
+        # TRANSLATORS: Meta variable for --increase-vol and--decrease-vol
+        metavar=_("N"),
+        help=_("Decrease the volume by N%").replace("%", "%%"),
+    )
+    group.add_argument(
+        "-m",
+        "--toggle-mute",
+        dest="ToggleMute",
+        action="store_true",
+        default=False,
+        help=_("Mute or unmute the volume"),
+    )
+    group.add_argument(
+        "--get-volume",
+        dest="GetVolume",
+        action="store_true",
+        default=False,
+        help=_("Print the current volume percentage"),
+    )
 
     group = p.add_argument_group(_('Other Options'))
-    group.add_argument("--new", dest="NewInstance", action="store_true",
-                       default=False, help=_("Start new instance"))
-    group.add_argument("-h", "--help", action="help",
-                       help=_("Show this help message and exit"))
-    group.add_argument("--version", dest="ShowVersion", action="store_true",
-                       help=_("Show program's version number and exit."))
-    group.add_argument("--start-minimized", dest="StartMinimized",
-                       action="store_true", default=False,
-                       help=_("Start minimized (to tray, if possible)"))
-    group.add_argument("--toggle-visible", dest="GuiToggleVisible",
-                       action="store_true", default=False,
-                       help=_("Toggle visibility of the GUI (if possible)"))
-    group.add_argument("--safemode", dest="SafeMode", action="store_true",
-                       default=False, help=_("Start in safe mode - sometimes"
-                                             " useful when you're running into problems"))
-    group.add_argument("--force-import", dest="ForceImport",
-                       action="store_true", default=False, help=_("Force import of old data"
-                                                                  " from version 0.2.x (overwrites current data)"))
-    group.add_argument("--no-import", dest="NoImport",
-                       action="store_true", default=False, help=_("Do not import old data"
-                                                                  " from version 0.2.x"))
-    group.add_argument("--start-anyway", dest="StartAnyway",
-                       action="store_true", default=False, help=_("Make control options like"
-                                                                  " --play start Exaile if it is not running"))
+    group.add_argument(
+        "--new",
+        dest="NewInstance",
+        action="store_true",
+        default=False,
+        help=_("Start new instance"),
+    )
+    group.add_argument(
+        "-h", "--help", action="help", help=_("Show this help message and exit")
+    )
+    group.add_argument(
+        "--version",
+        dest="ShowVersion",
+        action="store_true",
+        help=_("Show program's version number and exit."),
+    )
+    group.add_argument(
+        "--start-minimized",
+        dest="StartMinimized",
+        action="store_true",
+        default=False,
+        help=_("Start minimized (to tray, if possible)"),
+    )
+    group.add_argument(
+        "--toggle-visible",
+        dest="GuiToggleVisible",
+        action="store_true",
+        default=False,
+        help=_("Toggle visibility of the GUI (if possible)"),
+    )
+    group.add_argument(
+        "--safemode",
+        dest="SafeMode",
+        action="store_true",
+        default=False,
+        help=_(
+            "Start in safe mode - sometimes" " useful when you're running into problems"
+        ),
+    )
+    group.add_argument(
+        "--force-import",
+        dest="ForceImport",
+        action="store_true",
+        default=False,
+        help=_(
+            "Force import of old data" " from version 0.2.x (overwrites current data)"
+        ),
+    )
+    group.add_argument(
+        "--no-import",
+        dest="NoImport",
+        action="store_true",
+        default=False,
+        help=_("Do not import old data" " from version 0.2.x"),
+    )
+    group.add_argument(
+        "--start-anyway",
+        dest="StartAnyway",
+        action="store_true",
+        default=False,
+        help=_("Make control options like" " --play start Exaile if it is not running"),
+    )
 
     group = p.add_argument_group(_('Development/Debug Options'))
-    group.add_argument("--datadir", dest="UseDataDir",
-                       metavar=_('DIRECTORY'), help=_("Set data directory"))
-    group.add_argument("--all-data-dir", dest="UseAllDataDir",
-                       metavar=_('DIRECTORY'), help=_("Set data and config directory"))
-    group.add_argument("--modulefilter", dest="ModuleFilter",
-                       metavar=_('MODULE'), help=_('Limit log output to MODULE'))
-    group.add_argument("--levelfilter", dest="LevelFilter",
-                       metavar=_('LEVEL'), help=_('Limit log output to LEVEL'),
-                       choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'])
-    group.add_argument("--debug", dest="Debug", action="store_true",
-                       default=False, help=_("Show debugging output"))
-    group.add_argument("--eventdebug", dest="DebugEvent",
-                       action="store_true", default=False, help=_("Enable debugging of"
-                                                                  " xl.event. Generates lots of output"))
-    group.add_argument("--eventdebug-full", dest="DebugEventFull",
-                       action="store_true", default=False, help=_("Enable full debugging of"
-                                                                  " xl.event. Generates LOTS of output"))
-    group.add_argument("--threaddebug", dest="DebugThreads",
-                       action="store_true", default=False, help=_("Add thread name to logging"
-                                                                  " messages."))
-    group.add_argument("--eventfilter", dest="EventFilter", metavar=_('TYPE'),
-                       help=_("Limit xl.event debug to output of TYPE"))
-    group.add_argument("--quiet", dest="Quiet", action="store_true",
-                       default=False, help=_("Reduce level of output"))
-    group.add_argument('--startgui', dest='StartGui', action='store_true',
-                       default=False)
-    group.add_argument('--no-dbus', dest='Dbus', action='store_false',
-                       default=True, help=_("Disable D-Bus support"))
-    group.add_argument('--no-hal', dest='Hal', action='store_false',
-                       default=True, help=_("Disable HAL support."))
+    group.add_argument(
+        "--datadir",
+        dest="UseDataDir",
+        metavar=_('DIRECTORY'),
+        help=_("Set data directory"),
+    )
+    group.add_argument(
+        "--all-data-dir",
+        dest="UseAllDataDir",
+        metavar=_('DIRECTORY'),
+        help=_("Set data and config directory"),
+    )
+    group.add_argument(
+        "--modulefilter",
+        dest="ModuleFilter",
+        metavar=_('MODULE'),
+        help=_('Limit log output to MODULE'),
+    )
+    group.add_argument(
+        "--levelfilter",
+        dest="LevelFilter",
+        metavar=_('LEVEL'),
+        help=_('Limit log output to LEVEL'),
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+    )
+    group.add_argument(
+        "--debug",
+        dest="Debug",
+        action="store_true",
+        default=False,
+        help=_("Show debugging output"),
+    )
+    group.add_argument(
+        "--eventdebug",
+        dest="DebugEvent",
+        action="store_true",
+        default=False,
+        help=_("Enable debugging of" " xl.event. Generates lots of output"),
+    )
+    group.add_argument(
+        "--eventdebug-full",
+        dest="DebugEventFull",
+        action="store_true",
+        default=False,
+        help=_("Enable full debugging of" " xl.event. Generates LOTS of output"),
+    )
+    group.add_argument(
+        "--threaddebug",
+        dest="DebugThreads",
+        action="store_true",
+        default=False,
+        help=_("Add thread name to logging" " messages."),
+    )
+    group.add_argument(
+        "--eventfilter",
+        dest="EventFilter",
+        metavar=_('TYPE'),
+        help=_("Limit xl.event debug to output of TYPE"),
+    )
+    group.add_argument(
+        "--quiet",
+        dest="Quiet",
+        action="store_true",
+        default=False,
+        help=_("Reduce level of output"),
+    )
+    group.add_argument(
+        '--startgui', dest='StartGui', action='store_true', default=False
+    )
+    group.add_argument(
+        '--no-dbus',
+        dest='Dbus',
+        action='store_false',
+        default=True,
+        help=_("Disable D-Bus support"),
+    )
+    group.add_argument(
+        '--no-hal',
+        dest='Hal',
+        action='store_false',
+        default=True,
+        help=_("Disable HAL support."),
+    )
 
     return p
 
@@ -230,16 +442,19 @@ class Exaile(object):
     _exaile = None
 
     def __get_player(self):
-        raise DeprecationWarning('Using exaile.player is deprecated: '
-                                 'import xl.player.PLAYER instead.')
+        raise DeprecationWarning(
+            'Using exaile.player is deprecated: ' 'import xl.player.PLAYER instead.'
+        )
 
     def __get_queue(self):
-        raise DeprecationWarning('Using exaile.queue is deprecated: '
-                                 'import xl.player.QUEUE instead.')
+        raise DeprecationWarning(
+            'Using exaile.queue is deprecated: ' 'import xl.player.QUEUE instead.'
+        )
 
     def __get_lyrics(self):
-        raise DeprecationWarning('Using exaile.lyrics is deprecated: '
-                                 'import xl.lyrics.MANAGER instead.')
+        raise DeprecationWarning(
+            'Using exaile.lyrics is deprecated: ' 'import xl.lyrics.MANAGER instead.'
+        )
 
     player = property(__get_player)
     queue = property(__get_queue)
@@ -273,10 +488,11 @@ class Exaile(object):
                     alldatadir.decode('ascii')
                 except UnicodeDecodeError:
                     # if we don't do this here, os.path.join() will fail later.
-                    alldatadir = alldatadir.decode('utf-8').encode(
-                        'ascii', 'replace')
-                    print("WARNING : converted non-ASCII data dir %s to ascii: %s"
-                          % (self.options.UseAllDataDir, alldatadir))
+                    alldatadir = alldatadir.decode('utf-8').encode('ascii', 'replace')
+                    print(
+                        "WARNING : converted non-ASCII data dir %s to ascii: %s"
+                        % (self.options.UseAllDataDir, alldatadir)
+                    )
             xdg.data_home = alldatadir
             xdg.data_dirs.insert(0, xdg.data_home)
             xdg.config_home = alldatadir
@@ -286,7 +502,10 @@ class Exaile(object):
         try:
             xdg._make_missing_dirs()
         except OSError as e:
-            print('ERROR: Could not create configuration directories: %s' % e, file=sys.stderr)
+            print(
+                'ERROR: Could not create configuration directories: %s' % e,
+                file=sys.stderr,
+            )
             return
 
         # Make event debug imply debug
@@ -297,17 +516,20 @@ class Exaile(object):
             self.options.Debug = True
 
         try:
-            logger_setup.start_logging(self.options.Debug,
-                                       self.options.Quiet,
-                                       self.options.DebugThreads,
-                                       self.options.ModuleFilter,
-                                       self.options.LevelFilter)
+            logger_setup.start_logging(
+                self.options.Debug,
+                self.options.Quiet,
+                self.options.DebugThreads,
+                self.options.ModuleFilter,
+                self.options.LevelFilter,
+            )
         except OSError as e:
             print('ERROR: could not setup logging: %s' % e, file=sys.stderr)
             return
 
         global logger
         import logging
+
         logger = logging.getLogger(__name__)
 
         try:
@@ -331,6 +553,7 @@ class Exaile(object):
             # initialize DbusManager
             if self.options.StartGui and self.options.Dbus:
                 from xl import xldbus
+
                 exit = xldbus.check_exit(self.options, self.options.locs)
                 if exit == "exit":
                     sys.exit(0)
@@ -347,8 +570,12 @@ class Exaile(object):
             self.__init()
 
             # handle delayed commands
-            if self.options.StartGui and self.options.Dbus and \
-                    self.options.StartAnyway and exit == "command":
+            if (
+                self.options.StartGui
+                and self.options.Dbus
+                and self.options.StartAnyway
+                and exit == "command"
+            ):
                 xldbus.run_commands(self.options, self.dbus)
 
             # connect dbus signals
@@ -357,6 +584,7 @@ class Exaile(object):
 
             # On SIGTERM, quit normally.
             import signal
+
             signal.signal(signal.SIGTERM, (lambda sig, stack: self.quit()))
 
             # run the GUIs mainloop, if needed
@@ -392,6 +620,7 @@ class Exaile(object):
         # display locale information if available
         try:
             import locale
+
             lc, enc = locale.getlocale()
             if enc is not None:
                 locale_str = '%s %s' % (lc, enc)
@@ -415,14 +644,17 @@ class Exaile(object):
 
         # Migrate old rating options
         from xl.migrations.settings import rating
+
         rating.migrate()
 
         # Migrate builtin OSD to plugin
         from xl.migrations.settings import osd
+
         osd.migrate()
 
         # Migrate engines
         from xl.migrations.settings import engine
+
         engine.migrate()
 
         # TODO: enable audio plugins separately from normal
@@ -432,10 +664,12 @@ class Exaile(object):
         # miserably when you try to inherit from something and GST hasn't
         # been initialized yet. So this is here.
         from gi.repository import Gst
+
         Gst.init(None)
 
         # Initialize plugin manager
         from xl import plugins
+
         self.plugins = plugins.PluginsManager(self)
 
         if not self.options.SafeMode:
@@ -447,38 +681,47 @@ class Exaile(object):
         # Initialize the collection
         logger.info("Loading collection...")
         from xl import collection
+
         try:
-            self.collection = collection.Collection("Collection",
-                                                    location=os.path.join(xdg.get_data_dir(), 'music.db'))
+            self.collection = collection.Collection(
+                "Collection", location=os.path.join(xdg.get_data_dir(), 'music.db')
+            )
         except common.VersionError:
             logger.exception("VersionError loading collection")
             sys.exit(1)
 
         # Migrate covers.db. This can only be done after the collection is loaded.
         import xl.migrations.database.covers_1to2 as mig
+
         mig.migrate()
 
         from xl import event
+
         # Set up the player and playback queue
         from xl import player
+
         event.log_event("player_loaded", player.PLAYER, None)
 
         # Initalize playlist manager
         from xl import playlist
+
         self.playlists = playlist.PlaylistManager()
-        self.smart_playlists = playlist.SmartPlaylistManager('smart_playlists',
-                                                             collection=self.collection)
+        self.smart_playlists = playlist.SmartPlaylistManager(
+            'smart_playlists', collection=self.collection
+        )
         if firstrun:
             self._add_default_playlists()
         event.log_event("playlists_loaded", self, None)
 
         # Initialize dynamic playlist support
         from xl import dynamic
+
         dynamic.MANAGER.collection = self.collection
 
         # Initalize device manager
         logger.info("Loading devices...")
         from xl import devices
+
         self.devices = devices.DeviceManager()
         event.log_event("device_manager_ready", self, None)
 
@@ -507,6 +750,7 @@ class Exaile(object):
 
         # Radio Manager
         from xl import radio
+
         self.stations = playlist.PlaylistManager('radio_stations')
         self.radio = radio.RadioManager()
 
@@ -516,6 +760,7 @@ class Exaile(object):
             logger.info("Loading interface...")
 
             import xlgui
+
             self.gui = xlgui.Main(self)
             self.gui.main.window.show_all()
             event.log_event("gui_loaded", self, None)
@@ -549,12 +794,14 @@ class Exaile(object):
 
         if restore:
             player.QUEUE._restore_player_state(
-                os.path.join(xdg.get_data_dir(), 'player.state'))
+                os.path.join(xdg.get_data_dir(), 'player.state')
+            )
 
         # pylint: enable-msg=W0201
 
     def version(self):
         from xl.version import __version__
+
         print("Exaile", __version__)
         sys.exit(0)
 
@@ -563,23 +810,27 @@ class Exaile(object):
             Adds some default smart playlists to the playlist manager
         """
         from xl import playlist
+
         # entire playlist
-        entire_lib = playlist.SmartPlaylist(_("Entire Library"),
-                                            collection=self.collection)
+        entire_lib = playlist.SmartPlaylist(
+            _("Entire Library"), collection=self.collection
+        )
         self.smart_playlists.save_playlist(entire_lib, overwrite=True)
 
         # random playlists
         for count in (100, 300, 500):
-            pl = playlist.SmartPlaylist(_("Random %d") % count,
-                                        collection=self.collection)
+            pl = playlist.SmartPlaylist(
+                _("Random %d") % count, collection=self.collection
+            )
             pl.set_return_limit(count)
             pl.set_random_sort(True)
             self.smart_playlists.save_playlist(pl, overwrite=True)
 
         # rating based playlists
         for item in (3, 4):
-            pl = playlist.SmartPlaylist(_("Rating > %d") % item,
-                                        collection=self.collection)
+            pl = playlist.SmartPlaylist(
+                _("Rating > %d") % item, collection=self.collection
+            )
             pl.add_param('__rating', '>', item)
             self.smart_playlists.save_playlist(pl, overwrite=True)
 
@@ -591,18 +842,22 @@ class Exaile(object):
 
         if ver < MIN_VER:
             # Probably should exit?
-            logger.warning("Exaile requires PyGObject %d.%d.%d or greater! (got %d.%d.%d)",
-                           *(MIN_VER + ver))
+            logger.warning(
+                "Exaile requires PyGObject %d.%d.%d or greater! (got %d.%d.%d)",
+                *(MIN_VER + ver)
+            )
 
         if self.options.Dbus:
             import dbus
             import dbus.mainloop.glib
+
             dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
             dbus.mainloop.glib.threads_init()
             dbus.mainloop.glib.gthreads_init()
 
         if not self.options.StartGui:
             from gi.repository import GLib
+
             loop = GLib.MainLoop()
             context = loop.get_context()
             t = threading.Thread(target=self.__mainloop, args=(context,))
@@ -636,11 +891,9 @@ class Exaile(object):
 
         version = __version__
         if '+' in version:  # strip out revision identifier
-            version = version[:version.index('+')]
+            version = version[: version.index('+')]
 
-        fmt = {
-            'version': version
-        }
+        fmt = {'version': version}
 
         if not hasattr(self, '_user_agent_no_plugin'):
 
@@ -649,10 +902,12 @@ class Exaile(object):
             default_no_plugin = 'Exaile/%(version)s (+https://www.exaile.org)'
             default_plugin = 'Exaile/%(version)s %(plugin_name)s/%(plugin_version)s (+https://www.exaile.org)'
 
-            self._user_agent_no_plugin = \
-                settings.get_option('general/user_agent', default_no_plugin)
-            self._user_agent_w_plugin = \
-                settings.get_option('general/user_agent_w_plugin', default_plugin)
+            self._user_agent_no_plugin = settings.get_option(
+                'general/user_agent', default_no_plugin
+            )
+            self._user_agent_w_plugin = settings.get_option(
+                'general/user_agent_w_plugin', default_plugin
+            )
 
         if plugin_name is not None:
             plugin_info = self.plugins.get_plugin_info(plugin_name)
@@ -681,6 +936,7 @@ class Exaile(object):
         self.plugins.teardown(self)
 
         from xl import event
+
         # this event should be used by modules that dont need
         # to be saved in any particular order. modules that might be
         # touched by events triggered here should be added statically
@@ -694,6 +950,7 @@ class Exaile(object):
             self.gui.quit()
 
         from xl import covers
+
         covers.MANAGER.save()
 
         self.collection.save_to_location()
@@ -704,13 +961,15 @@ class Exaile(object):
 
         # save player, queue
         from xl import player
+
         player.QUEUE._save_player_state(
-            os.path.join(xdg.get_data_dir(), 'player.state'))
-        player.QUEUE.save_to_location(
-            os.path.join(xdg.get_data_dir(), 'queue.state'))
+            os.path.join(xdg.get_data_dir(), 'player.state')
+        )
+        player.QUEUE.save_to_location(os.path.join(xdg.get_data_dir(), 'queue.state'))
         player.PLAYER.stop()
 
         from xl import settings
+
         settings.MANAGER.save()
 
         if restart:
@@ -723,6 +982,7 @@ class Exaile(object):
                 # as one string.
                 # See https://bugs.python.org/issue436259 (closed wontfix).
                 import subprocess
+
                 cmd = [python] + sys.argv
                 cmd = subprocess.list2cmdline(cmd)
                 os.execl(python, cmd)
@@ -736,10 +996,15 @@ class Exaile(object):
 
 def exaile():
     if not Exaile._exaile:
-        raise AttributeError(_("Exaile is not yet finished loading"
-                               ". Perhaps you should listen for the exaile_loaded"
-                               " signal?"))
+        raise AttributeError(
+            _(
+                "Exaile is not yet finished loading"
+                ". Perhaps you should listen for the exaile_loaded"
+                " signal?"
+            )
+        )
 
     return Exaile._exaile
+
 
 # vim: et sts=4 sw=4

--- a/xl/metadata/__init__.py
+++ b/xl/metadata/__init__.py
@@ -36,6 +36,7 @@ from xl.metadata import (aiff, ape, asf, flac, mka, mod, mp3, mp4, mpc, ogg, sid
 
 #: dictionary mapping extensions to Format classes.
 formats = {
+    # fmt: off
     '669'   : mod.ModFormat,
     'aac'   : mp4.MP4Format,
     'ac3'   : None,
@@ -81,6 +82,7 @@ formats = {
     'wma'   : asf.AsfFormat,
     'wv'    : wv.WavpackFormat,
     'xm'    : mod.ModFormat,
+    # fmt: on
 }
 
 # pass get_loc_for_io() to this.

--- a/xl/metadata/__init__.py
+++ b/xl/metadata/__init__.py
@@ -31,8 +31,23 @@ from gi.repository import Gio
 from xl.metadata._base import BaseFormat, CoverImage, NotWritable, NotReadable
 import urlparse
 
-from xl.metadata import (aiff, ape, asf, flac, mka, mod, mp3, mp4, mpc, ogg, sid, speex,
-                         tta, wav, wv)
+from xl.metadata import (
+    aiff,
+    ape,
+    asf,
+    flac,
+    mka,
+    mod,
+    mp3,
+    mp4,
+    mpc,
+    ogg,
+    sid,
+    speex,
+    tta,
+    wav,
+    wv,
+)
 
 #: dictionary mapping extensions to Format classes.
 formats = {

--- a/xl/metadata/_apev2.py
+++ b/xl/metadata/_apev2.py
@@ -55,4 +55,5 @@ class ApeFormat(CaseInsensitveBaseFormat):
     others = True
     writable = True
 
+
 # vim: et sts=4 sw=4

--- a/xl/metadata/_base.py
+++ b/xl/metadata/_base.py
@@ -28,10 +28,12 @@ from collections import namedtuple
 import copy
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 from xl import version
 import mutagen
+
 version.register('Mutagen', mutagen.version_string)
 
 
@@ -62,6 +64,7 @@ class BaseFormat(object):
 
         subclasses not using mutagen should leave MutagenType as None
     """
+
     MutagenType = None
 
     # This should contain ALL keys supported by this filetype, unless 'others'
@@ -80,9 +83,12 @@ class BaseFormat(object):
         if cls.case_sensitive:
             cls._reverse_mapping = {v: k for k, v in cls.tag_mapping.iteritems()}
         else:
-            cls._reverse_mapping = {v.lower(): k for k, v in cls.tag_mapping.iteritems()}
+            cls._reverse_mapping = {
+                v.lower(): k for k, v in cls.tag_mapping.iteritems()
+            }
 
         from .tags import disk_tags
+
         cls.ignore_tags = set(disk_tags)
 
     def __init__(self, loc):
@@ -317,5 +323,6 @@ class CaseInsensitveBaseFormat(BaseFormat):
             Returns keys of all tags that can be read from disk
         """
         return [self._reverse_mapping.get(k.lower(), k) for k in self._get_raw().keys()]
+
 
 # vim: et sts=4 sw=4

--- a/xl/metadata/_id3.py
+++ b/xl/metadata/_id3.py
@@ -24,10 +24,7 @@
 # do so. If you do not wish to do so, delete this exception statement
 # from your version.
 
-from xl.metadata._base import (
-    BaseFormat,
-    CoverImage
-)
+from xl.metadata._base import BaseFormat, CoverImage
 from mutagen import id3
 
 
@@ -99,15 +96,22 @@ class ID3Format(BaseFormat):
             for value in field:
                 ret.extend([unicode(value.url.replace('\n', '').replace('\r', ''))])
         elif t == 'APIC':
-            ret = [CoverImage(type=f.type, desc=f.desc, mime=f.mime, data=f.data) for f in field]
+            ret = [
+                CoverImage(type=f.type, desc=f.desc, mime=f.mime, data=f.data)
+                for f in field
+            ]
         elif t == 'COMM':  # Newlines within comments are allowed, keep them
             for item in field:
                 ret.extend([value for value in item.text])
         else:
             for value in field:
                 try:
-                    ret.extend([unicode(x.replace('\n', '').replace('\r', ''))
-                                for x in value.text])
+                    ret.extend(
+                        [
+                            unicode(x.replace('\n', '').replace('\r', ''))
+                            for x in value.text
+                        ]
+                    )
                 except Exception:
                     pass
         return ret
@@ -124,10 +128,20 @@ class ID3Format(BaseFormat):
             data = data[0]
 
         if tag == 'APIC':
-            frames = [id3.Frames[tag](encoding=3, mime=info.mime, type=info.type, desc=info.desc, data=info.data)
-                      for info in data]
+            frames = [
+                id3.Frames[tag](
+                    encoding=3,
+                    mime=info.mime,
+                    type=info.type,
+                    desc=info.desc,
+                    data=info.data,
+                )
+                for info in data
+            ]
         elif tag == 'COMM':
-            frames = [id3.COMM(encoding=3, text=d, desc='', lang='\x00\x00\x00') for d in data]
+            frames = [
+                id3.COMM(encoding=3, text=d, desc='', lang='\x00\x00\x00') for d in data
+            ]
         elif tag == 'WOAR':
             frames = [id3.WOAR(encoding=3, url=d) for d in data]
         else:
@@ -142,5 +156,6 @@ class ID3Format(BaseFormat):
             tag = "TXXX:" + tag
         if raw.tags is not None:
             raw.tags.delall(tag)
+
 
 # vim: et sts=4 sw=4

--- a/xl/metadata/_matroska.py
+++ b/xl/metadata/_matroska.py
@@ -50,7 +50,6 @@ class EbmlWarning(Warning):
 
 
 class BinaryData(bytes):
-
     def __repr__(self):
         return "<BinaryData>"
 
@@ -214,6 +213,7 @@ class Ebml:
                 elif type_ is DATE:
                     us = self.readInteger(size, True) / 1000.0  # ns to us
                     from datetime import datetime, timedelta
+
                     value = datetime(2001, 1, 1) + timedelta(microseconds=us)
                 elif type_ is MASTER:
                     tell = self.tell()
@@ -247,7 +247,9 @@ class GioEbml(Ebml):
         self.buffer = Gio.BufferedInputStream.new(f.read())
         self._tell = 0
 
-        self.size = f.query_info('standard::size', Gio.FileQueryInfoFlags.NONE, None).get_size()
+        self.size = f.query_info(
+            'standard::size', Gio.FileQueryInfoFlags.NONE, None
+        ).get_size()
 
     def seek(self, offset, mode):
         if mode == 0:
@@ -360,11 +362,13 @@ def parse(location):
 
 def dump(location):
     from pprint import pprint
+
     pprint(parse(location))
 
 
 def dump_tags(location):
     from pprint import pprint
+
     mka = parse(location)
     segment = mka['Segment'][0]
     info = segment['Info'][0]
@@ -394,6 +398,7 @@ def gio_location(location):
             location = location.decode(sys.getfilesystemencoding())
         location = location.encode('utf-8')
     return location
+
 
 if __name__ == '__main__':
     location = gio_location(sys.argv[1])

--- a/xl/metadata/aiff.py
+++ b/xl/metadata/aiff.py
@@ -32,4 +32,5 @@ from mutagen import aiff
 class AIFFFormat(ID3Format):
     MutagenType = aiff.AIFF
 
+
 # vim: et sts=4 sw=4

--- a/xl/metadata/ape.py
+++ b/xl/metadata/ape.py
@@ -32,4 +32,5 @@ from mutagen import monkeysaudio
 class MonkeysFormat(ApeFormat):
     MutagenType = monkeysaudio.MonkeysAudio
 
+
 # vim: et sts=4 sw=4

--- a/xl/metadata/asf.py
+++ b/xl/metadata/asf.py
@@ -53,8 +53,12 @@ class AsfFormat(BaseFormat):
         # unicode so things don't break
         tag = super(AsfFormat, self)._get_tag(raw, tag_name)
         if isinstance(tag, list):
-            attrs = [asf.ASFUnicodeAttribute, asf.ASFDWordAttribute,
-                     asf.ASFQWordAttribute, asf.ASFWordAttribute]
+            attrs = [
+                asf.ASFUnicodeAttribute,
+                asf.ASFDWordAttribute,
+                asf.ASFQWordAttribute,
+                asf.ASFWordAttribute,
+            ]
 
             def __process_tag(any_tag):
                 for attrtype in attrs:
@@ -63,5 +67,6 @@ class AsfFormat(BaseFormat):
                 return any_tag
 
             return [__process_tag(t) for t in tag]
+
 
 # vim: et sts=4 sw=4

--- a/xl/metadata/asf.py
+++ b/xl/metadata/asf.py
@@ -33,6 +33,7 @@ class AsfFormat(BaseFormat):
     MutagenType = asf.ASF
     # TODO: figure out the the WM/ prefix is universal
     tag_mapping = {
+        # fmt: off
         "artist"        : "Author",
         "album"         : "WM/AlbumTitle",
         "title"         : "Title",
@@ -41,6 +42,7 @@ class AsfFormat(BaseFormat):
         "date"          : "WM/Year",
         "albumartist"   : "WM/AlbumArtist",
         "grouping"      : "WM/ContentGroupDescription"
+        # fmt: on
     }
     others = False
     writable = True

--- a/xl/metadata/flac.py
+++ b/xl/metadata/flac.py
@@ -25,10 +25,7 @@
 # from your version.
 
 import xl.unicode
-from xl.metadata._base import (
-    CaseInsensitveBaseFormat,
-    CoverImage
-)
+from xl.metadata._base import CaseInsensitveBaseFormat, CoverImage
 from mutagen import flac
 from mutagen.flac import Picture
 
@@ -55,8 +52,10 @@ class FlacFormat(CaseInsensitveBaseFormat):
 
     def _get_tag(self, raw, tag):
         if tag == '__cover':
-            return [CoverImage(type=p.type, desc=p.desc, mime=p.mime, data=p.data)
-                    for p in raw.pictures]
+            return [
+                CoverImage(type=p.type, desc=p.desc, mime=p.mime, data=p.data)
+                for p in raw.pictures
+            ]
 
         return CaseInsensitveBaseFormat._get_tag(self, raw, tag)
 
@@ -81,5 +80,6 @@ class FlacFormat(CaseInsensitveBaseFormat):
             raw.clear_pictures()
         elif tag in raw:
             del raw[tag]
+
 
 # vim: et sts=4 sw=4

--- a/xl/metadata/mod.py
+++ b/xl/metadata/mod.py
@@ -31,13 +31,14 @@ import os
 
 try:
     import ctypes
+
     modplug = ctypes.cdll.LoadLibrary("libmodplug.so.0")
     modplug.ModPlug_Load.restype = ctypes.c_void_p
     modplug.ModPlug_Load.argtypes = (ctypes.c_void_p, ctypes.c_int)
     modplug.ModPlug_GetName.restype = ctypes.c_char_p
-    modplug.ModPlug_GetName.argtypes = (ctypes.c_void_p, )
+    modplug.ModPlug_GetName.argtypes = (ctypes.c_void_p,)
     modplug.ModPlug_GetLength.restype = ctypes.c_int
-    modplug.ModPlug_GetLength.argtypes = (ctypes.c_void_p, )
+    modplug.ModPlug_GetLength.argtypes = (ctypes.c_void_p,)
 except (ImportError, OSError):
     modplug = None
 
@@ -64,5 +65,6 @@ class ModFormat(BaseFormat):
 
     def get_bitrate(self):
         return -1
+
 
 # vim: et sts=4 sw=4

--- a/xl/metadata/mp3.py
+++ b/xl/metadata/mp3.py
@@ -32,4 +32,5 @@ from mutagen import mp3
 class MP3Format(ID3Format):
     MutagenType = mp3.MP3
 
+
 # vim: et sts=4 sw=4

--- a/xl/metadata/mp4.py
+++ b/xl/metadata/mp4.py
@@ -32,6 +32,7 @@ from mutagen import mp4
 class MP4Format(BaseFormat):
     MutagenType = mp4.MP4
     tag_mapping = {
+        # fmt: off
         'title':       '\xa9nam',
         'artist':      '\xa9ART',
         'albumartist': '\x61ART',
@@ -49,7 +50,8 @@ class MP4Format(BaseFormat):
         'comment':     '\xa9cmt',
         'originaldate': '----:com.apple.iTunes:ORIGYEAR',
         'cover':       'covr',
-        'language': '----:com.apple.iTunes:LANGUAGE',
+        'language':    '----:com.apple.iTunes:LANGUAGE',
+        # fmt: on
     }
     others = False
     writable = True

--- a/xl/metadata/mp4.py
+++ b/xl/metadata/mp4.py
@@ -96,12 +96,15 @@ class MP4Format(BaseFormat):
                 elif val.mime == 'image/png':
                     f[name].append(mp4.MP4Cover(val.data, mp4.MP4Cover.FORMAT_JPEG))
                 else:
-                    raise ValueError('MP4 does not support cover image type %s' % val.type)
+                    raise ValueError(
+                        'MP4 does not support cover image type %s' % val.type
+                    )
         elif name == 'tmpo':
             f[name] = [int(v) for v in value]
         elif name == '----:com.apple.iTunes:ORIGYEAR':
             f[name] = [str(v) for v in value]
         else:
             f[name] = value
+
 
 # vim: et sts=4 sw=4

--- a/xl/metadata/mpc.py
+++ b/xl/metadata/mpc.py
@@ -32,4 +32,5 @@ from mutagen import musepack
 class MpcFormat(ApeFormat):
     MutagenType = musepack.Musepack
 
+
 # vim: et sts=4 sw=4

--- a/xl/metadata/ogg.py
+++ b/xl/metadata/ogg.py
@@ -25,10 +25,7 @@
 # from your version.
 
 import xl.unicode
-from xl.metadata._base import (
-    CaseInsensitveBaseFormat,
-    CoverImage
-)
+from xl.metadata._base import CaseInsensitveBaseFormat, CoverImage
 from mutagen import oggvorbis, oggopus
 from mutagen.flac import Picture
 import base64
@@ -49,7 +46,14 @@ class OggFormat(CaseInsensitveBaseFormat):
             new_value = []
             for v in value:
                 picture = Picture(base64.b64decode(v))
-                new_value.append(CoverImage(type=picture.type, desc=picture.desc, mime=picture.mime, data=picture.data))
+                new_value.append(
+                    CoverImage(
+                        type=picture.type,
+                        desc=picture.desc,
+                        mime=picture.mime,
+                        data=picture.data,
+                    )
+                )
             value = new_value
         return value
 

--- a/xl/metadata/speex.py
+++ b/xl/metadata/speex.py
@@ -33,4 +33,5 @@ class SpeexFormat(CaseInsensitveBaseFormat):
     MutagenType = oggspeex.OggSpeex
     writable = True
 
+
 # vim: et sts=4 sw=4

--- a/xl/metadata/tags.py
+++ b/xl/metadata/tags.py
@@ -9,9 +9,9 @@ def N_(x):
 class _TD(object):
 
     __slots__ = [
-        'name',                 # descriptive name
-        'translated_name',      # translated name
-        'tag_name',             # raw tag name
+        'name',  # descriptive name
+        'translated_name',  # translated name
+        'tag_name',  # raw tag name
         'type',
         'editable',
         'min',
@@ -31,6 +31,7 @@ class _TD(object):
 
         for k, v in kwargs.iteritems():
             setattr(self, k, v)
+
 
 #: List of metadata tags currently supported by exaile, which are
 #: translated into the corresponding tag for each audio format if
@@ -87,7 +88,6 @@ tag_data = {
     '__rating':         None,  # currently special.
     '__startoffset':    _TD(N_('Start offset'), 'time', min=0, max=3600),  # TODO: calculate these parameters
     '__stopoffset':     _TD(N_('Stop offset'),  'time', min=0, max=3600),
-    
     # fmt: on
 }
 

--- a/xl/metadata/tags.py
+++ b/xl/metadata/tags.py
@@ -42,6 +42,7 @@ class _TD(object):
 #: version
 
 tag_data = {
+    # fmt: off
     'album':            _TD(N_('Album'),        'text'),
     'arranger':         _TD(N_('Arranger'),     'text'),
     'artist':           _TD(N_('Artist'),       'text'),
@@ -86,6 +87,8 @@ tag_data = {
     '__rating':         None,  # currently special.
     '__startoffset':    _TD(N_('Start offset'), 'time', min=0, max=3600),  # TODO: calculate these parameters
     '__stopoffset':     _TD(N_('Stop offset'),  'time', min=0, max=3600),
+    
+    # fmt: on
 }
 
 disk_tags = set()

--- a/xl/metadata/tta.py
+++ b/xl/metadata/tta.py
@@ -32,4 +32,5 @@ from mutagen import trueaudio
 class TTAFormat(ID3Format):
     MutagenType = trueaudio.TrueAudio
 
+
 # vim: et sts=4 sw=4

--- a/xl/metadata/wav.py
+++ b/xl/metadata/wav.py
@@ -31,10 +31,7 @@ import os
 
 from xl.metadata._base import BaseFormat, NotReadable
 
-type_map = {
-    "au": sunau,
-    "wav": wave,
-}
+type_map = {"au": sunau, "wav": wave}
 
 
 class WavFormat(BaseFormat):

--- a/xl/metadata/wv.py
+++ b/xl/metadata/wv.py
@@ -35,4 +35,5 @@ class WavpackFormat(ApeFormat):
     def get_bitrate(self):
         return -1
 
+
 # vim: et sts=4 sw=4

--- a/xl/migrations/database/__init__.py
+++ b/xl/migrations/database/__init__.py
@@ -31,9 +31,12 @@ from xl import common
 
 def handle_migration(db, pdata, oldversion, newversion):
     if oldversion == 1 and newversion == 2:
-        migrator = imp.load_source("from1to2",
-                                   os.path.join(os.path.dirname(__file__), "from1to2.py"))
+        migrator = imp.load_source(
+            "from1to2", os.path.join(os.path.dirname(__file__), "from1to2.py")
+        )
         migrator.migrate(db, pdata, oldversion, newversion)
     else:
-        raise common.VersionError("Don't know how to handle upgrade from "
-                                  "music database version %s to %s." % (oldversion, newversion))
+        raise common.VersionError(
+            "Don't know how to handle upgrade from "
+            "music database version %s to %s." % (oldversion, newversion)
+        )

--- a/xl/migrations/database/covers_1to2.py
+++ b/xl/migrations/database/covers_1to2.py
@@ -37,6 +37,7 @@ import xl.covers
 
 logger = logging.getLogger(__name__)
 
+
 def old_get_track_key(track):
     """
         Get the db mapping key for a track
@@ -58,6 +59,7 @@ def old_get_track_key(track):
         # no album info, cant store it
         return None
     return (tag, tuple(value))
+
 
 def migrate():
     """Migrate covers.db version 1 to 2 (Exaile 4.0)."""
@@ -84,5 +86,5 @@ def migrate():
     man.save()
 
     cachedir = os.path.join(man.location, 'cache')
-    for cachefile in (frozenset(os.listdir(cachedir)) - valid_cachefiles):
+    for cachefile in frozenset(os.listdir(cachedir)) - valid_cachefiles:
         os.remove(os.path.join(cachedir, cachefile))

--- a/xl/migrations/database/to_bsddb.py
+++ b/xl/migrations/database/to_bsddb.py
@@ -36,22 +36,22 @@ logger = logging.getLogger(__name__)
 
 def migrate(path):
     bak_path = path + os.extsep + 'tmp'
-    
+
     try:
         old_shelf = shelve.open(path, 'r', protocol=common.PICKLE_PROTOCOL)
     except Exception:
         logger.warn("%s may be corrupt", path)
         raise
-    
+
     db = common.bsddb.hashopen(bak_path, 'c')
     new_shelf = shelve.BsdDbShelf(db, protocol=common.PICKLE_PROTOCOL)
-    
+
     for k, v in old_shelf.iteritems():
         new_shelf[k] = v
-    
+
     new_shelf.close()
     old_shelf.close()
-    
+
     try:
         common.replace_file(bak_path, path)
     except Exception:
@@ -60,7 +60,7 @@ def migrate(path):
         except Exception:
             pass
         raise
-        
+
     # Various types of *dbm modules use more than one file to store the data.
     # Now that we are assured that the migration is complete, delete them if
     # present
@@ -69,5 +69,5 @@ def migrate(path):
             os.unlink(extra)
         except Exception as e:
             logger.warning("Could not delete %s: %s", extra, e)
-    
+
     logger.info("Migration successfully completed!")

--- a/xl/nls.py
+++ b/xl/nls.py
@@ -38,10 +38,12 @@ try:
     locale.setlocale(locale.LC_ALL, '')
 except locale.Error as e:
     # Error message copied from bzr
-    sys.stderr.write('exaile: Warning: %s\n'
-                     '  Exaile could not set the application locale, this\n'
-                     '  may cause language-specific problems. To investigate this\n'
-                     '  issue, look at the output of the locale tool.\n' % e)
+    sys.stderr.write(
+        'exaile: Warning: %s\n'
+        '  Exaile could not set the application locale, this\n'
+        '  may cause language-specific problems. To investigate this\n'
+        '  issue, look at the output of the locale tool.\n' % e
+    )
 
 try:
     import gettext as gettextmod
@@ -71,7 +73,7 @@ try:
 
         # Detect the prefix, to see if we need to correct the locale path
         elif exaile_path.endswith(os.path.join('lib', 'exaile')):
-            exaile_prefix = exaile_path[:-len(os.path.join('lib', 'exaile'))]
+            exaile_prefix = exaile_path[: -len(os.path.join('lib', 'exaile'))]
             if os.path.exists(os.path.join(exaile_prefix, 'share', 'locale')):
                 locale_path = os.path.join(exaile_prefix, 'share', 'locale')
 
@@ -94,6 +96,7 @@ try:
     def ngettext(singular, plural, n):
         return ngettextfunc(singular, plural, n).decode('utf-8')
 
+
 except ImportError:
     # gettext is not available.  Provide a dummy function instead
     def gettext(text):
@@ -104,5 +107,6 @@ except ImportError:
             return singular
         else:
             return plural
+
 
 # vim: et sts=4 sw=4

--- a/xl/player/__init__.py
+++ b/xl/player/__init__.py
@@ -28,13 +28,7 @@
     Allows for playback and queue control
 """
 
-__all__ = [
-    'adapters',
-    'gst',
-    'queue',
-    'PLAYER',
-    'QUEUE'
-]
+__all__ = ['adapters', 'gst', 'queue', 'PLAYER', 'QUEUE']
 
 import os
 
@@ -44,5 +38,6 @@ from . import player
 from . import queue
 
 PLAYER = player.ExailePlayer('player')
-QUEUE = queue.PlayQueue(PLAYER, 'queue',
-                        location=os.path.join(xdg.get_data_dir(), 'queue.state'))
+QUEUE = queue.PlayQueue(
+    PLAYER, 'queue', location=os.path.join(xdg.get_data_dir(), 'queue.state')
+)

--- a/xl/player/adapters.py
+++ b/xl/player/adapters.py
@@ -35,20 +35,24 @@ class PlaybackAdapter(object):
     def __init__(self, player):
 
         self.__player = player
-        self.__events = ('playback_track_start', 'playback_track_end',
-                         'playback_player_end', 'playback_toggle_pause',
-                         'playback_error')
+        self.__events = (
+            'playback_track_start',
+            'playback_track_end',
+            'playback_player_end',
+            'playback_toggle_pause',
+            'playback_error',
+        )
 
         for e in self.__events:
             event.add_callback(getattr(self, 'on_%s' % e), e, player)
 
         if player.current is not None:
-            self.on_playback_track_start('playback_track_start',
-                                         player, player.current)
+            self.on_playback_track_start('playback_track_start', player, player.current)
 
             if player.is_paused():
-                self.on_playback_toggle_pause('playback_toggle_pause',
-                                              player, player.current)
+                self.on_playback_toggle_pause(
+                    'playback_toggle_pause', player, player.current
+                )
 
     def destroy(self):
         """
@@ -86,27 +90,35 @@ class QueueAdapter(object):
     def __init__(self, queue):
         self.__queue = queue
 
-        event.add_callback(self.on_queue_current_playlist_changed,
-                           'queue_current_playlist_changed', queue)
-        event.add_callback(self.__on_playlist_current_position_changed,
-                           'playlist_current_position_changed')
-        event.add_callback(self.__on_playlist_tracks_added,
-                           'playlist_tracks_added')
-        event.add_callback(self.__on_playlist_tracks_removed,
-                           'playlist_tracks_removed')
+        event.add_callback(
+            self.on_queue_current_playlist_changed,
+            'queue_current_playlist_changed',
+            queue,
+        )
+        event.add_callback(
+            self.__on_playlist_current_position_changed,
+            'playlist_current_position_changed',
+        )
+        event.add_callback(self.__on_playlist_tracks_added, 'playlist_tracks_added')
+        event.add_callback(self.__on_playlist_tracks_removed, 'playlist_tracks_removed')
 
     def destroy(self):
         """
             Cleanups
         """
-        event.remove_callback(self.on_queue_current_playlist_changed,
-                              'queue_current_playlist_changed', self.__queue)
-        event.remove_callback(self.__on_playlist_current_position_changed,
-                              'playlist_current_position_changed')
-        event.remove_callback(self.__on_playlist_tracks_added,
-                              'playlist_tracks_added')
-        event.remove_callback(self.__on_playlist_tracks_removed,
-                              'playlist_tracks_removed')
+        event.remove_callback(
+            self.on_queue_current_playlist_changed,
+            'queue_current_playlist_changed',
+            self.__queue,
+        )
+        event.remove_callback(
+            self.__on_playlist_current_position_changed,
+            'playlist_current_position_changed',
+        )
+        event.remove_callback(self.__on_playlist_tracks_added, 'playlist_tracks_added')
+        event.remove_callback(
+            self.__on_playlist_tracks_removed, 'playlist_tracks_removed'
+        )
 
     def __on_playlist_current_position_changed(self, event, playlist, positions):
         """

--- a/xl/player/gst/__init__.py
+++ b/xl/player/gst/__init__.py
@@ -11,12 +11,15 @@
 #
 
 from gi.repository import Gst
+
 Gst.init(None)
 
 try:
-    __gst_version__ = '%s.%s.%s' % (Gst.VERSION_MAJOR,
-                                    Gst.VERSION_MINOR,
-                                    Gst.VERSION_MICRO)
+    __gst_version__ = '%s.%s.%s' % (
+        Gst.VERSION_MAJOR,
+        Gst.VERSION_MINOR,
+        Gst.VERSION_MICRO,
+    )
 except AttributeError:
     # Old version of GStreamer < 1.3.3
     # https://bugzilla.gnome.org/show_bug.cgi?id=703021
@@ -24,6 +27,7 @@ except AttributeError:
 
 
 from xl.version import register
+
 register('GStreamer', __gst_version__)
 
 del register

--- a/xl/player/gst/dynamic_sink.py
+++ b/xl/player/gst/dynamic_sink.py
@@ -32,6 +32,7 @@ from gi.repository import Gst
 from gi.repository import GLib
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -110,7 +111,9 @@ class DynamicAudioSink(Gst.Bin):
 
             # Start off by blocking the src pad of the prior element
             spad = old_audio_sink.get_static_pad('sink').get_peer()
-            spad.add_probe(Gst.PadProbeType.BLOCK_DOWNSTREAM, self._pad_blocked_cb, audio_sink)
+            spad.add_probe(
+                Gst.PadProbeType.BLOCK_DOWNSTREAM, self._pad_blocked_cb, audio_sink
+            )
 
             # Don't release the lock until pad block is done
             release_lock = False
@@ -160,13 +163,19 @@ class DynamicAudioSink(Gst.Bin):
             #       the paused state because there's no buffer. This forces
             #       a resync of the buffer, so things still work.
 
-            seek_event = Gst.Event.new_seek(1.0, Gst.Format.TIME,
-                                            Gst.SeekFlags.FLUSH, Gst.SeekType.SET,
-                                            buffer_position[1],
-                                            Gst.SeekType.NONE, 0)
+            seek_event = Gst.Event.new_seek(
+                1.0,
+                Gst.Format.TIME,
+                Gst.SeekFlags.FLUSH,
+                Gst.SeekType.SET,
+                buffer_position[1],
+                Gst.SeekType.NONE,
+                0,
+            )
 
             self.send_event(seek_event)
 
         self.audio_sink = audio_sink
+
 
 # vim: et sts=4 sw=4

--- a/xl/player/gst/gst_utils.py
+++ b/xl/player/gst/gst_utils.py
@@ -30,6 +30,7 @@ from gi.repository import Gst
 from xl.providers import ProviderHandler
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -165,12 +166,16 @@ class ProviderBin(ElementBin, ProviderHandler):
             try:
                 self.elements[idx] = provider()
             except Exception:
-                logger.exception("Could not create %s element for %s.",
-                                 provider, self.get_name())
+                logger.exception(
+                    "Could not create %s element for %s.", provider, self.get_name()
+                )
 
         for k, v in dups.iteritems():
-            logger.warning("Audio plugins %s are sharing index %s (may have unpredictable output!)",
-                           v, k)
+            logger.warning(
+                "Audio plugins %s are sharing index %s (may have unpredictable output!)",
+                v,
+                k,
+            )
 
     def on_provider_added(self, provider):
         self.reset_providers()
@@ -191,17 +196,19 @@ def parse_stream_tags(track, tag_list):
 
     newsong = False
 
-    keep = ['bitrate',
-            'duration',
-            'track-number',
-            'track-count',
-            'album-disc-number',
-            'album-disc-count',
-            'album',
-            'artist',
-            'genre',
-            'comment',
-            'title']
+    keep = [
+        'bitrate',
+        'duration',
+        'track-number',
+        'track-count',
+        'album-disc-number',
+        'album-disc-count',
+        'album',
+        'artist',
+        'genre',
+        'comment',
+        'title',
+    ]
 
     # Build a dictionary first
     tags = {}
@@ -210,7 +217,9 @@ def parse_stream_tags(track, tag_list):
         if k not in keep:
             continue
 
-        values = [tag_list.get_value_index(k, vi) for vi in xrange(tag_list.get_tag_size(k))]
+        values = [
+            tag_list.get_value_index(k, vi) for vi in xrange(tag_list.get_tag_size(k))
+        ]
         if isinstance(values[0], str):
             try:
                 values = [unicode(v, 'utf-8') for v in values]
@@ -275,15 +284,14 @@ def parse_stream_tags(track, tag_list):
 
         if not track.get_tag_raw('artist'):
             title_array = v[0].split(' - ', 1)
-            if len(title_array) == 1 or \
-                    track.get_loc_for_io().lower().endswith(".mp3"):
+            if len(title_array) == 1 or track.get_loc_for_io().lower().endswith(".mp3"):
                 etags['title'] = v
             else:
                 etags['artist'] = [title_array[0]]
                 etags['title'] = [title_array[1]]
         else:
             etags['title'] = v
-    
+
     track.set_tags(**etags)
     return newsong
 

--- a/xl/player/gst/missing_plugin.py
+++ b/xl/player/gst/missing_plugin.py
@@ -85,8 +85,8 @@ def __handle_plugin_missing_message(message, engine):
     user_message = _(
         "A GStreamer 1.x plugin for %s is missing. "
         "Without this software installed, Exaile will not be able to play the current file. "
-        "Please install the required software on your computer. See %s for details.") \
-        % (desc, MISSING_PLUGIN_URL)
+        "Please install the required software on your computer. See %s for details."
+    ) % (desc, MISSING_PLUGIN_URL)
     # TODO make URL clickable by utilizing xlgui.widgets.dialogs.MessageBar
 
     engine.stop()
@@ -112,9 +112,12 @@ def __run_installer_helper(installer_details):
     LOGGER.info("Prompting user to install missing codec(s): %s", installer_details)
 
     start_result = GstPbutils.install_plugins_async(
-        [installer_details], cntxt, __installer_finished_callback)
-    LOGGER.debug("GstPbutils.install_plugins_async() return value: %s",
-                 GstPbutils.InstallPluginsReturn.get_name(start_result))
+        [installer_details], cntxt, __installer_finished_callback
+    )
+    LOGGER.debug(
+        "GstPbutils.install_plugins_async() return value: %s",
+        GstPbutils.InstallPluginsReturn.get_name(start_result),
+    )
     if start_result == GstPbutils.InstallPluginsReturn.INTERNAL_FAILURE:
         # should only happen when there is a bug in Exaile or its libs:
         LOGGER.error("Internal failure starting assisted GStreamer plugin installation")
@@ -130,20 +133,26 @@ def __run_installer_helper(installer_details):
         LOGGER.info("Successfully started assisted GStreamer plugin installation")
         return True
     else:
-        LOGGER.error("Code should not be reached. "
-                     "Unexpected return value from install_plugins_async: %s",
-                     GstPbutils.InstallPluginsReturn.get_name(start_result))
+        LOGGER.error(
+            "Code should not be reached. "
+            "Unexpected return value from install_plugins_async: %s",
+            GstPbutils.InstallPluginsReturn.get_name(start_result),
+        )
         return False
 
 
 def __installer_finished_callback(result):
     # due to a bug in PackageKit, this function will be called immediately
     # after starting the helper: https://bugs.freedesktop.org/show_bug.cgi?id=100791
-    LOGGER.debug("GstPbutils.install_plugins_async() helper process exit code: %s",
-                 GstPbutils.InstallPluginsReturn.get_name(result))
+    LOGGER.debug(
+        "GstPbutils.install_plugins_async() helper process exit code: %s",
+        GstPbutils.InstallPluginsReturn.get_name(result),
+    )
 
-    if result == GstPbutils.InstallPluginsReturn.SUCCESS or \
-            result == GstPbutils.InstallPluginsReturn.PARTIAL_SUCCESS:
+    if (
+        result == GstPbutils.InstallPluginsReturn.SUCCESS
+        or result == GstPbutils.InstallPluginsReturn.PARTIAL_SUCCESS
+    ):
         # TODO notify user that installation of plugins was successful and ask
         # the user whether we may restart GStreamer engine to apply plugin updates,
         # because the user might have resumed playback in the meantime, and we do
@@ -158,20 +167,26 @@ def __installer_finished_callback(result):
         LOGGER.warn("GStreamer helper was unable to install missing plugin.")
         # we do not care about these, the user already got a notification how
         # to install plugins. There is nothing more we can do.
-    elif result == GstPbutils.InstallPluginsReturn.ERROR or \
-            result == GstPbutils.InstallPluginsReturn.CRASHED or \
-            result == GstPbutils.InstallPluginsReturn.INVALID or \
-            result == GstPbutils.InstallPluginsReturn.INTERNAL_FAILURE:
-        LOGGER.error("GStreamer plugin helper failed with %s",
-                     GstPbutils.InstallPluginsReturn.get_name(result))
+    elif (
+        result == GstPbutils.InstallPluginsReturn.ERROR
+        or result == GstPbutils.InstallPluginsReturn.CRASHED
+        or result == GstPbutils.InstallPluginsReturn.INVALID
+        or result == GstPbutils.InstallPluginsReturn.INTERNAL_FAILURE
+    ):
+        LOGGER.error(
+            "GStreamer plugin helper failed with %s",
+            GstPbutils.InstallPluginsReturn.get_name(result),
+        )
     elif result == GstPbutils.InstallPluginsReturn.USER_ABORT:
         LOGGER.info("User aborted the GStreamer plugin installation.")
         # the user decided not to install any software, which might have been on purpose,
         # so we do not want to ask again immediately.
     else:
-        LOGGER.error("Code should not be reached. "
-                     "Unexpected return value from install_plugins_async callback: %s",
-                     GstPbutils.InstallPluginsReturn.get_name(result))
+        LOGGER.error(
+            "Code should not be reached. "
+            "Unexpected return value from install_plugins_async callback: %s",
+            GstPbutils.InstallPluginsReturn.get_name(result),
+        )
 
 
 def __create_context():

--- a/xl/player/gst/sink.py
+++ b/xl/player/gst/sink.py
@@ -35,6 +35,7 @@ from . import gst_utils
 import sys
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -77,28 +78,31 @@ SINK_PRESETS = {
     # fmt: on
 }
 
+
 def __filter_presets():
     for preset in list(SINK_PRESETS.keys()):
         pipe = SINK_PRESETS[preset].get('pipe')
         if pipe and not Gst.ElementFactory.make(pipe):
             SINK_PRESETS.pop(preset)
 
+
 __filter_presets()
 
 
 # Every audiosink is a bit different...
 _autodetect_propnames = [
-    'internal_name',    # pulseaudio
-    'device_id',        # OSX
-    'device_guid',      # directsound
-    'device'            # wasapi
+    'internal_name',  # pulseaudio
+    'device_id',  # OSX
+    'device_guid',  # directsound
+    'device',  # wasapi
 ]
+
 
 def _gst_device_autodetect():
     # Linux: support was added in gstreamer 1.4
     # OSX: support was added in gstreamer 1.10
     # Windows: support was added in gstreamer 1.14
-    
+
     dm = Gst.DeviceMonitor.new()
     dm.add_filter('Audio/Sink', Gst.Caps.new_empty_simple('audio/x-raw'))
     dm.start()
@@ -111,25 +115,24 @@ def _gst_device_autodetect():
                     break
             else:
                 continue
-            
+
             if not device_id:
                 continue
-            
+
             display_name = device.get_display_name()
             if hasattr(device.props, 'properties'):
                 api = device.props.properties.get_string('device.api')
                 if api:
                     display_name = '%s [%s]' % (display_name, api)
-                    
+
                     # TODO: remove this when wasapi is stable
                     if api == 'wasapi':
                         continue
 
-            yield (display_name,
-                   device_id,
-                   device.create_element)
+            yield (display_name, device_id, device.create_element)
     finally:
         dm.stop()
+
 
 def get_devices():
     '''
@@ -137,7 +140,11 @@ def get_devices():
         fn is a function that will create the audiosink when called
     '''
 
-    yield (_('Automatic'), 'auto', lambda name: Gst.ElementFactory.make('autoaudiosink', name))
+    yield (
+        _('Automatic'),
+        'auto',
+        lambda name: Gst.ElementFactory.make('autoaudiosink', name),
+    )
 
     for info in _gst_device_autodetect():
         yield info
@@ -164,7 +171,9 @@ def create_device(player_name, return_errorsink=True):
 
     if sink_type == 'auto':
 
-        specified_device = settings.get_option('%s/audiosink_device' % player_name, 'auto')
+        specified_device = settings.get_option(
+            '%s/audiosink_device' % player_name, 'auto'
+        )
 
         for _unused, device_id, create in get_devices():
             if specified_device == device_id:
@@ -209,10 +218,16 @@ def _get_error_audiosink(msg):
     sink = Gst.ElementFactory.make('fakesink', None)
 
     def handoff(s, b, p):
-        s.message_full(Gst.MessageType.ERROR,
-                       Gst.stream_error_quark(), Gst.StreamError.FAILED,
-                       msg, msg,
-                       "", "", 0)
+        s.message_full(
+            Gst.MessageType.ERROR,
+            Gst.stream_error_quark(),
+            Gst.StreamError.FAILED,
+            msg,
+            msg,
+            "",
+            "",
+            0,
+        )
 
     sink.props.signal_handoffs = True
     sink.props.sync = True
@@ -237,13 +252,13 @@ class CustomAudioSink(Gst.Bin):
         gst_utils.element_link_many(*elems)
 
         # GhostPad allows the bin to pretend to be an audio sink
-        ghost = Gst.GhostPad.new("sink",
-                                 elems[0].get_static_pad("sink"))
+        ghost = Gst.GhostPad.new("sink", elems[0].get_static_pad("sink"))
         self.add_pad(ghost)
 
 
 if sys.platform == 'win32':
     import sink_windows
+
     priority_boost = sink_windows.get_priority_booster()
 
 else:

--- a/xl/player/gst/sink.py
+++ b/xl/player/gst/sink.py
@@ -42,6 +42,7 @@ __all__ = ['SINK_PRESETS', 'create_device', 'get_devices']
 
 
 SINK_PRESETS = {
+    # fmt: off
     "auto": {
         "name": _("Automatic")
     },
@@ -73,6 +74,7 @@ SINK_PRESETS = {
     "custom": {
         "name": _("Custom")
     }
+    # fmt: on
 }
 
 def __filter_presets():

--- a/xl/player/gst/sink_windows.py
+++ b/xl/player/gst/sink_windows.py
@@ -64,7 +64,9 @@ def get_priority_booster():
             # note that we use "Pro Audio" because it gives a higher priority, and
             # that's what Chrome does anyways...
             unused = cwin.DWORD()
-            obj.task_handle = AvSetMmThreadCharacteristics("Pro Audio", ctypes.byref(unused))
+            obj.task_handle = AvSetMmThreadCharacteristics(
+                "Pro Audio", ctypes.byref(unused)
+            )
 
         # A gstreamer thread ends
         elif status.type == Gst.StreamStatusType.LEAVE:

--- a/xl/player/player.py
+++ b/xl/player/player.py
@@ -35,6 +35,7 @@ from xl import event
 from xl import settings
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -94,6 +95,7 @@ class ExailePlayer(object):
 
         # TODO: support other engines
         from .gst.engine import ExaileGstEngine
+
         self._engine = ExaileGstEngine(self._name, self, disable_autoswitch)
         self._engine.initialize()
 
@@ -114,8 +116,7 @@ class ExailePlayer(object):
             i = int(track.get_tag_raw('__playcount'))
         except Exception:
             i = 0
-        track.set_tags(__playcount=i + 1,
-                       __last_played=time.time())
+        track.set_tags(__playcount=i + 1, __last_played=time.time())
 
     @common.idle_add()
     def _on_track_tags_changed(self, eventtype, track, tags):
@@ -502,8 +503,7 @@ class ExailePlayer(object):
             return
 
         if gapless:
-            if (self._auto_advance_delay != 0 or
-                    not self._gapless_enabled):
+            if self._auto_advance_delay != 0 or not self._gapless_enabled:
                 return
 
         return self.queue.get_next()
@@ -569,8 +569,9 @@ class ExailePlayer(object):
                     last = 0
             elif not isinstance(last, int):
                 last = 0
-            track.set_tag_raw('__playtime', last + int(time.time() -
-                                                       self._playtime_stamp))
+            track.set_tag_raw(
+                '__playtime', last + int(time.time() - self._playtime_stamp)
+            )
             self._playtime_stamp = None
 
     def _reset_playtime_stamp(self):

--- a/xl/player/queue.py
+++ b/xl/player/queue.py
@@ -25,17 +25,13 @@
 # from your version.
 
 import logging
+
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
 
-from xl import (
-    common,
-    event,
-    playlist,
-    settings
-)
+from xl import common, event, playlist, settings
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +61,7 @@ class PlayQueue(playlist.Playlist):
         playlist.Playlist.__init__(self, name=name)
 
         self.__queue_has_tracks_val = False
-        self.__current_playlist = self      # this should never be None
+        self.__current_playlist = self  # this should never be None
         self.player = player
 
         # hack for making docs work
@@ -78,7 +74,9 @@ class PlayQueue(playlist.Playlist):
         event.add_callback(self._on_option_set, '%s_option_set' % name)
 
         self.__opt_remove_item_when_played = '%s/remove_item_when_played' % name
-        self.__opt_disable_new_track_when_playing = '%s/disable_new_track_when_playing' % name
+        self.__opt_disable_new_track_when_playing = (
+            '%s/disable_new_track_when_playing' % name
+        )
         self.__opt_enqueue_begins_playback = '%s/enqueue_begins_playback' % name
 
         self._on_option_set(None, settings, self.__opt_remove_item_when_played)
@@ -115,8 +113,9 @@ class PlayQueue(playlist.Playlist):
         event.log_event('queue_current_playlist_changed', self, playlist)
 
     #: The playlist currently processed in the queue
-    current_playlist = property(lambda self: self.__current_playlist,
-                                set_current_playlist)
+    current_playlist = property(
+        lambda self: self.__current_playlist, set_current_playlist
+    )
 
     def get_next(self):
         '''
@@ -175,8 +174,7 @@ class PlayQueue(playlist.Playlist):
             self.player.play(track)
 
         if not track:
-            event.log_event("playback_playlist_end", self,
-                            self.current_playlist)
+            event.log_event("playback_playlist_end", self, self.current_playlist)
         return track
 
     def prev(self):
@@ -272,12 +270,16 @@ class PlayQueue(playlist.Playlist):
         if value != self.__queue_has_tracks_val:
             oldpos = self.current_position
             self.__queue_has_tracks_val = value
-            event.log_event("playlist_current_position_changed",
-                            self, (self.current_position, oldpos))
+            event.log_event(
+                "playlist_current_position_changed",
+                self,
+                (self.current_position, oldpos),
+            )
 
     # Internal value indicating whether the internal queue has tracks left to play
-    __queue_has_tracks = property(lambda self: self.__queue_has_tracks_val,
-                                  __set_queue_has_tracks)
+    __queue_has_tracks = property(
+        lambda self: self.__queue_has_tracks_val, __set_queue_has_tracks
+    )
 
     def __setitem__(self, i, value):
         '''
@@ -298,8 +300,11 @@ class PlayQueue(playlist.Playlist):
 
         self.__queue_has_tracks = True
 
-        if old_len == 0 and settings.get_option('queue/enqueue_begins_playback', True) \
-           and old_len < playlist.Playlist.__len__(self):
+        if (
+            old_len == 0
+            and settings.get_option('queue/enqueue_begins_playback', True)
+            and old_len < playlist.Playlist.__len__(self)
+        ):
             self.play()
 
     def _save_player_state(self, location):
@@ -336,7 +341,8 @@ class PlayQueue(playlist.Playlist):
             if state['position'] is not None:
                 start_at = state['position']
 
-            paused = state['state'] == 'paused' or \
-                settings.get_option("%s/resume_paused" % self.player._name, False)
+            paused = state['state'] == 'paused' or settings.get_option(
+                "%s/resume_paused" % self.player._name, False
+            )
 
             self.player.play(self.get_current(), start_at=start_at, paused=paused)

--- a/xl/playlist.py
+++ b/xl/playlist.py
@@ -1915,6 +1915,7 @@ class SmartPlaylist(object):
                 point = datetime.now() - delta
                 value = time.mktime(point.timetuple())
 
+            # fmt: off
             if op == ">=" or op == "<=":
                 s += '( %(field)s%(op)s%(value)s ' \
                     '| %(field)s==%(value)s )' % \
@@ -1967,6 +1968,8 @@ class SmartPlaylist(object):
                         'value': value,
                         'op': op
                     }
+
+            # fmt: on
 
             params.append(s)
 

--- a/xl/plugins.py
+++ b/xl/plugins.py
@@ -33,26 +33,19 @@ import sys
 import tarfile
 
 from xl.nls import gettext as _
-from xl import (
-    event,
-    settings,
-    xdg
-)
+from xl import event, settings, xdg
 
 logger = logging.getLogger(__name__)
 
 
 class InvalidPluginError(Exception):
-
     def __str__(self):
         return str(self.args[0])
 
 
 class PluginsManager(object):
-
     def __init__(self, exaile, load=True):
-        self.plugindirs = [os.path.join(p, 'plugins')
-                           for p in xdg.get_data_dirs()]
+        self.plugindirs = [os.path.join(p, 'plugins') for p in xdg.get_data_dirs()]
         if xdg.local_hack:
             self.plugindirs.insert(1, os.path.join(xdg.exaile_dir, 'plugins'))
 
@@ -95,20 +88,19 @@ class PluginsManager(object):
         try:
             tar = tarfile.open(path, "r:*")  # transparently supports gz, bz2
         except (tarfile.ReadError, OSError):
-            raise InvalidPluginError(
-                _('Plugin archive is not in the correct format.'))
+            raise InvalidPluginError(_('Plugin archive is not in the correct format.'))
 
         # ensure the paths in the archive are sane
         mems = tar.getmembers()
         base = os.path.basename(path).split('.')[0]
         if os.path.isdir(os.path.join(self.plugindirs[0], base)):
             raise InvalidPluginError(
-                _('A plugin with the name "%s" is already installed.') % base)
+                _('A plugin with the name "%s" is already installed.') % base
+            )
 
         for m in mems:
             if not m.name.startswith(base):
-                raise InvalidPluginError(
-                    _('Plugin archive contains an unsafe path.'))
+                raise InvalidPluginError(_('Plugin archive contains an unsafe path.'))
 
         tar.extractall(self.plugindirs[0])
 
@@ -121,15 +113,23 @@ class PluginsManager(object):
 
         if hasattr(plugin, 'on_gui_loaded'):
             if self.exaile.loading:
-                event.add_ui_callback(self.__on_new_plugin_loaded, 'gui_loaded',
-                                      None, plugin.on_gui_loaded)
+                event.add_ui_callback(
+                    self.__on_new_plugin_loaded,
+                    'gui_loaded',
+                    None,
+                    plugin.on_gui_loaded,
+                )
             else:
                 plugin.on_gui_loaded()
 
         if hasattr(plugin, 'on_exaile_loaded'):
             if self.exaile.loading:
-                event.add_ui_callback(self.__on_new_plugin_loaded, 'exaile_loaded',
-                                      None, plugin.on_exaile_loaded)
+                event.add_ui_callback(
+                    self.__on_new_plugin_loaded,
+                    'exaile_loaded',
+                    None,
+                    plugin.on_exaile_loaded,
+                )
             else:
                 plugin.on_exaile_loaded()
 
@@ -183,8 +183,11 @@ class PluginsManager(object):
             if not os.path.exists(directory):
                 continue
             for name in os.listdir(directory):
-                if name == '__pycache__' or name in pluginlist or \
-                        not os.path.exists(os.path.join(directory, name, 'PLUGININFO')):
+                if (
+                    name == '__pycache__'
+                    or name in pluginlist
+                    or not os.path.exists(os.path.join(directory, name, 'PLUGININFO'))
+                ):
                     continue
                 pluginlist.append(name)
         return pluginlist
@@ -233,6 +236,7 @@ class PluginsManager(object):
             :param info: The data returned from get_plugin_info()
         '''
         from gi.repository import GIRepository
+
         gir = GIRepository.Repository.get_default()
 
         modules = info.get('RequiredModules', [])
@@ -296,5 +300,6 @@ class PluginsManager(object):
                     plugin.teardown(main)
                 except Exception:
                     logger.exception("Unable to tear down plugin %s", plugin_name)
+
 
 # vim: et sts=4 sw=4

--- a/xl/providers.py
+++ b/xl/providers.py
@@ -32,6 +32,7 @@
 
 from xl import event
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -72,11 +73,8 @@ class ProviderManager(object):
             providers.append(provider)
             logger.debug(
                 "Provider %(provider)s registered for service %(service)s "
-                "with target %(target)s" % {
-                    'provider': provider.name,
-                    'service': servicename,
-                    'target': target
-                }
+                "with target %(target)s"
+                % {'provider': provider.name, 'service': servicename, 'target': target}
             )
             event.log_event("%s_provider_added" % servicename, self, (provider, target))
 
@@ -99,13 +97,16 @@ class ProviderManager(object):
                 service[target].remove(provider)
                 logger.debug(
                     "Provider %(provider)s unregistered from "
-                    "service %(service)s with target %(target)s" % {
+                    "service %(service)s with target %(target)s"
+                    % {
                         'provider': provider.name,
                         'service': servicename,
-                        'target': target
+                        'target': target,
                     }
                 )
-                event.log_event("%s_provider_removed" % servicename, self, (provider, target))
+                event.log_event(
+                    "%s_provider_removed" % servicename, self, (provider, target)
+                )
                 if not service[target]:  # no values for target key then del it
                     del service[target]
         except KeyError:
@@ -167,6 +168,7 @@ class ProviderManager(object):
 
         return None
 
+
 MANAGER = ProviderManager()
 register = MANAGER.register_provider
 unregister = MANAGER.unregister_provider
@@ -200,10 +202,10 @@ class ProviderHandler(object):
         if simple_init:
             for provider in MANAGER.get_providers(servicename, target):
                 self.on_provider_added(provider)
-        event.add_ui_callback(self._add_callback,
-                              "%s_provider_added" % servicename)
-        event.add_ui_callback(self._remove_callback,
-                              "%s_provider_removed" % servicename)
+        event.add_ui_callback(self._add_callback, "%s_provider_added" % servicename)
+        event.add_ui_callback(
+            self._remove_callback, "%s_provider_removed" % servicename
+        )
 
     def _add_callback(self, name, obj, ptuple):
         """
@@ -271,7 +273,6 @@ class MultiProviderHandler(object):
     '''
 
     class _ProxyProvider(ProviderHandler):
-
         def __init__(self, servicename, target, simple_init, parent):
             self.parent = parent
             ProviderHandler.__init__(self, servicename, target, simple_init)
@@ -285,7 +286,11 @@ class MultiProviderHandler(object):
     def __init__(self, servicenames, target=None, simple_init=False):
         self.providers = []
         for servicename in servicenames:
-            self.providers.append(MultiProviderHandler._ProxyProvider(servicename, target, simple_init, self))
+            self.providers.append(
+                MultiProviderHandler._ProxyProvider(
+                    servicename, target, simple_init, self
+                )
+            )
 
     def on_provider_added(self, provider):
         """
@@ -315,5 +320,6 @@ class MultiProviderHandler(object):
         for provider in self.providers:
             providers.extend(provider.get_providers())
         return providers
+
 
 # vim: et sts=4 sw=4

--- a/xl/radio.py
+++ b/xl/radio.py
@@ -105,7 +105,6 @@ class RadioManager(providers.ProviderHandler):
 
 
 class RadioList(object):
-
     def __init__(self, name, station=None):
         """
             Initializes the rlist

--- a/xl/settings.py
+++ b/xl/settings.py
@@ -28,11 +28,7 @@
     Central storage of application and user settings
 """
 
-from ConfigParser import (
-    RawConfigParser,
-    NoSectionError,
-    NoOptionError
-)
+from ConfigParser import RawConfigParser, NoSectionError, NoOptionError
 import logging
 import os
 import sys
@@ -50,7 +46,7 @@ TYPE_MAPPING = {
     'B': bool,
     'L': list,
     'D': dict,
-    'U': unicode
+    'U': unicode,
 }
 
 MANAGER = None
@@ -60,6 +56,7 @@ class SettingsManager(RawConfigParser):
     """
         Manages Exaile's settings
     """
+
     settings = None
     __version__ = 1
 
@@ -89,9 +86,9 @@ class SettingsManager(RawConfigParser):
 
         if location is not None:
             try:
-                self.read(self.location) or \
-                    self.read(self.location + ".new") or \
-                    self.read(self.location + ".old")
+                self.read(self.location) or self.read(
+                    self.location + ".new"
+                ) or self.read(self.location + ".old")
             except Exception:
                 pass
 
@@ -253,8 +250,9 @@ class SettingsManager(RawConfigParser):
                 else:
                     return k + ": " + str(value)
 
-        raise ValueError(_("We don't know how to store that "
-                           "kind of setting: "), type(value))
+        raise ValueError(
+            _("We don't know how to store that " "kind of setting: "), type(value)
+        )
 
     def _str_to_val(self, value):
         """
@@ -296,8 +294,7 @@ class SettingsManager(RawConfigParser):
             Save the settings to disk
         """
         if self.location is None:
-            logger.debug("Save requested but not saving settings, "
-                         "location is None")
+            logger.debug("Save requested but not saving settings, " "location is None")
             return
 
         if self._saving or not self._dirty:
@@ -333,6 +330,7 @@ class SettingsManager(RawConfigParser):
         self._saving = False
         self._dirty = False
 
+
 location = xdg.get_config_dir()
 
 
@@ -346,8 +344,7 @@ else:
 
 
 MANAGER = SettingsManager(
-    os.path.join(location, "settings.ini"),
-    xdg.get_config_path("settings.ini")
+    os.path.join(location, "settings.ini"), xdg.get_config_path("settings.ini")
 )
 
 get_option = MANAGER.get_option

--- a/xl/transcoder.py
+++ b/xl/transcoder.py
@@ -144,7 +144,6 @@ class TranscodeError(Exception):
 
 
 class Transcoder(object):
-
     def __init__(self, destformat, quality, error_callback, end_callback):
         self.src = None
         self.sink = None
@@ -187,8 +186,13 @@ class Transcoder(object):
 
     def start_transcode(self):
         self._construct_encoder()
-        elements = [self.input, "decodebin name=\"decoder\"", "audioconvert",
-                    self.encoder, self.output]
+        elements = [
+            self.input,
+            "decodebin name=\"decoder\"",
+            "audioconvert",
+            self.encoder,
+            self.output,
+        ]
         pipestr = " ! ".join(elements)
         logger.info("Starting GStreamer decoder with pipestring: %s", pipestr)
         pipe = Gst.parse_launch(pipestr)

--- a/xl/transcoder.py
+++ b/xl/transcoder.py
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 """
 
 FORMATS = {
+    # fmt: off
     "Ogg Vorbis" : {
         "default"   : 0.5,
         "raw_steps" : [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
@@ -112,6 +113,7 @@ FORMATS = {
         "desc"      : _("A very fast Free lossless audio format with "
                         "good compression."),
     },
+    # fmt: on
 }
 
 # NOTE: the transcoder is NOT designed to transfer tags. You will need to

--- a/xl/trax/__init__.py
+++ b/xl/trax/__init__.py
@@ -40,7 +40,8 @@ from xl.trax.search import (
     TracksMatcher,
     TracksInList,
     TracksNotInList,
-    match_track_from_string)
+    match_track_from_string,
+)
 from xl.trax.util import (
     is_valid_track,
     get_album_tracks,
@@ -48,4 +49,5 @@ from xl.trax.util import (
     get_tracks_from_uri,
     sort_tracks,
     sort_result_tracks,
-    get_rating_from_tracks)
+    get_rating_from_tracks,
+)

--- a/xl/trax/search.py
+++ b/xl/trax/search.py
@@ -38,6 +38,7 @@ class SearchResultTrack(object):
 
         :param track: The Track object
     """
+
     __slots__ = ['track', 'on_tags']
 
     def __init__(self, track):
@@ -49,6 +50,7 @@ class _Matcher(object):
     """
         Base class for match conditions
     """
+
     __slots__ = ['tag', 'content', 'lower']
 
     def __init__(self, tag, content, lower):
@@ -164,6 +166,7 @@ class _NotMetaMatcher(object):
     """
         Condition for boolean NOT
     """
+
     __slots__ = ['matcher']
     tag = None
 
@@ -178,6 +181,7 @@ class _OrMetaMatcher(object):
     """
         Condition for boolean OR
     """
+
     __slots__ = ['left', 'right']
     tag = None
 
@@ -192,6 +196,7 @@ class _MultiMetaMatcher(object):
     """
         Condition for boolean AND
     """
+
     __slots__ = ['matchers']
     tag = None
 
@@ -213,6 +218,7 @@ class _ManyMultiMetaMatcher(object):
         fashion, but also know which tags were matched. Useful for
         the collection panel expansion.
     """
+
     __slots__ = ['matchers', 'tags']
     tag = None
 
@@ -239,6 +245,7 @@ class TracksMatcher(object):
         Holds criteria and determines whether
         a given track matches those criteria.
     """
+
     __slots__ = ['matchers', 'case_sensitive', 'keyword_tags']
 
     def __init__(self, search_string, case_sensitive=True, keyword_tags=None):
@@ -316,8 +323,9 @@ class TracksMatcher(object):
             elif subtoken == "|":
                 left = self.__tokens_to_matchers([token[1][0]])
                 right = self.__tokens_to_matchers([token[1][1]])
-                matchers.append(_OrMetaMatcher(
-                    _MultiMetaMatcher(left), _MultiMetaMatcher(right)))
+                matchers.append(
+                    _OrMetaMatcher(_MultiMetaMatcher(left), _MultiMetaMatcher(right))
+                )
             # ()
             elif subtoken == "(":
                 inner = self.__tokens_to_matchers([token[1]])
@@ -409,7 +417,7 @@ class TracksMatcher(object):
                 newsearch += c
             elif c == "\"":
                 in_quotes = not in_quotes  # toggle
-                #newsearch += c
+                # newsearch += c
             elif c in ["|", "!", "(", ")"]:
                 newsearch += c
             elif c == " ":
@@ -451,8 +459,8 @@ class TracksMatcher(object):
                     break
                 count += 1
             before = tokens[:start]
-            inside = self.__red(tokens[start + 1:end])
-            after = tokens[end + 1:]
+            inside = self.__red(tokens[start + 1 : end])
+            after = tokens[end + 1 :]
             tokens = before + [["(", inside]] + after
 
         # handle NOT
@@ -460,7 +468,7 @@ class TracksMatcher(object):
             start = tokens.index("!")
             end = start + 2
             before = tokens[:start]
-            inside = tokens[start + 1:end]
+            inside = tokens[start + 1 : end]
             after = tokens[end:]
             tokens = before + [["!", inside]] + after
 
@@ -468,8 +476,8 @@ class TracksMatcher(object):
         elif "|" in tokens:
             start = tokens.index("|")
             inside = [tokens[start - 1], tokens[start + 1]]
-            before = tokens[:start - 1]
-            after = tokens[start + 2:]
+            before = tokens[: start - 1]
+            after = tokens[start + 2 :]
             tokens = before + [["|", inside]] + after
 
         # nothing special, so just return it
@@ -540,8 +548,9 @@ def search_tracks(trackiter, trackmatchers):
         time.sleep(0)
 
 
-def search_tracks_from_string(trackiter, search_string,
-                              case_sensitive=True, keyword_tags=None):
+def search_tracks_from_string(
+    trackiter, search_string, case_sensitive=True, keyword_tags=None
+):
     """
         Convenience wrapper around search_tracks that builds matchers
         automatically from the search string.
@@ -549,13 +558,18 @@ def search_tracks_from_string(trackiter, search_string,
         Arguments have the same meaning as the corresponding arguments on
         on :class:`search_tracks` and :class:`TracksMatcher`.
     """
-    matchers = [TracksMatcher(search_string, case_sensitive=case_sensitive,
-                              keyword_tags=keyword_tags)]
+    matchers = [
+        TracksMatcher(
+            search_string, case_sensitive=case_sensitive, keyword_tags=keyword_tags
+        )
+    ]
     return search_tracks(trackiter, matchers)
 
 
-def match_track_from_string(track, search_string,
-                            case_sensitive=True, keyword_tags=None):
-    matcher = TracksMatcher(search_string, case_sensitive=case_sensitive,
-                            keyword_tags=keyword_tags)
+def match_track_from_string(
+    track, search_string, case_sensitive=True, keyword_tags=None
+):
+    matcher = TracksMatcher(
+        search_string, case_sensitive=case_sensitive, keyword_tags=keyword_tags
+    )
     return matcher.match(SearchResultTrack(track))

--- a/xl/trax/trackdb.py
+++ b/xl/trax/trackdb.py
@@ -43,7 +43,6 @@ logger = logging.getLogger(__name__)
 
 
 class TrackHolder(object):
-
     def __init__(self, track, key, **kwargs):
         self._track = track
         self._key = key
@@ -54,7 +53,6 @@ class TrackHolder(object):
 
 
 class TrackDBIterator(object):
-
     def __init__(self, track_iterator):
         self.iter = track_iterator
 
@@ -93,13 +91,18 @@ class TrackDB(object):
         # ensure that the DB is always loaded before any tracks are,
         # otherwise internal values are not loaded and may be lost/corrupted
         if loadfirst and Track._get_track_count() != 0:
-            raise RuntimeError(("Internal error! %d tracks already loaded, " +
-                                "TrackDB must be loaded first!") % Track._get_track_count())
+            raise RuntimeError(
+                (
+                    "Internal error! %d tracks already loaded, "
+                    + "TrackDB must be loaded first!"
+                )
+                % Track._get_track_count()
+            )
 
         self.name = name
         self.location = location
         self._dirty = False
-        self.tracks = {} # key is always URI of the track
+        self.tracks = {}  # key is always URI of the track
         self.pickle_attrs = pickle_attrs
         self.pickle_attrs += ['tracks', 'name', '_key']
         self._saving = False
@@ -177,7 +180,8 @@ class TrackDB(object):
             location = self.location
         if not location:
             raise AttributeError(
-                _("You did not specify a location to load the db from"))
+                _("You did not specify a location to load the db from")
+            )
 
         logger.debug("Loading %s DB from %s.", self.name, location)
 
@@ -189,18 +193,19 @@ class TrackDB(object):
             elif pdata['_dbversion'] < self._dbversion:
                 logger.info("Upgrading DB format....")
                 import shutil
-                shutil.copyfile(location,
-                                location + "-%s.bak" % pdata['_dbversion'])
+
+                shutil.copyfile(location, location + "-%s.bak" % pdata['_dbversion'])
                 import xl.migrations.database as dbmig
-                dbmig.handle_migration(self, pdata, pdata['_dbversion'],
-                                       self._dbversion)
+
+                dbmig.handle_migration(
+                    self, pdata, pdata['_dbversion'], self._dbversion
+                )
 
         for attr in self.pickle_attrs:
             try:
                 if 'tracks' == attr:
                     data = {}
-                    for k in (x for x in pdata.keys()
-                              if x.startswith("tracks-")):
+                    for k in (x for x in pdata.keys() if x.startswith("tracks-")):
                         p = pdata[k]
                         tr = Track(_unpickles=p[0])
                         loc = tr.get_loc_for_io()
@@ -244,8 +249,7 @@ class TrackDB(object):
         if not location:
             location = self.location
         if not location:
-            raise AttributeError(
-                _("You did not specify a location to save the db"))
+            raise AttributeError(_("You did not specify a location to save the db"))
 
         if self._saving:
             return
@@ -270,7 +274,7 @@ class TrackDB(object):
                         pdata[key] = (
                             track._track._pickles(),
                             track._key,
-                            deepcopy(track._attrs)
+                            deepcopy(track._attrs),
                         )
             else:
                 pdata[attr] = deepcopy(getattr(self, attr))
@@ -380,16 +384,22 @@ class TrackDB(object):
     def get_tracks(self):
         return list(self)
 
-    def search(self, query, sort_fields=[], return_lim=-1,
-               tracks=None, reverse=False):
+    def search(self, query, sort_fields=[], return_lim=-1, tracks=None, reverse=False):
         """
             DEPRECATED, DO NOT USE IN NEW CODE
         """
         import warnings
+
         warnings.warn("TrackDB.search is deprecated.", DeprecationWarning)
-        tracks = [x.track for x in search_tracks_from_string(self, query,
-                                                             case_sensitive=False, keyword_tags=['artist', 'albumartist',
-                                                                                                 'album', 'title'])]
+        tracks = [
+            x.track
+            for x in search_tracks_from_string(
+                self,
+                query,
+                case_sensitive=False,
+                keyword_tags=['artist', 'albumartist', 'album', 'title'],
+            )
+        ]
 
         if sort_fields:
             tracks = sort_tracks(sort_fields, tracks, reverse)

--- a/xl/trax/util.py
+++ b/xl/trax/util.py
@@ -77,12 +77,15 @@ def get_tracks_from_uri(uri):
         return [Track(uri)]
 
     try:
-        file_type = gloc.query_info("standard::type", Gio.FileQueryInfoFlags.NONE, None).get_file_type()
+        file_type = gloc.query_info(
+            "standard::type", Gio.FileQueryInfoFlags.NONE, None
+        ).get_file_type()
     except GLib.Error:  # E.g. cdda
         file_type = None
     if file_type == Gio.FileType.DIRECTORY:
         # TODO: refactor Library so we dont need the collection obj
         from xl.collection import Library, Collection
+
         tracks = Collection('scanner')
         lib = Library(uri)
         lib.set_collection(tracks)
@@ -111,8 +114,10 @@ def sort_tracks(fields, iter, trackfunc=None, reverse=False, artist_compilations
     fields = list(fields)  # we need the index method
     if trackfunc is None:
         trackfunc = lambda tr: tr
-    keyfunc = lambda tr: [trackfunc(tr).get_tag_sort(field,
-                                                     artist_compilations=artist_compilations) for field in fields]
+    keyfunc = lambda tr: [
+        trackfunc(tr).get_tag_sort(field, artist_compilations=artist_compilations)
+        for field in fields
+    ]
     return sorted(iter, key=keyfunc, reverse=reverse)
 
 
@@ -122,7 +127,9 @@ def sort_result_tracks(fields, trackiter, reverse=False, artist_compilations=Fal
 
         Same params as sort_tracks.
     """
-    return sort_tracks(fields, trackiter, lambda tr: tr.track, reverse, artist_compilations)
+    return sort_tracks(
+        fields, trackiter, lambda tr: tr.track, reverse, artist_compilations
+    )
 
 
 def get_rating_from_tracks(tracks):
@@ -138,9 +145,9 @@ def get_rating_from_tracks(tracks):
     if len(tracks) < 1:
         return 0
 
-# TODO: still needed?
-#    if len(tracks) > settings.get_option('rating/tracks_limit', 100):
-#        return 0
+    # TODO: still needed?
+    #    if len(tracks) > settings.get_option('rating/tracks_limit', 100):
+    #        return 0
 
     rating = tracks[0].get_rating()
 
@@ -161,7 +168,12 @@ def get_album_tracks(tracksiter, track, artist_compilations=False):
     """
     if not all(track.get_tag_raw(t) for t in ['artist', 'album']):
         return []
-    matchers = map(lambda t: TracksMatcher(track.get_tag_search(t, artist_compilations=artist_compilations)), ['artist', 'album'])
+    matchers = map(
+        lambda t: TracksMatcher(
+            track.get_tag_search(t, artist_compilations=artist_compilations)
+        ),
+        ['artist', 'album'],
+    )
     return (r.track for r in search_tracks(tracksiter, matchers))
 
 
@@ -173,9 +185,13 @@ def recursive_tracks_from_file(gfile):
         :param gfile: Gio.File
         :return: tracks iterable [Track]
     """
-    ftype = gfile.query_info('standard::type', Gio.FileQueryInfoFlags.NONE, None).get_file_type()
+    ftype = gfile.query_info(
+        'standard::type', Gio.FileQueryInfoFlags.NONE, None
+    ).get_file_type()
     if ftype == Gio.FileType.DIRECTORY:
-        file_infos = gfile.enumerate_children('standard::name', Gio.FileQueryInfoFlags.NONE, None)
+        file_infos = gfile.enumerate_children(
+            'standard::name', Gio.FileQueryInfoFlags.NONE, None
+        )
         files = (gfile.get_child(fi.get_name()) for fi in file_infos)
         for sub_gfile in files:
             for i in recursive_tracks_from_file(sub_gfile):

--- a/xl/version.py
+++ b/xl/version.py
@@ -28,6 +28,7 @@ import os
 from . import xdg
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 major = "4.0"
@@ -45,11 +46,12 @@ def get_current_revision(directory):
 
     try:
         with open(os.devnull, 'w') as devnull:
-            return subprocess.check_output([
-                'git', 'rev-parse', '--short=7', 'HEAD'
-            ], stderr=devnull).strip()
+            return subprocess.check_output(
+                ['git', 'rev-parse', '--short=7', 'HEAD'], stderr=devnull
+            ).strip()
     except (subprocess.CalledProcessError, OSError):
         return None
+
 
 if xdg.local_hack:
     revision = get_current_revision(xdg.exaile_dir)

--- a/xl/xdg.py
+++ b/xl/xdg.py
@@ -31,7 +31,7 @@ from gi.repository import GLib
 # We need the local hack for OSX bundled apps, so we depend on the main script
 # to set the environment variable correctly instead of trying to infer an
 # absolute path
-#exaile_dir = os.path.split(os.path.dirname(os.path.realpath(__file__)))[0]
+# exaile_dir = os.path.split(os.path.dirname(os.path.realpath(__file__)))[0]
 exaile_dir = os.environ['EXAILE_DIR']
 
 homedir = os.path.expanduser("~")
@@ -155,5 +155,6 @@ def _make_missing_dirs():
         os.makedirs(cache_home)
     if not os.path.exists(logs_home):
         os.makedirs(logs_home)
+
 
 # vim: et sts=4 sw=4

--- a/xl/xldbus.py
+++ b/xl/xldbus.py
@@ -65,8 +65,7 @@ def check_exit(options, args):
         # TODO: handle dbus stuff
         bus = dbus.SessionBus()
         if check_dbus(bus, 'org.exaile.Exaile'):
-            remote_object = bus.get_object('org.exaile.Exaile',
-                                           '/org/exaile/Exaile')
+            remote_object = bus.get_object('org.exaile.Exaile', '/org/exaile/Exaile')
             iface = dbus.Interface(remote_object, 'org.exaile.Exaile')
             iface.TestService('testing dbus service')
 
@@ -82,11 +81,29 @@ def check_exit(options, args):
                 iface.Enqueue(args)
 
     if not iface:
-        for command in ['GetArtist', 'GetTitle', 'GetAlbum', 'GetLength',
-                        'GetRating', 'SetRating', 'IncreaseVolume', 'DecreaseVolume',
-                        'Play', 'Pause', 'Stop', 'Next', 'Prev', 'PlayPause',
-                        'StopAfterCurrent', 'GuiToggleVisible', 'CurrentPosition',
-                        'CurrentProgress', 'GetVolume', 'Query', 'FormatQuery']:
+        for command in [
+            'GetArtist',
+            'GetTitle',
+            'GetAlbum',
+            'GetLength',
+            'GetRating',
+            'SetRating',
+            'IncreaseVolume',
+            'DecreaseVolume',
+            'Play',
+            'Pause',
+            'Stop',
+            'Next',
+            'Prev',
+            'PlayPause',
+            'StopAfterCurrent',
+            'GuiToggleVisible',
+            'CurrentPosition',
+            'CurrentProgress',
+            'GetVolume',
+            'Query',
+            'FormatQuery',
+        ]:
             if getattr(options, command):
                 return "command"
         return "continue"
@@ -121,14 +138,16 @@ def run_commands(options, iface):
         'DecreaseVolume',
         'SetRating',
         'Add',
-        'ExportPlaylist'
+        'ExportPlaylist',
     )
 
     for command in argument_commands:
         argument = getattr(options, command)
         if argument is not None:
             if command in ('IncreaseVolume', 'DecreaseVolume'):
-                iface.ChangeVolume(argument if command == 'IncreaseVolume' else -argument)
+                iface.ChangeVolume(
+                    argument if command == 'IncreaseVolume' else -argument
+                )
             else:
                 print(getattr(iface, command)(argument))
 
@@ -137,7 +156,11 @@ def run_commands(options, iface):
     # Special handling for FormatQuery & FormatQueryTags
     format = options.FormatQuery
     if format is not None:
-        print(iface.FormatQuery(format, options.FormatQueryTags or 'title,artist,album,__length'))
+        print(
+            iface.FormatQuery(
+                format, options.FormatQueryTags or 'title,artist,album,__length'
+            )
+        )
         comm = True
 
     run_commands = (
@@ -149,7 +172,7 @@ def run_commands(options, iface):
         'PlayPause',
         'StopAfterCurrent',
         'GuiToggleVisible',
-        'ToggleMute'
+        'ToggleMute',
     )
 
     for command in run_commands:
@@ -162,7 +185,7 @@ def run_commands(options, iface):
         'CurrentProgress',
         'GetRating',
         'GetVolume',
-        'Query'
+        'Query',
     )
 
     for command in query_commands:
@@ -170,9 +193,7 @@ def run_commands(options, iface):
             print(getattr(iface, command)(argument))
             comm = True
 
-    to_implement = (
-        'GuiQuery',
-    )
+    to_implement = ('GuiQuery',)
     for command in to_implement:
         if getattr(options, command):
             logger.warning("FIXME: command not implemented")
@@ -181,10 +202,8 @@ def run_commands(options, iface):
     if not comm:
         iface.GuiToggleVisible()
 
-PlaybackStatus = namedtuple(
-    'PlaybackStatus',
-    'state progress position current'
-)
+
+PlaybackStatus = namedtuple('PlaybackStatus', 'state progress position current')
 
 
 class DbusManager(dbus.service.Object):
@@ -198,8 +217,7 @@ class DbusManager(dbus.service.Object):
         """
         self.exaile = exaile
         self.bus = dbus.SessionBus()
-        self.bus_name = dbus.service.BusName('org.exaile.Exaile',
-                                             bus=self.bus)
+        self.bus_name = dbus.service.BusName('org.exaile.Exaile', bus=self.bus)
         dbus.service.Object.__init__(self, self.bus_name, '/org/exaile/Exaile')
         self.cached_track = ""
         self.cached_state = ""
@@ -208,18 +226,19 @@ class DbusManager(dbus.service.Object):
     def _connect_signals(self):
         # connect events
         from xl import player
-        event.add_callback(self.emit_state_changed,
-                           'playback_player_end', player.PLAYER)
-        event.add_callback(self.emit_state_changed,
-                           'playback_track_start', player.PLAYER)
-        event.add_callback(self.emit_state_changed,
-                           'playback_toggle_pause', player.PLAYER)
-        event.add_callback(self.emit_track_changed,
-                           'tags_parsed', player.PLAYER)
-        event.add_callback(self.emit_state_changed,
-                           'playback_buffering', player.PLAYER)
-        event.add_callback(self.emit_state_changed,
-                           'playback_error', player.PLAYER)
+
+        event.add_callback(
+            self.emit_state_changed, 'playback_player_end', player.PLAYER
+        )
+        event.add_callback(
+            self.emit_state_changed, 'playback_track_start', player.PLAYER
+        )
+        event.add_callback(
+            self.emit_state_changed, 'playback_toggle_pause', player.PLAYER
+        )
+        event.add_callback(self.emit_track_changed, 'tags_parsed', player.PLAYER)
+        event.add_callback(self.emit_state_changed, 'playback_buffering', player.PLAYER)
+        event.add_callback(self.emit_state_changed, 'playback_error', player.PLAYER)
 
     @dbus.service.method('org.exaile.Exaile', 's')
     def TestService(self, arg):
@@ -239,6 +258,7 @@ class DbusManager(dbus.service.Object):
             :rtype: boolean
         """
         from xl import player
+
         return bool(not player.PLAYER.is_stopped())
 
     @dbus.service.method('org.exaile.Exaile', 's', 's')
@@ -252,6 +272,7 @@ class DbusManager(dbus.service.Object):
             :rtype: string
         """
         from xl import player
+
         try:
             value = player.PLAYER.current.get_tag_raw(attr) or ''
         except (ValueError, TypeError, AttributeError):
@@ -272,6 +293,7 @@ class DbusManager(dbus.service.Object):
             :type value: any
         """
         from xl import player
+
         try:
             player.PLAYER.current.set_tag_raw(attr, value)
         except (AttributeError, TypeError):
@@ -312,6 +334,7 @@ class DbusManager(dbus.service.Object):
             :type value: int
         """
         from xl import player
+
         player.PLAYER.set_volume(player.PLAYER.get_volume() + value)
         self.cached_volume = -1
 
@@ -321,6 +344,7 @@ class DbusManager(dbus.service.Object):
             Mutes or unmutes the volume
         """
         from xl import player
+
         if self.cached_volume == -1:
             self.cached_volume = player.PLAYER.get_volume()
             player.PLAYER.set_volume(0)
@@ -337,6 +361,7 @@ class DbusManager(dbus.service.Object):
             :type value: int
         """
         from xl import player
+
         player.PLAYER.seek(value)
 
     @dbus.service.method('org.exaile.Exaile')
@@ -345,6 +370,7 @@ class DbusManager(dbus.service.Object):
             Jumps to the previous track
         """
         from xl import player
+
         player.QUEUE.prev()
 
     @dbus.service.method('org.exaile.Exaile')
@@ -353,6 +379,7 @@ class DbusManager(dbus.service.Object):
             Stops playback
         """
         from xl import player
+
         player.PLAYER.stop()
 
     @dbus.service.method('org.exaile.Exaile')
@@ -361,6 +388,7 @@ class DbusManager(dbus.service.Object):
             Jumps to the next track
         """
         from xl import player
+
         player.QUEUE.next()
 
     @dbus.service.method('org.exaile.Exaile')
@@ -369,6 +397,7 @@ class DbusManager(dbus.service.Object):
             Starts playback
         """
         from xl import player
+
         player.QUEUE.play()
 
     @dbus.service.method('org.exaile.Exaile')
@@ -377,6 +406,7 @@ class DbusManager(dbus.service.Object):
             Starts playback
         """
         from xl import player
+
         player.PLAYER.pause()
 
     @dbus.service.method('org.exaile.Exaile')
@@ -385,6 +415,7 @@ class DbusManager(dbus.service.Object):
             Toggle Play or Pause
         """
         from xl import player
+
         if player.PLAYER.is_stopped():
             player.PLAYER.play(player.QUEUE.get_current())
         else:
@@ -396,6 +427,7 @@ class DbusManager(dbus.service.Object):
             Toggle stopping after current track
         """
         from xl import player
+
         player.QUEUE.stop_track = player.QUEUE.get_current()
 
     @dbus.service.method('org.exaile.Exaile', None, 's')
@@ -407,6 +439,7 @@ class DbusManager(dbus.service.Object):
             :rtype: string
         """
         from xl import player
+
         progress = player.PLAYER.get_progress()
         if progress == -1:
             return ""
@@ -421,6 +454,7 @@ class DbusManager(dbus.service.Object):
             :rtype: string
         """
         from xl import player
+
         progress = player.PLAYER.get_time()
         return '%d:%02d' % (progress // 60, progress % 60)
 
@@ -433,6 +467,7 @@ class DbusManager(dbus.service.Object):
             :rtype: string
         """
         from xl import player
+
         return str(player.PLAYER.get_volume())
 
     def __get_playback_status(self, tags=["title", "artist", "album", "__length"]):
@@ -444,18 +479,12 @@ class DbusManager(dbus.service.Object):
             :returns: the playback status
             :rtype: :class:`xl.xldbus.PlaybackStatus`
         """
-        status = PlaybackStatus(
-            state='stopped',
-            current=None,
-            progress=0,
-            position=0
-        )
+        status = PlaybackStatus(state='stopped', current=None, progress=0, position=0)
 
         from xl import player
 
         current_track = player.QUEUE.get_current()
-        if current_track is not None and \
-           not player.PLAYER.is_stopped():
+        if current_track is not None and not player.PLAYER.is_stopped():
             current = {}
             # Make tags unique
             tags = list(set(tags))
@@ -466,13 +495,16 @@ class DbusManager(dbus.service.Object):
             # Special handling for internal tags
             if "__length" in tags:
                 from xl.formatter import LengthTagFormatter
-                current["__length"] = LengthTagFormatter.format_value(self.GetTrackAttr('__length'))
+
+                current["__length"] = LengthTagFormatter.format_value(
+                    self.GetTrackAttr('__length')
+                )
 
             status = PlaybackStatus(
                 state=player.PLAYER.get_state(),
                 progress=self.CurrentProgress(),
                 position=self.CurrentPosition(),
-                current=current
+                current=current,
             )
 
         return status
@@ -490,9 +522,11 @@ class DbusManager(dbus.service.Object):
         if status.current is None or status.state == "stopped":
             return _('Not playing.')
 
-        result = _('status: %(status)s, title: %(title)s, artist: %(artist)s,'
-                   ' album: %(album)s, length: %(length)s,'
-                   ' position: %(progress)s%% [%(position)s]') % {
+        result = _(
+            'status: %(status)s, title: %(title)s, artist: %(artist)s,'
+            ' album: %(album)s, length: %(length)s,'
+            ' position: %(progress)s%% [%(position)s]'
+        ) % {
             'status': status.state,
             'title': status.current["title"],
             'artist': status.current["artist"],
@@ -598,10 +632,7 @@ class DbusManager(dbus.service.Object):
         from xl import player, playlist
 
         if player.QUEUE.current_playlist is not None:
-            playlist.export_playlist(
-                player.QUEUE.current_playlist,
-                location
-            )
+            playlist.export_playlist(player.QUEUE.current_playlist, location)
 
     @dbus.service.method('org.exaile.Exaile')
     def GuiToggleVisible(self):
@@ -620,6 +651,7 @@ class DbusManager(dbus.service.Object):
             :rtype: binary data
         """
         from xl import covers, player
+
         cover = covers.MANAGER.get_cover(player.PLAYER.current, set_only=True)
         if not cover:
             cover = ''
@@ -634,6 +666,7 @@ class DbusManager(dbus.service.Object):
             :rtype: string
         """
         from xl import player
+
         return player.PLAYER.get_state()
 
     @dbus.service.signal('org.exaile.Exaile')
@@ -667,5 +700,6 @@ class DbusManager(dbus.service.Object):
         if self.cached_track != new_track:
             self.cached_track = new_track
             self.TrackChanged()
+
 
 # vim: et sts=4 sw=4

--- a/xlgui/__init__.py
+++ b/xlgui/__init__.py
@@ -31,25 +31,19 @@ from gi.repository import GLib
 from gi.repository import Gtk
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 import os
 import sys
 
-from xl import (
-    common,
-    player,
-    providers,
-    settings,
-    version,
-    xdg
-)
+from xl import common, player, providers, settings, version, xdg
 from xl.nls import gettext as _
 from xlgui import guiutil
 
-version.register("GTK+", "%s.%s.%s" % (Gtk.MAJOR_VERSION,
-                                       Gtk.MINOR_VERSION,
-                                       Gtk.MICRO_VERSION))
+version.register(
+    "GTK+", "%s.%s.%s" % (Gtk.MAJOR_VERSION, Gtk.MINOR_VERSION, Gtk.MICRO_VERSION)
+)
 
 
 def get_controller():
@@ -60,6 +54,7 @@ class Main(object):
     """
         This is the main gui controller for exaile
     """
+
     _main = None
 
     def __init__(self, exaile):
@@ -98,9 +93,15 @@ class Main(object):
             # some clients, e.g. pavucontrol.
             os.environ['PULSE_PROP_application.icon_name'] = exaile_icon_path
 
-        for name in ('exaile-pause', 'exaile-play',
-                     'office-calendar', 'extension',
-                     'music-library', 'artist', 'genre'):
+        for name in (
+            'exaile-pause',
+            'exaile-play',
+            'office-calendar',
+            'extension',
+            'music-library',
+            'artist',
+            'genre',
+        ):
             add_icon(name, images_dir)
         for name in ('dynamic', 'repeat', 'shuffle'):
             add_icon('media-playlist-' + name, images_dir)
@@ -126,19 +127,22 @@ class Main(object):
         logger.info("Connecting panel events...")
         self.main._connect_panel_events()
 
-        guiutil.gtk_widget_replace(panel_notebook,
-                                   self.panel_notebook)
-        self.panel_notebook.get_parent()    \
-            .child_set_property(self.panel_notebook, 'shrink', False)
+        guiutil.gtk_widget_replace(panel_notebook, self.panel_notebook)
+        self.panel_notebook.get_parent().child_set_property(
+            self.panel_notebook, 'shrink', False
+        )
 
         if settings.get_option('gui/use_tray', False):
             if tray.is_supported():
                 self.tray_icon = tray.TrayIcon(self.main)
             else:
                 settings.set_option('gui/use_tray', False)
-                logger.warn("Tray icons are not supported on your platform. Disabling tray icon.")
+                logger.warn(
+                    "Tray icons are not supported on your platform. Disabling tray icon."
+                )
 
         from xl import event
+
         event.add_ui_callback(self.add_device_panel, 'device_connected')
         event.add_ui_callback(self.remove_device_panel, 'device_disconnected')
         event.add_ui_callback(self.on_gui_loaded, 'gui_loaded')
@@ -204,19 +208,21 @@ class Main(object):
             Shows the cover manager
         """
         from xlgui.cover import CoverManager
-        CoverManager(self.main.window,
-                     self.exaile.collection)
+
+        CoverManager(self.main.window, self.exaile.collection)
 
     def show_preferences(self):
         """
             Shows the preferences dialog
         """
         from xlgui.preferences import PreferencesDialog
+
         dialog = PreferencesDialog(self.main.window, self)
         dialog.run()
 
     def show_devices(self):
         from xlgui.devices import ManagerDialog
+
         dialog = ManagerDialog(self.main.window, self)
         dialog.run()
 
@@ -230,8 +236,7 @@ class Main(object):
         from xl.collection import Library
         from xlgui.collection import CollectionManagerDialog
 
-        dialog = CollectionManagerDialog(self.main.window,
-                                         self.exaile.collection)
+        dialog = CollectionManagerDialog(self.main.window, self.exaile.collection)
         result = dialog.run()
         dialog.hide()
 
@@ -239,15 +244,22 @@ class Main(object):
             collection = self.exaile.collection
             collection.freeze_libraries()
 
-            collection_libraries = sorted([(l.location, l.monitored, l.startup_scan)
-                                           for l in collection.libraries.itervalues()])
+            collection_libraries = sorted(
+                [
+                    (l.location, l.monitored, l.startup_scan)
+                    for l in collection.libraries.itervalues()
+                ]
+            )
             new_libraries = sorted(dialog.get_items())
 
             if collection_libraries != new_libraries:
-                collection_locations = [location
-                                        for location, monitored, startup_scan in collection_libraries]
-                new_locations = [location
-                                 for location, monitored, startup_scan in new_libraries]
+                collection_locations = [
+                    location
+                    for location, monitored, startup_scan in collection_libraries
+                ]
+                new_locations = [
+                    location for location, monitored, startup_scan in new_libraries
+                ]
 
                 if collection_locations != new_locations:
                     for location in new_locations:
@@ -298,11 +310,13 @@ class Main(object):
         if not self.exaile.collection._scanning and len(libraries) > 0:
             from xl.collection import CollectionScanThread
 
-            thread = CollectionScanThread(self.exaile.collection, startup_scan=startup,
-                                          force_update=force_update)
+            thread = CollectionScanThread(
+                self.exaile.collection, startup_scan=startup, force_update=force_update
+            )
             thread.connect('done', self.on_rescan_done)
-            self.progress_manager.add_monitor(thread,
-                                              _("Scanning collection..."), 'drive-harddisk')
+            self.progress_manager.add_monitor(
+                thread, _("Scanning collection..."), 'drive-harddisk'
+            )
 
     def on_rescan_done(self, thread):
         """
@@ -353,28 +367,39 @@ class Main(object):
             elif issubclass(device.panel_type, xlgui.panel.Panel):
                 paneltype = device.panel_type
 
-        panel = paneltype(self.main.window, self.main,
-                          device, device.get_name())
+        panel = paneltype(self.main.window, self.main, device, device.get_name())
 
         do_sort = True
-        panel.connect('append-items', lambda _panel, items, play:
-                      self.main.on_append_items(items, play, sort=do_sort))
-        panel.connect('queue-items', lambda _panel, items:
-                      self.main.on_append_items(items, queue=True, sort=do_sort))
-        panel.connect('replace-items', lambda _panel, items:
-                      self.main.on_append_items(items, replace=True, sort=do_sort))
+        panel.connect(
+            'append-items',
+            lambda _panel, items, play: self.main.on_append_items(
+                items, play, sort=do_sort
+            ),
+        )
+        panel.connect(
+            'queue-items',
+            lambda _panel, items: self.main.on_append_items(
+                items, queue=True, sort=do_sort
+            ),
+        )
+        panel.connect(
+            'replace-items',
+            lambda _panel, items: self.main.on_append_items(
+                items, replace=True, sort=do_sort
+            ),
+        )
 
         self.device_panels[device.get_name()] = panel
         GLib.idle_add(providers.register, 'main-panel', panel)
         thread = CollectionScanThread(device.get_collection())
         thread.connect('done', panel.load_tree)
-        self.progress_manager.add_monitor(thread,
-                                          _("Scanning %s..." % device.name), 'drive-harddisk')
+        self.progress_manager.add_monitor(
+            thread, _("Scanning %s..." % device.name), 'drive-harddisk'
+        )
 
     def remove_device_panel(self, type, obj, device):
         try:
-            providers.unregister('main-panel',
-                                 self.device_panels[device.get_name()])
+            providers.unregister('main-panel', self.device_panels[device.get_name()])
         except ValueError:
             logger.debug("Couldn't remove panel for %s", device.get_name())
         del self.device_panels[device.get_name()]
@@ -389,6 +414,7 @@ class Main(object):
 
         try:
             import gi
+
             gi.require_version('GtkosxApplication', '1.0')
             from gi.repository import GtkosxApplication
         except (ValueError, ImportError):
@@ -408,10 +434,8 @@ class Main(object):
         # If the dock icon gets clicked we get
         # applicationShouldHandleReopen_hasVisibleWindows_ and show everything.
         class Delegate(NSObject):
-
             @objc.signature('B@:#B')
-            def applicationShouldHandleReopen_hasVisibleWindows_(
-                    self, ns_app, flag):
+            def applicationShouldHandleReopen_hasVisibleWindows_(self, ns_app, flag):
                 logger.debug("osx: handle reopen")
                 # TODO
                 # app.present()

--- a/xlgui/accelerators.py
+++ b/xlgui/accelerators.py
@@ -40,13 +40,14 @@ class Accelerator(object):
 
 
 class AcceleratorManager(providers.ProviderHandler):
-
     def __init__(self, providername, accelgroup):
         self.accelgroup = accelgroup
         providers.ProviderHandler.__init__(self, providername, simple_init=True)
-        
+
     def on_provider_added(self, provider):
-        self.accelgroup.connect(provider.key, provider.mods, Gtk.AccelFlags.VISIBLE, provider.callback)
+        self.accelgroup.connect(
+            provider.key, provider.mods, Gtk.AccelFlags.VISIBLE, provider.callback
+        )
 
     def on_provider_removed(self, provider):
         self.accelgroup.disconnect_key(provider.key, provider.mods)

--- a/xlgui/collection.py
+++ b/xlgui/collection.py
@@ -58,8 +58,7 @@ class CollectionManagerDialog(Gtk.Dialog):
 
         self.set_transient_for(self.parent)
         self.message = dialogs.MessageBar(
-            parent=self.content_area,
-            buttons=Gtk.ButtonsType.CLOSE
+            parent=self.content_area, buttons=Gtk.ButtonsType.CLOSE
         )
 
         for location, library in collection.libraries.iteritems():
@@ -100,10 +99,17 @@ class CollectionManagerDialog(Gtk.Dialog):
         """
             Adds a path to the list
         """
-        dialog = Gtk.FileChooserDialog(_("Add a Directory"),
-                                       self.parent, Gtk.FileChooserAction.SELECT_FOLDER,
-                                       (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                                        Gtk.STOCK_ADD, Gtk.ResponseType.OK))
+        dialog = Gtk.FileChooserDialog(
+            _("Add a Directory"),
+            self.parent,
+            Gtk.FileChooserAction.SELECT_FOLDER,
+            (
+                Gtk.STOCK_CANCEL,
+                Gtk.ResponseType.CANCEL,
+                Gtk.STOCK_ADD,
+                Gtk.ResponseType.OK,
+            ),
+        )
         dialog.set_current_folder(xdg.get_last_dir())
         dialog.set_local_only(False)  # enable gio
         response = dialog.run()
@@ -121,15 +127,17 @@ class CollectionManagerDialog(Gtk.Dialog):
 
             for row in self.model:
                 library_location = Gio.File.new_for_uri(row[0])
-                #monitored = row[1]
-                #scan_on_startup = row[2]
+                # monitored = row[1]
+                # scan_on_startup = row[2]
 
                 if location.has_prefix(library_location):
                     self.message.show_warning(
                         _('Directory not added.'),
-                        _('The directory is already in your collection '
-                          'or is a subdirectory of another directory in '
-                          'your collection.')
+                        _(
+                            'The directory is already in your collection '
+                            'or is a subdirectory of another directory in '
+                            'your collection.'
+                        ),
                     )
                     break
                 elif library_location.has_prefix(location):
@@ -158,6 +166,7 @@ class CollectionManagerDialog(Gtk.Dialog):
         """
 
         from xlgui import main
+
         main.mainwindow().controller.on_rescan_collection()
 
     @GtkTemplate.Callback
@@ -167,6 +176,7 @@ class CollectionManagerDialog(Gtk.Dialog):
         """
 
         from xlgui import main
+
         main.mainwindow().controller.on_rescan_collection_forced()
 
     @GtkTemplate.Callback

--- a/xlgui/cover.py
+++ b/xlgui/cover.py
@@ -38,19 +38,11 @@ from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gtk
 
-from xl import (
-    common,
-    event,
-    providers,
-    settings,
-    xdg
-)
+from xl import common, event, providers, settings, xdg
 from xl.covers import MANAGER as COVER_MANAGER
 from xl.nls import gettext as _
 from xlgui.widgets import dialogs, menu
-from xlgui import (
-    guiutil
-)
+from xlgui import guiutil
 from xlgui.guiutil import pixbuf_from_data
 
 logger = logging.getLogger(__name__)
@@ -76,42 +68,19 @@ class CoverManager(GObject.GObject):
     """
         Cover manager window
     """
+
     __gsignals__ = {
-        'prefetch-started': (
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            ()
-        ),
-        'prefetch-progress': (
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            (GObject.TYPE_INT,)
-        ),
-        'prefetch-completed': (
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            (GObject.TYPE_INT,)
-        ),
-        'fetch-started': (
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            (GObject.TYPE_INT,)
-        ),
-        'fetch-completed': (
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            (GObject.TYPE_INT,)
-        ),
-        'fetch-progress': (
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            (GObject.TYPE_INT,)
-        ),
+        'prefetch-started': (GObject.SignalFlags.RUN_LAST, None, ()),
+        'prefetch-progress': (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_INT,)),
+        'prefetch-completed': (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_INT,)),
+        'fetch-started': (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_INT,)),
+        'fetch-completed': (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_INT,)),
+        'fetch-progress': (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_INT,)),
         'cover-fetched': (
             GObject.SignalFlags.RUN_LAST,
             None,
-            (GObject.TYPE_PYOBJECT, GdkPixbuf.Pixbuf)
-        )
+            (GObject.TYPE_PYOBJECT, GdkPixbuf.Pixbuf),
+        ),
     }
 
     def __init__(self, parent, collection):
@@ -129,7 +98,8 @@ class CoverManager(GObject.GObject):
         self.completed_text = _('All covers fetched')
         self.cover_size = (90, 90)
         self.default_cover_pixbuf = pixbuf_from_data(
-            COVER_MANAGER.get_default_cover(), self.cover_size)
+            COVER_MANAGER.get_default_cover(), self.cover_size
+        )
 
         builder = Gtk.Builder()
         builder.add_from_file(xdg.get_data_path('ui', 'covermanager.ui'))
@@ -139,8 +109,7 @@ class CoverManager(GObject.GObject):
         self.window.set_transient_for(parent)
 
         self.message = dialogs.MessageBar(
-            parent=builder.get_object('content_area'),
-            buttons=Gtk.ButtonsType.CLOSE
+            parent=builder.get_object('content_area'), buttons=Gtk.ButtonsType.CLOSE
         )
 
         self.previews_box = builder.get_object('previews_box')
@@ -152,8 +121,9 @@ class CoverManager(GObject.GObject):
 
         self.progress_bar = builder.get_object('progressbar')
         self.progress_bar.set_text(_('Collecting albums and covers...'))
-        self.progress_bar.pulse_timeout = \
-            GLib.timeout_add(100, self.on_progress_pulse_timeout)
+        self.progress_bar.pulse_timeout = GLib.timeout_add(
+            100, self.on_progress_pulse_timeout
+        )
         self.close_button = builder.get_object('close_button')
         self.stop_button = builder.get_object('stop_button')
         self.stop_button.set_sensitive(False)
@@ -162,7 +132,9 @@ class CoverManager(GObject.GObject):
         self.window.show_all()
 
         self.stopper = threading.Event()
-        thread = threading.Thread(target=self.prefetch, name='CoverPrefetch', args=(collection,))
+        thread = threading.Thread(
+            target=self.prefetch, name='CoverPrefetch', args=(collection,)
+        )
         thread.daemon = True
         thread.start()
 
@@ -212,8 +184,9 @@ class CoverManager(GObject.GObject):
             cover_pixbuf = pixbuf_from_data(cover_data) if cover_data else None
 
             try:
-                thumbnail_pixbuf = cover_pixbuf.scale_simple(*cover_size,
-                                                             interp_type=GdkPixbuf.InterpType.BILINEAR)
+                thumbnail_pixbuf = cover_pixbuf.scale_simple(
+                    *cover_size, interp_type=GdkPixbuf.InterpType.BILINEAR
+                )
             except AttributeError:  # cover_pixbuf is None
                 thumbnail_pixbuf = default_cover_pixbuf
                 outstanding.append(album)
@@ -280,8 +253,7 @@ class CoverManager(GObject.GObject):
                 savedir = Gio.File.new_for_uri(track.get_loc_for_io()).get_parent()
                 if savedir:
                     savedir = savedir.get_path()
-                cover_window = CoverWindow(self.window, cover_pixbuf, album[1],
-                                           savedir)
+                cover_window = CoverWindow(self.window, cover_pixbuf, album[1], savedir)
                 cover_window.show_all()
 
     def fetch_cover(self):
@@ -331,8 +303,9 @@ class CoverManager(GObject.GObject):
         self.previews_box.set_model(self.model)
         self.fetch_button.set_sensitive(True)
         self.progress_bar.set_fraction(0)
-        self.progress_bar.set_text(self.outstanding_text.format(
-            outstanding=outstanding))
+        self.progress_bar.set_text(
+            self.outstanding_text.format(outstanding=outstanding)
+        )
 
     def do_prefetch_progress(self, progress):
         """
@@ -372,8 +345,7 @@ class CoverManager(GObject.GObject):
         outstanding = len(self.outstanding)
 
         if outstanding > 0:
-            progress_text = self.outstanding_text.format(
-                outstanding=outstanding)
+            progress_text = self.outstanding_text.format(outstanding=outstanding)
         else:
             progress_text = self.completed_text
 
@@ -387,8 +359,9 @@ class CoverManager(GObject.GObject):
             Updates the widgets to reflect the newly fetched cover
         """
         path = self.model_path_cache[album]
-        self.model[path][1] = pixbuf.scale_simple(*self.cover_size,
-                                                  interp_type=GdkPixbuf.InterpType.BILINEAR)
+        self.model[path][1] = pixbuf.scale_simple(
+            *self.cover_size, interp_type=GdkPixbuf.InterpType.BILINEAR
+        )
 
     def on_cover_chosen(self, cover_chooser, track, cover_data):
         """
@@ -411,7 +384,8 @@ class CoverManager(GObject.GObject):
 
                 if outstanding > 0:
                     progress_text = self.outstanding_text.format(
-                        outstanding=outstanding)
+                        outstanding=outstanding
+                    )
                 else:
                     progress_text = self.completed_text
 
@@ -516,7 +490,7 @@ class CoverMenu(menu.Menu):
         """
         menu.Menu.__init__(self, widget)
         self.w = widget
-        
+
         self.add_simple(_('Show Cover'), self.on_show_clicked)
         self.add_simple(_('Fetch Cover'), self.on_fetch_clicked)
         self.add_simple(_('Remove Cover'), self.on_remove_clicked)
@@ -538,9 +512,8 @@ class CoverWidget(Gtk.EventBox):
     """
         Represents the cover widget displayed by the track information
     """
-    __gsignals__ = {
-        'cover-found': (GObject.SignalFlags.RUN_LAST, None, (object,)),
-    }
+
+    __gsignals__ = {'cover-found': (GObject.SignalFlags.RUN_LAST, None, (object,))}
 
     def __init__(self, image):
         """
@@ -555,7 +528,7 @@ class CoverWidget(Gtk.EventBox):
         self.cover_data = None
         self.menu = CoverMenu(self)
         self.menu.attach_to_widget(self)
-        
+
         self.filename = None
 
         guiutil.gtk_widget_replace(image, self)
@@ -563,8 +536,7 @@ class CoverWidget(Gtk.EventBox):
         self.set_track(None)
         self.image.show()
 
-        event.add_callback(self.on_quit_application,
-                           'quit_application')
+        event.add_callback(self.on_quit_application, 'quit_application')
 
         if settings.get_option('gui/use_alpha', False):
             self.set_app_paintable(True)
@@ -577,8 +549,7 @@ class CoverWidget(Gtk.EventBox):
             os.remove(self.filename)
             self.filename = None
 
-        event.remove_callback(self.on_quit_application,
-                              'quit-application')
+        event.remove_callback(self.on_quit_application, 'quit-application')
 
     def set_track(self, track):
         """
@@ -588,11 +559,11 @@ class CoverWidget(Gtk.EventBox):
         self.__track = track
 
         self.set_blank()
-        self.drag_dest_set(Gtk.DestDefaults.ALL,
-                           [Gtk.TargetEntry.new('text/uri-list', 0, 0)],
-                           Gdk.DragAction.COPY |
-                           Gdk.DragAction.DEFAULT |
-                           Gdk.DragAction.MOVE)
+        self.drag_dest_set(
+            Gtk.DestDefaults.ALL,
+            [Gtk.TargetEntry.new('text/uri-list', 0, 0)],
+            Gdk.DragAction.COPY | Gdk.DragAction.DEFAULT | Gdk.DragAction.MOVE,
+        )
 
         @common.threaded
         def __get_cover():
@@ -621,8 +592,12 @@ class CoverWidget(Gtk.EventBox):
             savedir = Gio.File.new_for_uri(self.__track.get_loc_for_io()).get_parent()
             if savedir:
                 savedir = savedir.get_path()
-            window = CoverWindow(self.get_toplevel(), pixbuf,
-                                 self.__track.get_tag_display('album'), savedir)
+            window = CoverWindow(
+                self.get_toplevel(),
+                pixbuf,
+                self.__track.get_tag_display('album'),
+                savedir,
+            )
             window.show_all()
 
     def fetch_cover(self):
@@ -668,11 +643,11 @@ class CoverWidget(Gtk.EventBox):
             return
 
         if enabled:
-            self.drag_source_set(Gdk.ModifierType.BUTTON1_MASK,
-                                 [Gtk.TargetEntry.new('text/uri-list', 0, 0)],
-                                 Gdk.DragAction.DEFAULT |
-                                 Gdk.DragAction.MOVE
-                                 )
+            self.drag_source_set(
+                Gdk.ModifierType.BUTTON1_MASK,
+                [Gtk.TargetEntry.new('text/uri-list', 0, 0)],
+                Gdk.DragAction.DEFAULT | Gdk.DragAction.MOVE,
+            )
         else:
             self.drag_source_unset()
 
@@ -698,10 +673,10 @@ class CoverWidget(Gtk.EventBox):
         context = self.props.window.cairo_create()
         background = self.style.bg[Gtk.StateType.NORMAL]
         context.set_source_rgba(
-            float(background.red) / 256**2,
-            float(background.green) / 256**2,
-            float(background.blue) / 256**2,
-            opacity
+            float(background.red) / 256 ** 2,
+            float(background.green) / 256 ** 2,
+            float(background.blue) / 256 ** 2,
+            opacity,
         )
         context.set_operator(cairo.OPERATOR_SOURCE)
         context.paint()
@@ -752,8 +727,7 @@ class CoverWidget(Gtk.EventBox):
 
             if pixbuf is not None:
                 self.image.set_from_pixbuf(pixbuf)
-                COVER_MANAGER.set_cover(self.__track, db_string,
-                                        self.cover_data)
+                COVER_MANAGER.set_cover(self.__track, db_string, self.cover_data)
 
     def on_cover_chosen(self, object, track, cover_data):
         """
@@ -839,8 +813,9 @@ class CoverWindow(object):
         tb_min_height, tb_natural_height = self.toolbar.get_preferred_height()
         sb_min_height, sb_natural_height = self.statusbar.get_preferred_height()
         self.cover_window_height = 500 + tb_natural_height + sb_natural_height
-        self.cover_window.set_default_size(self.cover_window_width,
-                                           self.cover_window_height)
+        self.cover_window.set_default_size(
+            self.cover_window_width, self.cover_window_height
+        )
 
         self.image_original_pixbuf = pixbuf
         self.image_pixbuf = self.image_original_pixbuf
@@ -864,15 +839,16 @@ class CoverWindow(object):
         tb_min_height, tb_natural_height = self.toolbar.get_preferred_height()
         sb_min_height, sb_natural_height = self.statusbar.get_preferred_height()
 
-        return self.cover_window.get_size()[1] - \
-            tb_natural_height - sb_natural_height
+        return self.cover_window.get_size()[1] - tb_natural_height - sb_natural_height
 
     def center_image(self):
         """Centers the image in the layout"""
-        new_x = max(0, int((self.available_image_width() -
-                            self.image_pixbuf.get_width()) / 2))
-        new_y = max(0, int((self.available_image_height() -
-                            self.image_pixbuf.get_height()) / 2))
+        new_x = max(
+            0, int((self.available_image_width() - self.image_pixbuf.get_width()) / 2)
+        )
+        new_y = max(
+            0, int((self.available_image_height() - self.image_pixbuf.get_height()) / 2)
+        )
         self.layout.move(self.image, new_x, new_y)
 
     def update_widgets(self):
@@ -881,19 +857,27 @@ class CoverWindow(object):
         if window:
             window.freeze_updates()
         self.apply_zoom()
-        self.layout.set_size(self.image_pixbuf.get_width(),
-                             self.image_pixbuf.get_height())
-        if self.image_fitted or \
-           (self.image_pixbuf.get_width() == self.available_image_width() and
-                self.image_pixbuf.get_height() == self.available_image_height()):
+        self.layout.set_size(
+            self.image_pixbuf.get_width(), self.image_pixbuf.get_height()
+        )
+        if self.image_fitted or (
+            self.image_pixbuf.get_width() == self.available_image_width()
+            and self.image_pixbuf.get_height() == self.available_image_height()
+        ):
             self.scrolledwindow.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.NEVER)
         else:
-            self.scrolledwindow.set_policy(Gtk.PolicyType.AUTOMATIC,
-                                           Gtk.PolicyType.AUTOMATIC)
+            self.scrolledwindow.set_policy(
+                Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC
+            )
         percent = int(100 * self.image_ratio)
-        message = str(self.image_original_pixbuf.get_width()) + " x " + \
-            str(self.image_original_pixbuf.get_height()) + \
-            " pixels " + str(percent) + '%'
+        message = (
+            str(self.image_original_pixbuf.get_width())
+            + " x "
+            + str(self.image_original_pixbuf.get_height())
+            + " pixels "
+            + str(percent)
+            + '%'
+        )
         self.zoom_in_button.set_sensitive(percent < self.max_percent)
         self.zoom_out_button.set_sensitive(percent > self.min_percent)
         self.statusbar.pop(self.statusbar.get_context_id(''))
@@ -905,39 +889,51 @@ class CoverWindow(object):
 
     def apply_zoom(self):
         """Scales the image if needed"""
-        new_width = int(self.image_original_pixbuf.get_width() *
-                        self.image_ratio)
-        new_height = int(self.image_original_pixbuf.get_height() *
-                         self.image_ratio)
-        if new_width != self.image_pixbuf.get_width() or \
-           new_height != self.image_pixbuf.get_height():
-            self.image_pixbuf = self.image_original_pixbuf.scale_simple(new_width,
-                                                                        new_height, self.image_interp)
+        new_width = int(self.image_original_pixbuf.get_width() * self.image_ratio)
+        new_height = int(self.image_original_pixbuf.get_height() * self.image_ratio)
+        if (
+            new_width != self.image_pixbuf.get_width()
+            or new_height != self.image_pixbuf.get_height()
+        ):
+            self.image_pixbuf = self.image_original_pixbuf.scale_simple(
+                new_width, new_height, self.image_interp
+            )
 
     def set_ratio_to_fit(self):
         """Calculates and sets the needed ratio to show the full image"""
-        width_ratio = float(self.image_original_pixbuf.get_width()) / \
-            self.available_image_width()
-        height_ratio = float(self.image_original_pixbuf.get_height()) / \
-            self.available_image_height()
+        width_ratio = (
+            float(self.image_original_pixbuf.get_width()) / self.available_image_width()
+        )
+        height_ratio = (
+            float(self.image_original_pixbuf.get_height())
+            / self.available_image_height()
+        )
         self.image_ratio = 1 / max(1, width_ratio, height_ratio)
 
     def on_key_press(self, widget, event, data=None):
         """
             Closes the cover window when Escape or Ctrl+W is pressed
         """
-        if event.keyval == Gdk.KEY_Escape or \
-                (event.state & Gdk.ModifierType.CONTROL_MASK and event.keyval == Gdk.KEY_w):
+        if event.keyval == Gdk.KEY_Escape or (
+            event.state & Gdk.ModifierType.CONTROL_MASK and event.keyval == Gdk.KEY_w
+        ):
             widget.destroy()
 
     def on_save_as_button_clicked(self, widget):
         """
             Saves image to user-specified location
         """
-        dialog = Gtk.FileChooserDialog(_("Save File"), self.cover_window,
-                                       Gtk.FileChooserAction.SAVE,
-                                       (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                                        Gtk.STOCK_SAVE, Gtk.ResponseType.ACCEPT))
+        dialog = Gtk.FileChooserDialog(
+            _("Save File"),
+            self.cover_window,
+            Gtk.FileChooserAction.SAVE,
+            (
+                Gtk.STOCK_CANCEL,
+                Gtk.ResponseType.CANCEL,
+                Gtk.STOCK_SAVE,
+                Gtk.ResponseType.ACCEPT,
+            ),
+        )
         names = settings.get_option('covers/localfile/preferred_names')
         filename = (names[0] if names else 'cover') + '.png'
         dialog.set_current_name(filename)
@@ -992,8 +988,10 @@ class CoverWindow(object):
         self.cover_window.hide()
 
     def cover_window_size_allocate(self, widget, allocation):
-        if self.cover_window_width != allocation.width or \
-           self.cover_window_height != allocation.height:
+        if (
+            self.cover_window_width != allocation.width
+            or self.cover_window_height != allocation.height
+        ):
             if self.image_fitted:
                 self.set_ratio_to_fit()
             self.update_widgets()
@@ -1006,17 +1004,10 @@ class CoverChooser(GObject.GObject):
         Fetches all album covers for a string, and allows the user to choose
         one out of the list
     """
+
     __gsignals__ = {
-        'covers-fetched': (
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            (object,)
-        ),
-        'cover-chosen': (
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            (object, object)
-        )
+        'covers-fetched': (GObject.SignalFlags.RUN_LAST, None, (object,)),
+        'cover-chosen': (GObject.SignalFlags.RUN_LAST, None, (object, object)),
     }
 
     def __init__(self, parent, track, search=None):
@@ -1030,15 +1021,18 @@ class CoverChooser(GObject.GObject):
         self.builder.connect_signals(self)
         self.window = self.builder.get_object('CoverChooser')
 
-        self.window.set_title(_("Cover options for %(artist)s - %(album)s") % {
-            'artist': track.get_tag_display('artist'),
-            'album': track.get_tag_display('album')
-        })
+        self.window.set_title(
+            _("Cover options for %(artist)s - %(album)s")
+            % {
+                'artist': track.get_tag_display('artist'),
+                'album': track.get_tag_display('album'),
+            }
+        )
         self.window.set_transient_for(parent)
 
         self.message = dialogs.MessageBar(
             parent=self.builder.get_object('main_container'),
-            buttons=Gtk.ButtonsType.CLOSE
+            buttons=Gtk.ButtonsType.CLOSE,
         )
         self.message.connect('response', self.on_message_response)
 
@@ -1069,7 +1063,9 @@ class CoverChooser(GObject.GObject):
         self.window.show_all()
 
         self.stopper = threading.Event()
-        self.fetcher_thread = threading.Thread(target=self.fetch_cover, name='Coverfetcher')
+        self.fetcher_thread = threading.Thread(
+            target=self.fetch_cover, name='Coverfetcher'
+        )
         self.fetcher_thread.start()
 
     def fetch_cover(self):
@@ -1088,11 +1084,13 @@ class CoverChooser(GObject.GObject):
                 pixbuf = pixbuf_from_data(coverdata)
 
                 if pixbuf:
-                    self.covers_model.append([
-                        (db_string, coverdata),
-                        pixbuf,
-                        pixbuf.scale_simple(50, 50, GdkPixbuf.InterpType.BILINEAR)
-                    ])
+                    self.covers_model.append(
+                        [
+                            (db_string, coverdata),
+                            pixbuf,
+                            pixbuf.scale_simple(50, 50, GdkPixbuf.InterpType.BILINEAR),
+                        ]
+                    )
 
         self.emit('covers-fetched', db_strings)
 
@@ -1118,14 +1116,20 @@ class CoverChooser(GObject.GObject):
 
             # Try to select the current cover of the track, fallback to first
             track_db_string = COVER_MANAGER.get_db_string(self.track)
-            position = db_strings.index(track_db_string) if track_db_string in db_strings else 0
+            position = (
+                db_strings.index(track_db_string)
+                if track_db_string in db_strings
+                else 0
+            )
             self.previews_box.select_path(Gtk.TreePath(position))
         else:
             self.builder.get_object('stack').hide()
             self.builder.get_object('actions_box').hide()
             self.message.show_warning(
                 _('No covers found.'),
-                _('None of the enabled sources has a cover for this track, try enabling more sources.')
+                _(
+                    'None of the enabled sources has a cover for this track, try enabling more sources.'
+                ),
             )
 
     def on_cancel_button_clicked(self, button):
@@ -1166,8 +1170,11 @@ class CoverChooser(GObject.GObject):
             pixbuf = self.covers_model[path][1]
 
             self.cover.set_image_pixbuf(pixbuf)
-            self.size_label.set_text(_('{width}x{height} pixels').format(
-                width=pixbuf.get_width(), height=pixbuf.get_height()))
+            self.size_label.set_text(
+                _('{width}x{height} pixels').format(
+                    width=pixbuf.get_width(), height=pixbuf.get_height()
+                )
+            )
             # Display readable title of the provider, fallback to its name
             self.source_label.set_text(getattr(provider, 'title', source))
 

--- a/xlgui/devices.py
+++ b/xlgui/devices.py
@@ -42,8 +42,7 @@ class ManagerDialog(Gtk.Window):
 
     __gtype_name__ = 'DeviceManager'
 
-    btn_add, btn_edit, btn_remove, tree_devices, model \
-        = GtkTemplate.Child.widgets(5)
+    btn_add, btn_edit, btn_remove, tree_devices, model = GtkTemplate.Child.widgets(5)
 
     def __init__(self, parent, main):
         Gtk.Window.__init__(self)

--- a/xlgui/guiutil.py
+++ b/xlgui/guiutil.py
@@ -109,8 +109,11 @@ def get_workarea_dimensions(window=None):
         screen = Gdk.Screen.get_default()
         default_monitor = screen.get_primary_monitor()
         return screen.get_monitor_workarea(default_monitor)
-    elif Gtk.get_major_version() > 3 or \
-            Gtk.get_major_version() == 3 and Gtk.get_minor_version() >= 22:
+    elif (
+        Gtk.get_major_version() > 3
+        or Gtk.get_major_version() == 3
+        and Gtk.get_minor_version() >= 22
+    ):
         # Gdk.Monitor was introduced in Gtk+ 3.22
         display = window.get_window().get_display()
         work_area = display.get_monitor_at_window(window.get_window()).get_workarea()
@@ -177,6 +180,7 @@ def pixbuf_from_data(data, size=None, keep_ratio=True, upscale=False):
     loader = GdkPixbuf.PixbufLoader()
 
     if size is not None:
+
         def on_size_prepared(loader, width, height):
             """
                 Keeps the ratio if requested
@@ -197,15 +201,16 @@ def pixbuf_from_data(data, size=None, keep_ratio=True, upscale=False):
                     width = height = max(width, height)
 
             loader.set_size(width, height)
+
         loader.connect('size-prepared', on_size_prepared)
 
     try:
         loader.write(data)
         loader.close()
     except GLib.GError as e:
-        logger.warning('Failed to get pixbuf from data: {error}'.format(
-            error=e.message
-        ))
+        logger.warning(
+            'Failed to get pixbuf from data: {error}'.format(error=e.message)
+        )
     else:
         pixbuf = loader.get_pixbuf()
 
@@ -239,7 +244,9 @@ class ScalableImageWidget(Gtk.Image):
             :param fill: True to expand the image, False to keep its ratio
             :type fill: boolean
         """
-        pixbuf = GdkPixbuf.Pixbuf.new_from_file(Gio.File.new_for_uri(location).get_path())
+        pixbuf = GdkPixbuf.Pixbuf.new_from_file(
+            Gio.File.new_for_uri(location).get_path()
+        )
         self.set_image_pixbuf(pixbuf, fill)
 
     def set_image_data(self, data, fill=False):
@@ -307,13 +314,12 @@ class SearchEntry(object):
         """
             Called when the entry changes
         """
-        empty_search = (entry.get_text() == '')
+        empty_search = entry.get_text() == ''
         entry.props.secondary_icon_sensitive = not empty_search
 
         if self.change_id:
             GLib.source_remove(self.change_id)
-        self.change_id = GLib.timeout_add(self.timeout,
-                                          self.entry_activate)
+        self.change_id = GLib.timeout_add(self.timeout, self.entry_activate)
 
     def on_entry_icon_press(self, entry, icon_pos, event):
         """
@@ -383,7 +389,7 @@ def position_menu(menu, *args):
     menu_allocation = menu.get_allocation()
     position = (
         window_x + widget_allocation.x + 1,
-        window_y + widget_allocation.y - menu_allocation.height - 1
+        window_y + widget_allocation.y - menu_allocation.height - 1,
     )
 
     return (position[0], position[1], True)
@@ -434,7 +440,10 @@ def initialize_from_xml(this, other=None):
             for widget_name in obj.ui_widgets:
                 widget = builder.get_object(widget_name)
                 if widget is None:
-                    raise RuntimeError("Widget '%s' is not present in '%s'" % (widget_name, this.ui_filename))
+                    raise RuntimeError(
+                        "Widget '%s' is not present in '%s'"
+                        % (widget_name, this.ui_filename)
+                    )
                 setattr(obj, widget_name, widget)
 
     signals = None
@@ -445,13 +454,18 @@ def initialize_from_xml(this, other=None):
                 signals = {}
             for signal_name in obj.ui_signals:
                 if not hasattr(obj, signal_name):
-                    raise RuntimeError("Function '%s' is not present in '%s'" % (signal_name, obj))
+                    raise RuntimeError(
+                        "Function '%s' is not present in '%s'" % (signal_name, obj)
+                    )
                 signals[signal_name] = getattr(obj, signal_name)
 
     if signals is not None:
         missing = builder.connect_signals(signals)
         if missing is not None:
-            err = 'The following signals were found in %s but have no assigned handler: %s' % (this.ui_filename, str(missing))
+            err = (
+                'The following signals were found in %s but have no assigned handler: %s'
+                % (this.ui_filename, str(missing))
+            )
             raise RuntimeError(err)
 
     return builder
@@ -595,7 +609,12 @@ def css_from_pango_font_description(pango_font_str):
     # According to https://www.w3schools.com/cssref/pr_font_font-family.asp
     # "If a font name contains white-space, it must be quoted"
     font_css_str = 'font: %s %s %s %s %s "%s"' % (
-        style, variant, weight, stretch, size, new_font.get_family(),
+        style,
+        variant,
+        weight,
+        stretch,
+        size,
+        new_font.get_family(),
     )
     return font_css_str
 
@@ -605,15 +624,15 @@ def _get_closest_visible(model, child_path):
     # (which is presumed to not be visible in the model)
     # -> derived from python's bisect_left (Python license)
     x = child_path.get_indices()[0]
-    
+
     ll = len(model)
     lo = 0
     hi = ll
     if not hi:
         return
-    
+
     while lo < hi:
-        mid = (lo + hi)//2
+        mid = (lo + hi) // 2
         amid = model.convert_path_to_child_path(model[mid].path).get_indices()[0]
         if amid < x:
             lo = mid + 1
@@ -622,6 +641,7 @@ def _get_closest_visible(model, child_path):
     if lo == ll:
         lo -= 1
     return model[lo].path
+
 
 @contextlib.contextmanager
 def without_model(tv):
@@ -639,14 +659,14 @@ def without_model(tv):
     model = tv.get_model()
     child_model = model.get_model()
     selection = tv.get_selection()
-    
+
     # Save existing scroll information if this is a modelfilter
     visible_data = tv.get_visible_range()
     if visible_data:
         # save a ref and path data -- path is used if the row disappears
         visible_data = model.convert_path_to_child_path(visible_data[0])
         visible_ref = Gtk.TreeRowReference(child_model, visible_data)
-    
+
     # grab selection data, convert them to child row references
     # -> need refs because paths will change if objects are deleted
     seldata = selection.get_selected_rows()
@@ -658,11 +678,11 @@ def without_model(tv):
             if not first_selected_path:
                 first_selected_path = path
             selected_rows.append(Gtk.TreeRowReference(child_model, path))
-    
+
     tv.set_model(None)
     yield model
     tv.set_model(model)
-    
+
     # restore selection data first
     for row in selected_rows:
         if not row.valid():
@@ -671,13 +691,13 @@ def without_model(tv):
         if path:
             selection.select_path(path)
             first_selected_path = None
-    
+
     # If there were no visible iters, try to find something close
     if first_selected_path:
         first_selected_path = _get_closest_visible(model, first_selected_path)
         if first_selected_path:
             selection.select_path(first_selected_path)
-    
+
     # Restore scroll position
     if visible_data:
         # If original item is visible, this is easy
@@ -687,12 +707,13 @@ def without_model(tv):
         else:
             # But if it isn't valid, then just use the path data
             scroll_to = model.convert_child_path_to_path(visible_data)
-        
+
         if scroll_to is None:
             # If not, search for the closest visible item
             scroll_to = _get_closest_visible(model, visible_data)
-        
+
         if scroll_to:
             tv.scroll_to_cell(scroll_to, None, True, 0, 0)
+
 
 # vim: et sts=4 sw=4

--- a/xlgui/icons.py
+++ b/xlgui/icons.py
@@ -29,20 +29,12 @@
 """
 
 import glob
-from gi.repository import (
-    GdkPixbuf,
-    GLib,
-    Gtk
-)
+from gi.repository import GdkPixbuf, GLib, Gtk
 from itertools import imap, ifilter
 import logging
 import os
 
-from xl import (
-    common,
-    covers,
-    settings,
-)
+from xl import common, covers, settings
 from xlgui.guiutil import pixbuf_from_data
 
 logger = logging.getLogger(__name__)
@@ -70,13 +62,16 @@ class ExtendedPixbuf(object):
             pixbuf.get_has_alpha(),
             pixbuf.get_bits_per_sample(),
             pixbuf.get_width(),
-            pixbuf.get_height()
+            pixbuf.get_height(),
         )
         pixbuf.copy_area(
-            src_x=0, src_y=0,
-            width=self.pixbuf.get_width(), height=self.pixbuf.get_height(),
+            src_x=0,
+            src_y=0,
+            width=self.pixbuf.get_width(),
+            height=self.pixbuf.get_height(),
             dest_pixbuf=self.pixbuf,
-            dest_x=0, dest_y=0
+            dest_x=0,
+            dest_y=0,
         )
 
     def get_width(self):
@@ -208,21 +203,27 @@ class ExtendedPixbuf(object):
             self.pixbuf.get_has_alpha(),
             self.pixbuf.get_bits_per_sample(),
             self.pixbuf.get_width() + spacing + other.get_width(),
-            height
+            height,
         )
         new_pixbuf.fill(0xffffff00)
 
         self.pixbuf.copy_area(
-            src_x=0, src_y=0,
-            width=self.pixbuf.get_width(), height=self.pixbuf.get_height(),
+            src_x=0,
+            src_y=0,
+            width=self.pixbuf.get_width(),
+            height=self.pixbuf.get_height(),
             dest_pixbuf=new_pixbuf,
-            dest_x=0, dest_y=0
+            dest_x=0,
+            dest_y=0,
         )
         other.copy_area(
-            src_x=0, src_y=0,
-            width=other.get_width(), height=other.get_height(),
+            src_x=0,
+            src_y=0,
+            width=other.get_width(),
+            height=other.get_height(),
             dest_pixbuf=new_pixbuf,
-            dest_x=self.pixbuf.get_width() + spacing, dest_y=0
+            dest_x=self.pixbuf.get_width() + spacing,
+            dest_y=0,
         )
 
         return ExtendedPixbuf(new_pixbuf)
@@ -249,21 +250,27 @@ class ExtendedPixbuf(object):
             self.pixbuf.get_has_alpha(),
             self.pixbuf.get_bits_per_sample(),
             width,
-            self.pixbuf.get_height() + spacing + other.get_height()
+            self.pixbuf.get_height() + spacing + other.get_height(),
         )
         new_pixbuf.fill(0xffffff00)
 
         self.pixbuf.copy_area(
-            src_x=0, src_y=0,
-            width=self.pixbuf.get_width(), height=self.pixbuf.get_height(),
+            src_x=0,
+            src_y=0,
+            width=self.pixbuf.get_width(),
+            height=self.pixbuf.get_height(),
             dest_pixbuf=new_pixbuf,
-            dest_x=0, dest_y=0
+            dest_x=0,
+            dest_y=0,
         )
         other.copy_area(
-            src_x=0, src_y=0,
-            width=other.get_width(), height=other.get_height(),
+            src_x=0,
+            src_y=0,
+            width=other.get_width(),
+            height=other.get_height(),
             dest_pixbuf=new_pixbuf,
-            dest_x=0, dest_y=self.pixbuf.get_height() + spacing
+            dest_x=0,
+            dest_y=self.pixbuf.get_height() + spacing,
         )
 
         return ExtendedPixbuf(new_pixbuf)
@@ -286,16 +293,19 @@ class ExtendedPixbuf(object):
             self.pixbuf.get_has_alpha(),
             self.pixbuf.get_bits_per_sample(),
             self.pixbuf.get_width() * multiplier + spacing * multiplier,
-            self.pixbuf.get_height()
+            self.pixbuf.get_height(),
         )
         new_pixbuf.fill(0xffffff00)
 
         for n in xrange(0, multiplier):
             self.pixbuf.copy_area(
-                src_x=0, src_y=0,
-                width=self.pixbuf.get_width(), height=self.pixbuf.get_height(),
+                src_x=0,
+                src_y=0,
+                width=self.pixbuf.get_width(),
+                height=self.pixbuf.get_height(),
                 dest_pixbuf=new_pixbuf,
-                dest_x=n * self.pixbuf.get_width() + n * spacing, dest_y=0
+                dest_x=n * self.pixbuf.get_width() + n * spacing,
+                dest_y=0,
             )
 
         return ExtendedPixbuf(new_pixbuf)
@@ -318,16 +328,19 @@ class ExtendedPixbuf(object):
             self.pixbuf.get_has_alpha(),
             self.pixbuf.get_bits_per_sample(),
             self.pixbuf.get_width(),
-            self.pixbuf.get_height() * multiplier + spacing * multiplier
+            self.pixbuf.get_height() * multiplier + spacing * multiplier,
         )
         new_pixbuf.fill(0xffffff00)
 
         for n in xrange(0, multiplier):
             self.pixbuf.copy_area(
-                src_x=0, src_y=0,
-                width=self.pixbuf.get_width(), height=self.pixbuf.get_height(),
+                src_x=0,
+                src_y=0,
+                width=self.pixbuf.get_width(),
+                height=self.pixbuf.get_height(),
                 dest_pixbuf=new_pixbuf,
-                dest_x=0, dest_y=n * self.pixbuf.get_height() + n * spacing
+                dest_x=0,
+                dest_y=n * self.pixbuf.get_height() + n * spacing,
             )
 
         return ExtendedPixbuf(new_pixbuf)
@@ -352,21 +365,25 @@ class ExtendedPixbuf(object):
             self.pixbuf.get_colorspace(),
             self.pixbuf.get_has_alpha(),
             self.pixbuf.get_bits_per_sample(),
-            width, height
+            width,
+            height,
         )
         new_pixbuf.fill(0xffffff00)
 
         for pixbuf in (self.pixbuf, other):
             pixbuf.composite(
                 dest=new_pixbuf,
-                dest_x=0, dest_y=0,
+                dest_x=0,
+                dest_y=0,
                 dest_width=pixbuf.get_width(),
                 dest_height=pixbuf.get_height(),
-                offset_x=0, offset_y=0,
-                scale_x=1, scale_y=1,
+                offset_x=0,
+                offset_y=0,
+                scale_x=1,
+                scale_y=1,
                 interp_type=GdkPixbuf.InterpType.BILINEAR,
                 # Alpha needs to be embedded in the pixbufs
-                overall_alpha=255
+                overall_alpha=255,
             )
 
         return ExtendedPixbuf(new_pixbuf)
@@ -401,16 +418,19 @@ class ExtendedPixbuf(object):
             self.pixbuf.get_colorspace(),
             self.pixbuf.get_has_alpha(),
             self.pixbuf.get_bits_per_sample(),
-            width, height
+            width,
+            height,
         )
         new_pixbuf.fill(0xffffff00)
 
         self.pixbuf.copy_area(
-            src_x=0, src_y=0,
+            src_x=0,
+            src_y=0,
             width=self.pixbuf.get_width(),
             height=self.pixbuf.get_height(),
             dest_pixbuf=new_pixbuf,
-            dest_x=offset_x, dest_y=offset_y
+            dest_x=offset_x,
+            dest_y=offset_y,
         )
 
         return ExtendedPixbuf(new_pixbuf)
@@ -425,31 +445,53 @@ class ExtendedPixbuf(object):
         """
             Override to return same type
         """
-        return ExtendedPixbuf(GdkPixbuf.Pixbuf.add_alpha(
-            self.pixbuf, substitute_color, r, g, b))
+        return ExtendedPixbuf(
+            GdkPixbuf.Pixbuf.add_alpha(self.pixbuf, substitute_color, r, g, b)
+        )
 
     def scale_simple(self, dest_width, dest_height, interp_type):
         """
             Override to return same type
         """
-        return ExtendedPixbuf(GdkPixbuf.Pixbuf.scale_simple(
-            self.pixbuf, dest_width, dest_height, interp_type))
+        return ExtendedPixbuf(
+            GdkPixbuf.Pixbuf.scale_simple(
+                self.pixbuf, dest_width, dest_height, interp_type
+            )
+        )
 
-    def composite_color_simple(self, dest_width, dest_height, interp_type,
-                               overall_alpha, check_size, color1, color2):
+    def composite_color_simple(
+        self,
+        dest_width,
+        dest_height,
+        interp_type,
+        overall_alpha,
+        check_size,
+        color1,
+        color2,
+    ):
         """
             Override to return same type
         """
-        return ExtendedPixbuf(GdkPixbuf.Pixbuf.composite_color_simple(
-            self.pixbuf, dest_width, dest_height, interp_type,
-            overall_alpha, check_size, color1, color2))
+        return ExtendedPixbuf(
+            GdkPixbuf.Pixbuf.composite_color_simple(
+                self.pixbuf,
+                dest_width,
+                dest_height,
+                interp_type,
+                overall_alpha,
+                check_size,
+                color1,
+                color2,
+            )
+        )
 
     def new_subpixbuf(self, src_x, src_y, width, height):
         """
             Override to return same type
         """
-        return ExtendedPixbuf(GdkPixbuf.Pixbuf.new_subpixbuf(
-            self.pixbuf, src_x, src_y, width, height))
+        return ExtendedPixbuf(
+            GdkPixbuf.Pixbuf.new_subpixbuf(self.pixbuf, src_x, src_y, width, height)
+        )
 
     def rotate_simple(self, angle):
         """
@@ -491,12 +533,14 @@ class IconManager(object):
         self._cache = {}
 
         self.rating_active_pixbuf = ExtendedPixbuf(
-            self.pixbuf_from_icon_name('starred', size=Gtk.IconSize.MENU))
+            self.pixbuf_from_icon_name('starred', size=Gtk.IconSize.MENU)
+        )
         self.rating_inactive_pixbuf = ExtendedPixbuf(
-            self.pixbuf_from_icon_name('non-starred', size=Gtk.IconSize.MENU))
+            self.pixbuf_from_icon_name('non-starred', size=Gtk.IconSize.MENU)
+        )
 
         # nobody actually sets the rating option, so don't handle it for now
-        #event.add_ui_callback(self.on_option_set, 'rating_option_set')
+        # event.add_ui_callback(self.on_option_set, 'rating_option_set')
 
     def add_icon_name_from_directory(self, icon_name, directory):
         """
@@ -553,12 +597,12 @@ class IconManager(object):
             self.add_icon_name_from_pixbuf(icon_name, pixbuf, size)
         except Exception as e:
             # Happens if, e.g., librsvg is not installed.
-            logger.warning('Failed to add icon name "{icon_name}" '
-                           'from file "{filename}": {error}'.format(
-                               icon_name=icon_name,
-                               filename=filename,
-                               error=e.message
-                           ))
+            logger.warning(
+                'Failed to add icon name "{icon_name}" '
+                'from file "{filename}": {error}'.format(
+                    icon_name=icon_name, filename=filename, error=e.message
+                )
+            )
             pass
 
     def add_icon_name_from_pixbuf(self, icon_name, pixbuf, size=None):
@@ -596,12 +640,16 @@ class IconManager(object):
 
         try:
             pixbuf = self.icon_theme.load_icon(
-                icon_name, size, Gtk.IconLookupFlags.NO_SVG | Gtk.IconLookupFlags.FORCE_SIZE)
+                icon_name,
+                size,
+                Gtk.IconLookupFlags.NO_SVG | Gtk.IconLookupFlags.FORCE_SIZE,
+            )
         except GLib.GError as e:
-            logger.warning('Failed to get pixbuf from "{icon_name}": {error}'.format(
-                icon_name=icon_name,
-                error=e.message
-            ))
+            logger.warning(
+                'Failed to get pixbuf from "{icon_name}": {error}'.format(
+                    icon_name=icon_name, error=e.message
+                )
+            )
             pixbuf = None
 
         # TODO: Check if fallbacks are necessary
@@ -622,12 +670,16 @@ class IconManager(object):
         width = self.rating_active_pixbuf.get_width()
         height = self.rating_active_pixbuf.get_height()
 
-        active_pixbuf = self.rating_active_pixbuf.scale_simple(int(width * size_ratio),
-                                                               int(height * size_ratio),
-                                                               GdkPixbuf.InterpType.BILINEAR)
-        inactive_pixbuf = self.rating_inactive_pixbuf.scale_simple(int(width * size_ratio),
-                                                                   int(height * size_ratio),
-                                                                   GdkPixbuf.InterpType.BILINEAR)
+        active_pixbuf = self.rating_active_pixbuf.scale_simple(
+            int(width * size_ratio),
+            int(height * size_ratio),
+            GdkPixbuf.InterpType.BILINEAR,
+        )
+        inactive_pixbuf = self.rating_inactive_pixbuf.scale_simple(
+            int(width * size_ratio),
+            int(height * size_ratio),
+            GdkPixbuf.InterpType.BILINEAR,
+        )
         rating = max(0, rating)
         rating = min(rating, maximum)
 
@@ -654,21 +706,28 @@ class IconManager(object):
         # Sizes
         cover_side = cover_width
         cover_portion = int(cover_side * 0.08)  # 8% of sides
-        covers_square_side = (cover_side + cover_portion * (len(pixbuf_list) - 1))
+        covers_square_side = cover_side + cover_portion * (len(pixbuf_list) - 1)
         border = 4
         total_width = total_height = covers_square_side + (2 * border)
 
         # The result pixbuf
-        result_pixbuf = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, True, 8, total_width, total_height)
+        result_pixbuf = GdkPixbuf.Pixbuf.new(
+            GdkPixbuf.Colorspace.RGB, True, 8, total_width, total_height
+        )
         result_pixbuf.fill(0x00000000)  # Fill with transparent background
 
-        covers_area = result_pixbuf.new_subpixbuf(src_x=border, src_y=border, width=covers_square_side,
-                                                  height=covers_square_side)
+        covers_area = result_pixbuf.new_subpixbuf(
+            src_x=border,
+            src_y=border,
+            width=covers_square_side,
+            height=covers_square_side,
+        )
         # Write covers
         for i, pixbuf in enumerate(pixbuf_list):
             dest = cover_portion * i  # Put in a diagonal
-            pixbuf.copy_area(0, 0, pixbuf.get_width(), pixbuf.get_height(),
-                             covers_area, dest, dest)
+            pixbuf.copy_area(
+                0, 0, pixbuf.get_width(), pixbuf.get_height(), covers_area, dest, dest
+            )
 
         return result_pixbuf
 
@@ -680,11 +739,15 @@ class IconManager(object):
             :return: GdkPixbuf.Pixbuf or None if none found
         """
         cover_width = settings.get_option('gui/cover_width', 100)
-        as_pixbuf = lambda data: pixbuf_from_data(data=data, size=(cover_width, cover_width))
+        as_pixbuf = lambda data: pixbuf_from_data(
+            data=data, size=(cover_width, cover_width)
+        )
         get_cover_for_tracks = covers.MANAGER.get_cover_for_tracks
         db_string_list = []
         cover_for_tracks = lambda tracks: get_cover_for_tracks(tracks, db_string_list)
-        filtered_covers = ifilter(None, imap(cover_for_tracks, tracks)) # Remove None cover tracks
+        filtered_covers = ifilter(
+            None, imap(cover_for_tracks, tracks)
+        )  # Remove None cover tracks
         async_loader = common.AsyncLoader(imap(as_pixbuf, filtered_covers))
         async_loader.end(0.333)
         return self.__create_drag_cover_icon(async_loader.result, cover_width)

--- a/xlgui/main.py
+++ b/xlgui/main.py
@@ -32,33 +32,13 @@ from gi.repository import GObject
 from gi.repository import Gtk
 
 from xl.nls import gettext as _
-from xl import (
-    common,
-    event,
-    formatter,
-    player,
-    providers,
-    settings,
-    trax,
-)
+from xl import common, event, formatter, player, providers, settings, trax
 from xlgui.accelerators import AcceleratorManager
 from xlgui.accelerators import Accelerator
 from xlgui.playlist_container import PlaylistContainer
-from xlgui.widgets import (
-    dialogs,
-    info,
-    menu,
-    playback
-)
-from xlgui.widgets.playlist import (
-    PlaylistPage,
-    PlaylistView
-)
-from xlgui import (
-    guiutil,
-    tray,
-    menu as mainmenu
-)
+from xlgui.widgets import dialogs, info, menu, playback
+from xlgui.widgets.playlist import PlaylistPage, PlaylistView
+from xlgui import guiutil, tray, menu as mainmenu
 
 logger = logging.getLogger(__name__)
 
@@ -73,11 +53,15 @@ class MainWindow(GObject.GObject):
     """
         Main Exaile Window
     """
+
     __gproperties__ = {
-        'is-fullscreen': (bool, 'Fullscreen',
-                          'Whether the window is fullscreen.',
-                          False,  # Default
-                          GObject.PARAM_READWRITE),
+        'is-fullscreen': (
+            bool,
+            'Fullscreen',
+            'Whether the window is fullscreen.',
+            False,  # Default
+            GObject.PARAM_READWRITE,
+        )
     }
 
     __gsignals__ = {'main-visible-toggle': (GObject.SignalFlags.RUN_LAST, bool, ())}
@@ -106,13 +90,17 @@ class MainWindow(GObject.GObject):
 
         self.window = self.builder.get_object('ExaileWindow')
         self.window.set_title('Exaile')
-        self.title_formatter = formatter.TrackFormatter(settings.get_option(
-            'gui/main_window_title_format',
-            _('$title (by $artist)') + ' - Exaile'))
+        self.title_formatter = formatter.TrackFormatter(
+            settings.get_option(
+                'gui/main_window_title_format', _('$title (by $artist)') + ' - Exaile'
+            )
+        )
 
         self.accel_group = Gtk.AccelGroup()
         self.window.add_accel_group(self.accel_group)
-        self.accel_manager = AcceleratorManager('mainwindow-accelerators', self.accel_group)
+        self.accel_manager = AcceleratorManager(
+            'mainwindow-accelerators', self.accel_group
+        )
         self.menubar = self.builder.get_object("mainmenu")
 
         fileitem = self.builder.get_object("file_menu_item")
@@ -156,47 +144,82 @@ class MainWindow(GObject.GObject):
             return (keybinding, description, callback)
 
         hotkeys = (
-            ('<Primary>S', _('Save currently selected playlist'),
-             lambda *_e: self.on_save_playlist()),
-            ('<Shift><Primary>S', _('Save currently selected playlist under a custom name'),
-             lambda *_e: self.on_save_playlist_as()),
-            ('<Primary>F', _('Focus filter in currently focused panel'),
-             lambda *_e: self.on_panel_filter_focus()),
-            ('<Primary>G', _('Focus playlist search'),
-             lambda *_e: self.on_search_playlist_focus()),  # FIXME
-            ('<Primary><Alt>l', _('Clear queue'),
-             lambda *_e: player.QUEUE.clear()),  # FIXME
-
-            ('<Primary>P', _('Start, pause or resume the playback'),
-             self._on_playpause_button),
-            ('<Primary>Right', _('Seek to the right'),
-             lambda *_e: self._on_seek_key(True)),
-            ('<Primary>Left', _('Seek to the left'),
-             lambda *_e: self._on_seek_key(False)),
-
-            ('<Primary>plus', _('Increase the volume'),
-             lambda *_e: self._on_volume_key(True)),
-            ('<Primary>minus', _('Decrease the volume'),
-             lambda *_e: self._on_volume_key(False)),
-
-            ('<Primary>Page_Up', _('Switch to previous tab'),
-             self._on_prev_tab_key),
-            ('<Primary>Page_Down', _('Switch to next tab'),
-             self._on_next_tab_key),
-
-            ('<Alt>N', _('Focus the playlist container'),
-             self._on_focus_playlist_container),
-
+            (
+                '<Primary>S',
+                _('Save currently selected playlist'),
+                lambda *_e: self.on_save_playlist(),
+            ),
+            (
+                '<Shift><Primary>S',
+                _('Save currently selected playlist under a custom name'),
+                lambda *_e: self.on_save_playlist_as(),
+            ),
+            (
+                '<Primary>F',
+                _('Focus filter in currently focused panel'),
+                lambda *_e: self.on_panel_filter_focus(),
+            ),
+            (
+                '<Primary>G',
+                _('Focus playlist search'),
+                lambda *_e: self.on_search_playlist_focus(),
+            ),  # FIXME
+            (
+                '<Primary><Alt>l',
+                _('Clear queue'),
+                lambda *_e: player.QUEUE.clear(),
+            ),  # FIXME
+            (
+                '<Primary>P',
+                _('Start, pause or resume the playback'),
+                self._on_playpause_button,
+            ),
+            (
+                '<Primary>Right',
+                _('Seek to the right'),
+                lambda *_e: self._on_seek_key(True),
+            ),
+            (
+                '<Primary>Left',
+                _('Seek to the left'),
+                lambda *_e: self._on_seek_key(False),
+            ),
+            (
+                '<Primary>plus',
+                _('Increase the volume'),
+                lambda *_e: self._on_volume_key(True),
+            ),
+            (
+                '<Primary>minus',
+                _('Decrease the volume'),
+                lambda *_e: self._on_volume_key(False),
+            ),
+            ('<Primary>Page_Up', _('Switch to previous tab'), self._on_prev_tab_key),
+            ('<Primary>Page_Down', _('Switch to next tab'), self._on_next_tab_key),
+            (
+                '<Alt>N',
+                _('Focus the playlist container'),
+                self._on_focus_playlist_container,
+            ),
             # These 4 are subject to change.. probably should do this
             # via a different mechanism too...
-            ('<Alt>I', _('Focus the files panel'),
-             lambda *_e: self.controller.focus_panel('files')),
-            #('<Alt>C', _('Focus the collection panel'),  # TODO: Does not work, why?
+            (
+                '<Alt>I',
+                _('Focus the files panel'),
+                lambda *_e: self.controller.focus_panel('files'),
+            ),
+            # ('<Alt>C', _('Focus the collection panel'),  # TODO: Does not work, why?
             # lambda *_e: self.controller.focus_panel('collection')),
-            ('<Alt>R', _('Focus the radio panel'),
-             lambda *_e: self.controller.focus_panel('radio')),
-            ('<Alt>L', _('Focus the playlists panel'),
-             lambda *_e: self.controller.focus_panel('playlists')),
+            (
+                '<Alt>R',
+                _('Focus the radio panel'),
+                lambda *_e: self.controller.focus_panel('radio'),
+            ),
+            (
+                '<Alt>L',
+                _('Focus the playlists panel'),
+                lambda *_e: self.controller.focus_panel('playlists'),
+            ),
             factory(1, _('Focus the first tab')),
             factory(2, _('Focus the second tab')),
             factory(3, _('Focus the third tab')),
@@ -219,10 +242,9 @@ class MainWindow(GObject.GObject):
         """
         # TODO: Maybe make this stackable
         self.message = dialogs.MessageBar(
-            parent=self.builder.get_object('player_box'),
-            buttons=Gtk.ButtonsType.CLOSE
+            parent=self.builder.get_object('player_box'), buttons=Gtk.ButtonsType.CLOSE
         )
-        
+
         self.info_area = MainWindowTrackInfoPane(player.PLAYER)
         self.info_area.set_auto_update(True)
         self.info_area.set_border_width(3)
@@ -239,13 +261,15 @@ class MainWindow(GObject.GObject):
             self.window.set_visual(visual)
             self.window.connect('screen-changed', self.on_screen_changed)
             self._update_alpha()
-        
+
         self._update_dark_hint()
 
         playlist_area = self.builder.get_object('playlist_area')
         self.playlist_container = PlaylistContainer('saved_tabs', player.PLAYER)
         for notebook in self.playlist_container.notebooks:
-            notebook.connect_after('switch-page', self.on_playlist_container_switch_page)
+            notebook.connect_after(
+                'switch-page', self.on_playlist_container_switch_page
+            )
             page = notebook.get_current_tab()
             if page is not None:
                 selection = page.view.get_selection()
@@ -259,15 +283,19 @@ class MainWindow(GObject.GObject):
         # Just in case that's not always the case, we provide a hidden option to
         # force RTL layout instead. This can be removed once we're more certain
         # that the default behavior (always LTR) is correct.
-        controls_direction = Gtk.TextDirection.RTL \
-            if settings.get_option('gui/rtl_playback_controls') \
+        controls_direction = (
+            Gtk.TextDirection.RTL
+            if settings.get_option('gui/rtl_playback_controls')
             else Gtk.TextDirection.LTR
+        )
 
-        self.play_image = Gtk.Image.new_from_icon_name('media-playback-start',
-                                                       Gtk.IconSize.SMALL_TOOLBAR)
+        self.play_image = Gtk.Image.new_from_icon_name(
+            'media-playback-start', Gtk.IconSize.SMALL_TOOLBAR
+        )
         self.play_image.set_direction(controls_direction)
-        self.pause_image = Gtk.Image.new_from_icon_name('media-playback-pause',
-                                                        Gtk.IconSize.SMALL_TOOLBAR)
+        self.pause_image = Gtk.Image.new_from_icon_name(
+            'media-playback-pause', Gtk.IconSize.SMALL_TOOLBAR
+        )
         self.pause_image.set_direction(controls_direction)
 
         play_toolbar = self.builder.get_object('play_toolbar')
@@ -282,34 +310,36 @@ class MainWindow(GObject.GObject):
         # Don't expand vertically; looks awful on Adwaita.
         self.progress_bar.set_valign(Gtk.Align.CENTER)
         guiutil.gtk_widget_replace(
-            self.builder.get_object('playback_progressbar_dummy'),
-            self.progress_bar
+            self.builder.get_object('playback_progressbar_dummy'), self.progress_bar
         )
 
         self.stop_button.toggle_spat = False
         self.stop_button.add_events(Gdk.EventMask.POINTER_MOTION_MASK)
-        self.stop_button.connect('motion-notify-event',
-                                 self.on_stop_button_motion_notify_event)
-        self.stop_button.connect('leave-notify-event',
-                                 self.on_stop_button_leave_notify_event)
-        self.stop_button.connect('key-press-event',
-                                 self.on_stop_button_key_press_event)
-        self.stop_button.connect('key-release-event',
-                                 self.on_stop_button_key_release_event)
-        self.stop_button.connect('focus-out-event',
-                                 self.on_stop_button_focus_out_event)
-        self.stop_button.connect('button-press-event',
-                                 self.on_stop_button_press_event)
-        self.stop_button.connect('button-release-event',
-                                 self.on_stop_button_release_event)
-        self.stop_button.drag_dest_set(Gtk.DestDefaults.ALL,
-                                       [Gtk.TargetEntry.new("exaile-index-list", Gtk.TargetFlags.SAME_APP, 0)], Gdk.DragAction.COPY)
-        self.stop_button.connect('drag-motion',
-                                 self.on_stop_button_drag_motion)
-        self.stop_button.connect('drag-leave',
-                                 self.on_stop_button_drag_leave)
-        self.stop_button.connect('drag-data-received',
-                                 self.on_stop_button_drag_data_received)
+        self.stop_button.connect(
+            'motion-notify-event', self.on_stop_button_motion_notify_event
+        )
+        self.stop_button.connect(
+            'leave-notify-event', self.on_stop_button_leave_notify_event
+        )
+        self.stop_button.connect('key-press-event', self.on_stop_button_key_press_event)
+        self.stop_button.connect(
+            'key-release-event', self.on_stop_button_key_release_event
+        )
+        self.stop_button.connect('focus-out-event', self.on_stop_button_focus_out_event)
+        self.stop_button.connect('button-press-event', self.on_stop_button_press_event)
+        self.stop_button.connect(
+            'button-release-event', self.on_stop_button_release_event
+        )
+        self.stop_button.drag_dest_set(
+            Gtk.DestDefaults.ALL,
+            [Gtk.TargetEntry.new("exaile-index-list", Gtk.TargetFlags.SAME_APP, 0)],
+            Gdk.DragAction.COPY,
+        )
+        self.stop_button.connect('drag-motion', self.on_stop_button_drag_motion)
+        self.stop_button.connect('drag-leave', self.on_stop_button_drag_leave)
+        self.stop_button.connect(
+            'drag-data-received', self.on_stop_button_drag_data_received
+        )
 
         self.statusbar = info.Statusbar(self.builder.get_object('status_bar'))
         event.add_ui_callback(self.on_exaile_loaded, 'exaile_loaded')
@@ -318,42 +348,43 @@ class MainWindow(GObject.GObject):
         """
             Connects the various events to their handlers
         """
-        self.builder.connect_signals({
-            'on_configure_event': self.configure_event,
-            'on_window_state_event': self.window_state_change_event,
-            'on_delete_event': self.on_delete_event,
-            'on_playpause_button_clicked': self._on_playpause_button,
-            'on_next_button_clicked':
-                lambda *e: player.QUEUE.next(),
-            'on_prev_button_clicked':
-                lambda *e: player.QUEUE.prev(),
-            'on_about_item_activate': self.on_about_item_activate,
-            # Controller
-            #            'on_scan_collection_item_activate': self.controller.on_rescan_collection,
-            #            'on_device_manager_item_activate': lambda *e: self.controller.show_devices(),
-            #            'on_track_properties_activate':self.controller.on_track_properties,
-        })
+        self.builder.connect_signals(
+            {
+                'on_configure_event': self.configure_event,
+                'on_window_state_event': self.window_state_change_event,
+                'on_delete_event': self.on_delete_event,
+                'on_playpause_button_clicked': self._on_playpause_button,
+                'on_next_button_clicked': lambda *e: player.QUEUE.next(),
+                'on_prev_button_clicked': lambda *e: player.QUEUE.prev(),
+                'on_about_item_activate': self.on_about_item_activate,
+                # Controller
+                #            'on_scan_collection_item_activate': self.controller.on_rescan_collection,
+                #            'on_device_manager_item_activate': lambda *e: self.controller.show_devices(),
+                #            'on_track_properties_activate':self.controller.on_track_properties,
+            }
+        )
 
-        event.add_ui_callback(self.on_playback_resume, 'playback_player_resume',
-                              player.PLAYER)
-        event.add_ui_callback(self.on_playback_end, 'playback_player_end',
-                              player.PLAYER)
-        event.add_ui_callback(self.on_playback_end, 'playback_error',
-                              player.PLAYER)
-        event.add_ui_callback(self.on_playback_start, 'playback_track_start',
-                              player.PLAYER)
-        event.add_ui_callback(self.on_toggle_pause, 'playback_toggle_pause',
-                              player.PLAYER)
+        event.add_ui_callback(
+            self.on_playback_resume, 'playback_player_resume', player.PLAYER
+        )
+        event.add_ui_callback(
+            self.on_playback_end, 'playback_player_end', player.PLAYER
+        )
+        event.add_ui_callback(self.on_playback_end, 'playback_error', player.PLAYER)
+        event.add_ui_callback(
+            self.on_playback_start, 'playback_track_start', player.PLAYER
+        )
+        event.add_ui_callback(
+            self.on_toggle_pause, 'playback_toggle_pause', player.PLAYER
+        )
         event.add_ui_callback(self.on_track_tags_changed, 'track_tags_changed')
-        event.add_ui_callback(self.on_buffering, 'playback_buffering',
-                              player.PLAYER)
-        event.add_ui_callback(self.on_playback_error, 'playback_error',
-                              player.PLAYER)
+        event.add_ui_callback(self.on_buffering, 'playback_buffering', player.PLAYER)
+        event.add_ui_callback(self.on_playback_error, 'playback_error', player.PLAYER)
 
-        event.add_ui_callback(self.on_playlist_tracks_added,
-                              'playlist_tracks_added')
-        event.add_ui_callback(self.on_playlist_tracks_removed,
-                              'playlist_tracks_removed')
+        event.add_ui_callback(self.on_playlist_tracks_added, 'playlist_tracks_added')
+        event.add_ui_callback(
+            self.on_playlist_tracks_removed, 'playlist_tracks_removed'
+        )
 
         # Settings
         self._on_option_set('gui_option_set', settings, 'gui/show_info_area')
@@ -366,8 +397,12 @@ class MainWindow(GObject.GObject):
         """
 
         # When there's nothing in the notebook, hide it
-        self.controller.panel_notebook.connect('page-added', self.on_panel_notebook_add_page)
-        self.controller.panel_notebook.connect('page-removed', self.on_panel_notebook_remove_page)
+        self.controller.panel_notebook.connect(
+            'page-added', self.on_panel_notebook_add_page
+        )
+        self.controller.panel_notebook.connect(
+            'page-removed', self.on_panel_notebook_remove_page
+        )
 
         # panels
         panels = self.controller.panel_notebook.panels
@@ -379,12 +414,24 @@ class MainWindow(GObject.GObject):
             if panel_name in ('files', 'collection'):
                 do_sort = True
 
-            panel.connect('append-items', lambda panel, items, force_play:
-                          self.on_append_items(items, force_play, sort=do_sort))
-            panel.connect('queue-items', lambda panel, items:
-                          self.on_append_items(items, queue=True, sort=do_sort))
-            panel.connect('replace-items', lambda panel, items:
-                          self.on_append_items(items, replace=True, sort=do_sort))
+            panel.connect(
+                'append-items',
+                lambda panel, items, force_play: self.on_append_items(
+                    items, force_play, sort=do_sort
+                ),
+            )
+            panel.connect(
+                'queue-items',
+                lambda panel, items: self.on_append_items(
+                    items, queue=True, sort=do_sort
+                ),
+            )
+            panel.connect(
+                'replace-items',
+                lambda panel, items: self.on_append_items(
+                    items, replace=True, sort=do_sort
+                ),
+            )
 
         ## Collection Panel
         panel = panels['collection'].panel
@@ -392,35 +439,41 @@ class MainWindow(GObject.GObject):
 
         ## Playlist Panel
         panel = panels['playlists'].panel
-        panel.connect('playlist-selected',
-                      lambda panel, playlist:
-                      self.playlist_container.create_tab_from_playlist(playlist))
+        panel.connect(
+            'playlist-selected',
+            lambda panel, playlist: self.playlist_container.create_tab_from_playlist(
+                playlist
+            ),
+        )
 
         ## Radio Panel
         panel = panels['radio'].panel
-        panel.connect('playlist-selected',
-                      lambda panel, playlist:
-                      self.playlist_container.create_tab_from_playlist(playlist))
+        panel.connect(
+            'playlist-selected',
+            lambda panel, playlist: self.playlist_container.create_tab_from_playlist(
+                playlist
+            ),
+        )
 
         ## Files Panel
-        #panel = panels['files']
+        # panel = panels['files']
 
     def _update_alpha(self):
         if not settings.get_option('gui/use_alpha', False):
             return
         opac = 1.0 - float(settings.get_option('gui/transparency', 0.3))
         Gtk.Widget.set_opacity(self.window, opac)
-    
+
     def _update_dark_hint(self):
         gs = Gtk.Settings.get_default()
-        
+
         # We should use reset_property, but that's only available in > 3.20...
         if not hasattr(self, '_default_dark_hint'):
             self._default_dark_hint = gs.props.gtk_application_prefer_dark_theme
-        
+
         if settings.get_option('gui/gtk_dark_hint', False):
             gs.props.gtk_application_prefer_dark_theme = True
-            
+
         elif gs.props.gtk_application_prefer_dark_theme != self._default_dark_hint:
             # don't set it explicitly otherwise the app will revert to a light
             # theme -- what we actually want is to leave it up to the OS
@@ -452,8 +505,9 @@ class MainWindow(GObject.GObject):
     def on_panel_notebook_add_page(self, notebook, page, page_num):
         if self.splitter.get_child1() is None:
             self.splitter.pack1(self.controller.panel_notebook)
-            self.controller.panel_notebook.get_parent()    \
-                .child_set_property(self.controller.panel_notebook, 'shrink', False)
+            self.controller.panel_notebook.get_parent().child_set_property(
+                self.controller.panel_notebook, 'shrink', False
+            )
 
     def on_panel_notebook_remove_page(self, notebook, page, page_num):
         if notebook.get_n_pages() == 0:
@@ -465,29 +519,32 @@ class MainWindow(GObject.GObject):
         """
         widget.__hovered = True
         if event.get_state() & Gdk.ModifierType.SHIFT_MASK:
-            widget.set_image(Gtk.Image.new_from_icon_name(
-                'process-stop', Gtk.IconSize.BUTTON))
+            widget.set_image(
+                Gtk.Image.new_from_icon_name('process-stop', Gtk.IconSize.BUTTON)
+            )
         else:
-            widget.set_image(Gtk.Image.new_from_icon_name(
-                'media-playback-stop', Gtk.IconSize.BUTTON))
+            widget.set_image(
+                Gtk.Image.new_from_icon_name('media-playback-stop', Gtk.IconSize.BUTTON)
+            )
 
     def on_stop_button_leave_notify_event(self, widget, event):
         """
             Unsets the hover state and resets the button icon
         """
         widget.__hovered = False
-        if not widget.is_focus() and \
-           ~(event.get_state() & Gdk.ModifierType.SHIFT_MASK):
-            widget.set_image(Gtk.Image.new_from_icon_name(
-                'media-playback-stop', Gtk.IconSize.BUTTON))
+        if not widget.is_focus() and ~(event.get_state() & Gdk.ModifierType.SHIFT_MASK):
+            widget.set_image(
+                Gtk.Image.new_from_icon_name('media-playback-stop', Gtk.IconSize.BUTTON)
+            )
 
     def on_stop_button_key_press_event(self, widget, event):
         """
             Shows SPAT icon on Shift key press
         """
         if event.keyval in (Gdk.KEY_Shift_L, Gdk.KEY_Shift_R):
-            widget.set_image(Gtk.Image.new_from_icon_name(
-                'process-stop', Gtk.IconSize.BUTTON))
+            widget.set_image(
+                Gtk.Image.new_from_icon_name('process-stop', Gtk.IconSize.BUTTON)
+            )
             widget.toggle_spat = True
 
         if event.keyval in (Gdk.KEY_space, Gdk.KEY_Return):
@@ -501,8 +558,9 @@ class MainWindow(GObject.GObject):
             Resets the button icon
         """
         if event.keyval in (Gdk.KEY_Shift_L, Gdk.KEY_Shift_R):
-            widget.set_image(Gtk.Image.new_from_icon_name(
-                'media-playback-stop', Gtk.IconSize.BUTTON))
+            widget.set_image(
+                Gtk.Image.new_from_icon_name('media-playback-stop', Gtk.IconSize.BUTTON)
+            )
             widget.toggle_spat = False
 
     def on_stop_button_focus_out_event(self, widget, event):
@@ -511,8 +569,9 @@ class MainWindow(GObject.GObject):
             the button is still hovered
         """
         if not getattr(widget, '__hovered', False):
-            widget.set_image(Gtk.Image.new_from_icon_name(
-                'media-playback-stop', Gtk.IconSize.BUTTON))
+            widget.set_image(
+                Gtk.Image.new_from_icon_name('media-playback-stop', Gtk.IconSize.BUTTON)
+            )
 
     def on_stop_button_press_event(self, widget, event):
         """
@@ -524,8 +583,11 @@ class MainWindow(GObject.GObject):
         elif event.triggers_context_menu():
             m = menu.Menu(self)
             m.attach_to_widget(widget)
-            m.add_simple(_("Toggle: Stop after Selected Track"),
-                         self.on_spat_clicked, 'process-stop')
+            m.add_simple(
+                _("Toggle: Stop after Selected Track"),
+                self.on_spat_clicked,
+                'process-stop',
+            )
             m.popup(event)
 
     def on_stop_button_release_event(self, widget, event):
@@ -542,24 +604,30 @@ class MainWindow(GObject.GObject):
         """
         target = widget.drag_dest_find_target(context, None).name()
         if target == 'exaile-index-list':
-            widget.set_image(Gtk.Image.new_from_icon_name(
-                'process-stop', Gtk.IconSize.BUTTON))
+            widget.set_image(
+                Gtk.Image.new_from_icon_name('process-stop', Gtk.IconSize.BUTTON)
+            )
 
     def on_stop_button_drag_leave(self, widget, context, time):
         """
             Resets the stop button
         """
-        widget.set_image(Gtk.Image.new_from_icon_name(
-            'media-playback-stop', Gtk.IconSize.BUTTON))
+        widget.set_image(
+            Gtk.Image.new_from_icon_name('media-playback-stop', Gtk.IconSize.BUTTON)
+        )
 
-    def on_stop_button_drag_data_received(self, widget, context, x, y, selection, info, time):
+    def on_stop_button_drag_data_received(
+        self, widget, context, x, y, selection, info, time
+    ):
         """
             Allows for triggering the SPAT feature
             by dropping tracks on the stop button
         """
         source_widget = Gtk.drag_get_source_widget(context)
 
-        if selection.target.name() == 'exaile-index-list' and isinstance(source_widget, PlaylistView):
+        if selection.target.name() == 'exaile-index-list' and isinstance(
+            source_widget, PlaylistView
+        ):
             position = int(selection.data.split(',')[0])
 
             if position == source_widget.playlist.spat_position:
@@ -584,7 +652,9 @@ class MainWindow(GObject.GObject):
 
         self.get_selected_page().view.queue_draw()
 
-    def on_append_items(self, tracks, force_play=False, queue=False, sort=False, replace=False):
+    def on_append_items(
+        self, tracks, force_play=False, queue=False, sort=False, replace=False
+    ):
         """
             Called when a panel (or other component)
             has tracks to append and possibly queue
@@ -617,8 +687,10 @@ class MainWindow(GObject.GObject):
             if player.QUEUE is not page.playlist:
                 player.QUEUE.extend(tracks)
 
-        elif (force_play or settings.get_option('playlist/append_menu_starts_playback', False)) and \
-                not player.PLAYER.current:
+        elif (
+            force_play
+            or settings.get_option('playlist/append_menu_starts_playback', False)
+        ) and not player.PLAYER.current:
             page.view.play_track_at(offset, tracks[0])
 
     def on_playback_error(self, type, player, message):
@@ -743,6 +815,7 @@ class MainWindow(GObject.GObject):
         """
             Shows a dialog to open media
         """
+
         def on_uris_selected(dialog, uris):
             uris.reverse()
 
@@ -760,6 +833,7 @@ class MainWindow(GObject.GObject):
         """
             Shows a dialog to open an URI
         """
+
         def on_uri_selected(dialog, uri):
             self.controller.open_uri(uri, play=False)
 
@@ -771,6 +845,7 @@ class MainWindow(GObject.GObject):
         """
             Shows a dialog to open directories
         """
+
         def on_uris_selected(dialog, uris):
             uris.reverse()
 
@@ -814,8 +889,9 @@ class MainWindow(GObject.GObject):
         """
             Shows or hides the playlist utilities bar
         """
-        settings.set_option('gui/playlist_utilities_bar_visible',
-                            checkmenuitem.get_active())
+        settings.set_option(
+            'gui/playlist_utilities_bar_visible', checkmenuitem.get_active()
+        )
 
     def on_show_playing_track_item_activate(self, menuitem):
         """
@@ -862,7 +938,8 @@ class MainWindow(GObject.GObject):
         """
         if option == 'gui/main_window_title_format':
             self.title_formatter.props.format = settings.get_option(
-                option, self.title_formatter.props.format)
+                option, self.title_formatter.props.format
+            )
 
         elif option == 'gui/use_tray':
             usetray = settings.get_option(option, False)
@@ -891,12 +968,14 @@ class MainWindow(GObject.GObject):
 
         elif option == 'gui/transparency':
             self._update_alpha()
-        
+
         elif option == 'gui/gtk_dark_hint':
             self._update_dark_hint()
 
     def _on_volume_key(self, is_up):
-        diff = int(100 * settings.get_option('gui/volue_key_step_size', VOLUME_STEP_DEFAULT))
+        diff = int(
+            100 * settings.get_option('gui/volue_key_step_size', VOLUME_STEP_DEFAULT)
+        )
         if not is_up:
             diff = -diff
 
@@ -989,8 +1068,9 @@ class MainWindow(GObject.GObject):
         if sash_pos > 10:
             settings.set_option('gui/mainw_sash_pos', sash_pos)
 
-        if settings.get_option('gui/use_tray', False) and \
-           settings.get_option('gui/close_to_tray', False):
+        if settings.get_option('gui/use_tray', False) and settings.get_option(
+            'gui/close_to_tray', False
+        ):
             self.window.hide()
         else:
             self.quit()
@@ -1018,8 +1098,12 @@ class MainWindow(GObject.GObject):
         toggle_handled = self.emit('main-visible-toggle')
 
         if not toggle_handled:
-            if bringtofront and self.window.is_active() or \
-               not bringtofront and self.window.get_property('visible'):
+            if (
+                bringtofront
+                and self.window.is_active()
+                or not bringtofront
+                and self.window.get_property('visible')
+            ):
                 self.window.hide()
             else:
                 # the ordering for deiconify/show matters -- if this gets
@@ -1032,18 +1116,19 @@ class MainWindow(GObject.GObject):
             Called when the window is resized or moved
         """
         # Don't save window size if it is maximized or fullscreen.
-        if settings.get_option('gui/mainw_maximized', False) or \
-                self._fullscreen:
+        if settings.get_option('gui/mainw_maximized', False) or self._fullscreen:
             return False
 
         (width, height) = self.window.get_size()
-        if [width, height] != [settings.get_option("gui/mainw_" + key, -1) for
-                               key in ["width", "height"]]:
+        if [width, height] != [
+            settings.get_option("gui/mainw_" + key, -1) for key in ["width", "height"]
+        ]:
             settings.set_option('gui/mainw_height', height, save=False)
             settings.set_option('gui/mainw_width', width, save=False)
         (x, y) = self.window.get_position()
-        if [x, y] != [settings.get_option("gui/mainw_" + key, -1) for
-                      key in ["x", "y"]]:
+        if [x, y] != [
+            settings.get_option("gui/mainw_" + key, -1) for key in ["x", "y"]
+        ]:
             settings.set_option('gui/mainw_x', x, save=False)
             settings.set_option('gui/mainw_y', y, save=False)
 
@@ -1055,8 +1140,10 @@ class MainWindow(GObject.GObject):
             states and minimizes to tray if requested
         """
         if event.changed_mask & Gdk.WindowState.MAXIMIZED:
-            settings.set_option('gui/mainw_maximized',
-                                bool(event.new_window_state & Gdk.WindowState.MAXIMIZED))
+            settings.set_option(
+                'gui/mainw_maximized',
+                bool(event.new_window_state & Gdk.WindowState.MAXIMIZED),
+            )
         if event.changed_mask & Gdk.WindowState.FULLSCREEN:
             self._fullscreen = bool(event.new_window_state & Gdk.WindowState.FULLSCREEN)
             self.notify('is-fullscreen')
@@ -1066,15 +1153,19 @@ class MainWindow(GObject.GObject):
 
         if not self.minimized:
 
-            if event.changed_mask & Gdk.WindowState.ICONIFIED and \
-                    not event.changed_mask & Gdk.WindowState.WITHDRAWN and \
-                    event.new_window_state & Gdk.WindowState.ICONIFIED and \
-                    not event.new_window_state & Gdk.WindowState.WITHDRAWN and \
-                    not self.window_state & Gdk.WindowState.ICONIFIED:
+            if (
+                event.changed_mask & Gdk.WindowState.ICONIFIED
+                and not event.changed_mask & Gdk.WindowState.WITHDRAWN
+                and event.new_window_state & Gdk.WindowState.ICONIFIED
+                and not event.new_window_state & Gdk.WindowState.WITHDRAWN
+                and not self.window_state & Gdk.WindowState.ICONIFIED
+            ):
                 self.minimized = True
         else:
-            if event.changed_mask & Gdk.WindowState.WITHDRAWN and \
-                    not event.new_window_state & (Gdk.WindowState.WITHDRAWN):  # and \
+            if (
+                event.changed_mask & Gdk.WindowState.WITHDRAWN
+                and not event.new_window_state & (Gdk.WindowState.WITHDRAWN)
+            ):  # and \
                 self.minimized = False
 
         # track this
@@ -1094,13 +1185,17 @@ class MainWindow(GObject.GObject):
             #    destroy tray
 
             if self.minimized != prev_minimized and self.minimized is True:
-                if not settings.get_option('gui/use_tray', False) and \
-                        self.controller.tray_icon is None:
+                if (
+                    not settings.get_option('gui/use_tray', False)
+                    and self.controller.tray_icon is None
+                ):
                     self.controller.tray_icon = tray.TrayIcon(self)
 
                 window.hide()
-            elif not settings.get_option('gui/use_tray', False) and \
-                    self.controller.tray_icon is not None:
+            elif (
+                not settings.get_option('gui/use_tray', False)
+                and self.controller.tray_icon is not None
+            ):
                 self.controller.tray_icon.destroy()
                 self.controller.tray_icon = None
 
@@ -1145,8 +1240,9 @@ class MainWindowTrackInfoPane(info.TrackInfoPane, providers.ProviderHandler):
         self.__widget_area_widgets = {}
 
         # call this last if we're using simple_init=True
-        providers.ProviderHandler.__init__(self, 'mainwindow-info-area-widget',
-                                           target=player, simple_init=True)
+        providers.ProviderHandler.__init__(
+            self, 'mainwindow-info-area-widget', target=player, simple_init=True
+        )
 
     def get_player(self):
         '''
@@ -1194,5 +1290,6 @@ def get_selected_playlist():
 
 def mainwindow():
     return MainWindow._mainwindow
+
 
 # vim: et sts=4 sw=4

--- a/xlgui/menu.py
+++ b/xlgui/menu.py
@@ -38,12 +38,15 @@ from xlgui.widgets import menu, dialogs
 
 def get_main():
     from xlgui import main
+
     return main.mainwindow()
 
 
 def get_selected_playlist():
     from xlgui import main
+
     return main.get_selected_playlist()
+
 
 _smi = menu.simple_menu_item
 _sep = menu.simple_separator
@@ -57,45 +60,74 @@ def __create_file_menu():
         get_main().playlist_container.create_new_playlist()
 
     accelerators.append(Accelerator('<Primary>t', _("_New Playlist"), new_playlist_cb))
-    items.append(_smi('new-playlist', [], icon_name='tab-new',
-                      callback=accelerators[-1]))
+    items.append(
+        _smi('new-playlist', [], icon_name='tab-new', callback=accelerators[-1])
+    )
     items.append(_sep('new-sep', [items[-1].name]))
 
     def open_cb(*args):
         dialog = dialogs.MediaOpenDialog(get_main().window)
-        dialog.connect('uris-selected', lambda d, uris:
-                       get_main().controller.open_uris(uris))
+        dialog.connect(
+            'uris-selected', lambda d, uris: get_main().controller.open_uris(uris)
+        )
         dialog.show()
-        
+
     accelerators.append(Accelerator('<Primary>o', _("_Open"), open_cb))
-    items.append(_smi('open', [items[-1].name], icon_name='document-open',
-                      callback=accelerators[-1]))
+    items.append(
+        _smi(
+            'open',
+            [items[-1].name],
+            icon_name='document-open',
+            callback=accelerators[-1],
+        )
+    )
 
     def open_uri_cb(*args):
         dialog = dialogs.URIOpenDialog(get_main().window)
-        dialog.connect('uri-selected', lambda d, uri:
-                       get_main().controller.open_uri(uri))
+        dialog.connect(
+            'uri-selected', lambda d, uri: get_main().controller.open_uri(uri)
+        )
         dialog.show()
 
     accelerators.append(Accelerator('<Primary><Shift>o', _("Open _URL"), open_uri_cb))
-    items.append(_smi('open-uri', [items[-1].name], icon_name='emblem-web',
-                      callback=accelerators[-1]))
+    items.append(
+        _smi(
+            'open-uri',
+            [items[-1].name],
+            icon_name='emblem-web',
+            callback=accelerators[-1],
+        )
+    )
 
     def open_dirs_cb(*args):
         dialog = dialogs.DirectoryOpenDialog(get_main().window)
         dialog.props.create_folders = False
-        dialog.connect('uris-selected', lambda d, uris:
-                       get_main().controller.open_uris(uris))
+        dialog.connect(
+            'uris-selected', lambda d, uris: get_main().controller.open_uris(uris)
+        )
         dialog.show()
-    items.append(_smi('open-dirs', [items[-1].name], _("Open _Directories"),
-                      'folder-open', open_dirs_cb))
+
+    items.append(
+        _smi(
+            'open-dirs',
+            [items[-1].name],
+            _("Open _Directories"),
+            'folder-open',
+            open_dirs_cb,
+        )
+    )
 
     items.append(_sep('open-sep', [items[-1].name]))
 
-    items.append(_smi('import-playlist', [items[-1].name],
-                      _("_Import Playlist"), 'document-open',
-                      lambda *e: get_main().controller.get_panel('playlists').import_playlist()
-                      ))
+    items.append(
+        _smi(
+            'import-playlist',
+            [items[-1].name],
+            _("_Import Playlist"),
+            'document-open',
+            lambda *e: get_main().controller.get_panel('playlists').import_playlist(),
+        )
+    )
 
     def export_playlist_cb(*args):
         main = get_main()
@@ -112,36 +144,61 @@ def __create_file_menu():
             elif message_type == Gtk.MessageType.ERROR:
                 main.message.show_error(_('Playlist export failed!'), message)
             return True
+
         dialog = dialogs.PlaylistExportDialog(page.playlist, main.window)
         dialog.connect('message', on_message)
         dialog.show()
-    items.append(_smi('export-playlist', [items[-1].name],
-                      _("E_xport Current Playlist"), 'document-save-as', export_playlist_cb))
+
+    items.append(
+        _smi(
+            'export-playlist',
+            [items[-1].name],
+            _("E_xport Current Playlist"),
+            'document-save-as',
+            export_playlist_cb,
+        )
+    )
     items.append(_sep('export-sep', [items[-1].name]))
 
     def close_tab_cb(*args):
         get_main().get_selected_page().tab.close()
 
     accelerators.append(Accelerator('<Primary>w', _("Close _Tab"), close_tab_cb))
-    items.append(_smi('close-tab', [items[-1].name], icon_name='window-close',
-                      callback=accelerators[-1]))
+    items.append(
+        _smi(
+            'close-tab',
+            [items[-1].name],
+            icon_name='window-close',
+            callback=accelerators[-1],
+        )
+    )
 
     if get_main().controller.exaile.options.Debug:
+
         def restart_cb(*args):
             from xl import main
+
             main.exaile().quit(True)
-        
+
         accelerators.append(Accelerator('<Primary>r', _("_Restart"), restart_cb))
-        items.append(_smi('restart-application', [items[-1].name],
-                          callback=accelerators[-1]))
+        items.append(
+            _smi('restart-application', [items[-1].name], callback=accelerators[-1])
+        )
 
     def quit_cb(*args):
         from xl import main
+
         main.exaile().quit()
-    
+
     accelerators.append(Accelerator('<Primary>q', _("_Quit Exaile"), quit_cb))
-    items.append(_smi('quit-application', [items[-1].name], icon_name='application-exit',
-                      callback=accelerators[-1]))
+    items.append(
+        _smi(
+            'quit-application',
+            [items[-1].name],
+            icon_name='application-exit',
+            callback=accelerators[-1],
+        )
+    )
 
     for item in items:
         providers.register('menubar-file-menu', item)
@@ -155,28 +212,49 @@ def __create_edit_menu():
 
     def collection_manager_cb(*args):
         from xlgui import get_controller
+
         get_controller().collection_manager()
-    items.append(_smi('collection-manager', [], _("_Collection"), None, collection_manager_cb))
+
+    items.append(
+        _smi('collection-manager', [], _("_Collection"), None, collection_manager_cb)
+    )
 
     def queue_cb(*args):
         get_main().playlist_container.show_queue()
 
     accelerators.append(Accelerator('<Primary>m', _("_Queue"), queue_cb))
-    items.append(_smi('queue', [items[-1].name],
-                      callback=accelerators[-1]))
+    items.append(_smi('queue', [items[-1].name], callback=accelerators[-1]))
 
     def cover_manager_cb(*args):
         from xlgui.cover import CoverManager
+
         CoverManager(get_main().window, get_main().collection)
-    items.append(_smi('cover-manager', [items[-1].name], _("C_overs"),
-                      'image-x-generic', cover_manager_cb))
+
+    items.append(
+        _smi(
+            'cover-manager',
+            [items[-1].name],
+            _("C_overs"),
+            'image-x-generic',
+            cover_manager_cb,
+        )
+    )
 
     def preferences_cb(*args):
         from xlgui.preferences import PreferencesDialog
+
         dialog = PreferencesDialog(get_main().window, get_main().controller)
         dialog.run()
-    items.append(_smi('preferences', [items[-1].name], _("_Preferences"),
-                      'preferences-system', preferences_cb))
+
+    items.append(
+        _smi(
+            'preferences',
+            [items[-1].name],
+            _("_Preferences"),
+            'preferences-system',
+            preferences_cb,
+        )
+    )
 
     for item in items:
         providers.register('menubar-edit-menu', item)
@@ -190,38 +268,68 @@ def __create_view_menu():
 
     def show_playing_track_cb(*args):
         get_main().playlist_container.show_current_track()
-        
+
     def show_playing_track_sensitive():
         from xl import player
+
         return player.PLAYER.get_state() != 'stopped'
-    
-    accelerators.append(Accelerator('<Primary>j', _("_Show Playing Track"), show_playing_track_cb))
-    items.append(_smi('show-playing-track', [], icon_name='go-jump',
-                      callback=accelerators[-1],
-                      sensitive_cb=show_playing_track_sensitive))
+
+    accelerators.append(
+        Accelerator('<Primary>j', _("_Show Playing Track"), show_playing_track_cb)
+    )
+    items.append(
+        _smi(
+            'show-playing-track',
+            [],
+            icon_name='go-jump',
+            callback=accelerators[-1],
+            sensitive_cb=show_playing_track_sensitive,
+        )
+    )
 
     items.append(_sep('show-playing-track-sep', [items[-1].name]))
 
     def playlist_utilities_cb(widget, name, parent, context):
-        settings.set_option('gui/playlist_utilities_bar_visible',
-                            widget.get_active())
+        settings.set_option('gui/playlist_utilities_bar_visible', widget.get_active())
 
     def playlist_utilities_is_checked(name, parent, context):
         return settings.get_option('gui/playlist_utilities_bar_visible', True)
-    items.append(menu.check_menu_item('playlist-utilities', [items[-1].name],
-                                      _("_Playlist Utilities Bar"), playlist_utilities_is_checked, playlist_utilities_cb))
 
-    items.append(_smi('columns', [items[-1].name], _('C_olumns'),
-                      submenu=menu.ProviderMenu('playlist-columns-menu', get_main())))
+    items.append(
+        menu.check_menu_item(
+            'playlist-utilities',
+            [items[-1].name],
+            _("_Playlist Utilities Bar"),
+            playlist_utilities_is_checked,
+            playlist_utilities_cb,
+        )
+    )
+
+    items.append(
+        _smi(
+            'columns',
+            [items[-1].name],
+            _('C_olumns'),
+            submenu=menu.ProviderMenu('playlist-columns-menu', get_main()),
+        )
+    )
 
     def clear_playlist_cb(*args):
         page = get_main().get_selected_page()
         if page:
             page.playlist.clear()
 
-    accelerators.append(Accelerator('<Primary>l', _('_Clear playlist'), clear_playlist_cb))
-    items.append(_smi('clear-playlist', [items[-1].name], icon_name='edit-clear-all',
-                      callback=accelerators[-1]))
+    accelerators.append(
+        Accelerator('<Primary>l', _('_Clear playlist'), clear_playlist_cb)
+    )
+    items.append(
+        _smi(
+            'clear-playlist',
+            [items[-1].name],
+            icon_name='edit-clear-all',
+            callback=accelerators[-1],
+        )
+    )
 
     for item in items:
         providers.register('menubar-view-menu', item)
@@ -237,14 +345,35 @@ def __create_playlist_menu():
 
 def __create_tools_menu():
     items = []
-    items.append(_smi('device-manager', [], _('_Device Manager'),
-                      'multimedia-player', lambda *x: get_main().controller.show_devices()))
+    items.append(
+        _smi(
+            'device-manager',
+            [],
+            _('_Device Manager'),
+            'multimedia-player',
+            lambda *x: get_main().controller.show_devices(),
+        )
+    )
 
-    items.append(_smi('scan-collection', [items[-1].name], _('_Rescan Collection'),
-                      'view-refresh', get_main().controller.on_rescan_collection))
+    items.append(
+        _smi(
+            'scan-collection',
+            [items[-1].name],
+            _('_Rescan Collection'),
+            'view-refresh',
+            get_main().controller.on_rescan_collection,
+        )
+    )
 
-    items.append(_smi('slow-scan-collection', [items[-1].name], _('Rescan Collection (_slow)'),
-                      'view-refresh', get_main().controller.on_rescan_collection_forced))
+    items.append(
+        _smi(
+            'slow-scan-collection',
+            [items[-1].name],
+            _('Rescan Collection (_slow)'),
+            'view-refresh',
+            get_main().controller.on_rescan_collection_forced,
+        )
+    )
 
     for item in items:
         providers.register('menubar-tools-menu', item)
@@ -272,18 +401,29 @@ def __create_help_menu():
         dialog = dialogs.AboutDialog(parent.window)
         dialog.show()
 
-    items.append(_smi('guide', [], _("User's Guide (website)"), 'help-contents',
-                      show_user_guide))
-    items.append(_smi('shortcuts', [items[-1].name], _("Shortcuts"), None,
-                      show_shortcuts))
+    items.append(
+        _smi('guide', [], _("User's Guide (website)"), 'help-contents', show_user_guide)
+    )
+    items.append(
+        _smi('shortcuts', [items[-1].name], _("Shortcuts"), None, show_shortcuts)
+    )
     items.append(_sep('about-sep1', [items[-1].name]))
-    items.append(_smi('report', [items[-1].name], _("Report an issue (GitHub)"), None,
-                      show_report_issue))
-    items.append(_smi('logs', [items[-1].name], _("Open error logs"), None,
-                      show_logs_directory))
+    items.append(
+        _smi(
+            'report',
+            [items[-1].name],
+            _("Report an issue (GitHub)"),
+            None,
+            show_report_issue,
+        )
+    )
+    items.append(
+        _smi('logs', [items[-1].name], _("Open error logs"), None, show_logs_directory)
+    )
     items.append(_sep('about-sep2', [items[-1].name]))
-    items.append(_smi('about', [items[-1].name], _("_About"), 'help-about',
-                      show_about_dialog))
+    items.append(
+        _smi('about', [items[-1].name], _("_About"), 'help-about', show_about_dialog)
+    )
     for item in items:
         providers.register('menubar-help-menu', item)
     for accelerator in accelerators:

--- a/xlgui/panel/__init__.py
+++ b/xlgui/panel/__init__.py
@@ -44,6 +44,7 @@ class Panel(GObject.GObject):
         This class is abstract and should be subclassed.  All subclasses
         should define a 'ui_info' and 'name' variables.
     """
+
     ui_info = ('panel.ui', 'PanelWindow')
 
     def __init__(self, parent, name, label=None):
@@ -56,8 +57,8 @@ class Panel(GObject.GObject):
             @param label: text of the label displayed to the user
         """
         GObject.GObject.__init__(self)
-        self.name = name        # panel id
-        self.label = label      # label to be displayed
+        self.name = name  # panel id
+        self.label = label  # label to be displayed
         self.parent = parent
 
         # if the UI designer file starts with file:// use the full path minus
@@ -92,8 +93,8 @@ class Panel(GObject.GObject):
                 if not self.label:
                     self.label = widget.get_title()
                 LOGGER.info(
-                    "Old style panel %s is creating unnecessary Gtk.Window.",
-                    self.label)
+                    "Old style panel %s is creating unnecessary Gtk.Window.", self.label
+                )
                 widget.remove(child)
                 widget.destroy()
             else:

--- a/xlgui/panel/collection.py
+++ b/xlgui/panel/collection.py
@@ -128,6 +128,7 @@ class Order(object):
         return self.__formatters[level].format(track)
 
 DEFAULT_ORDERS = [
+    # fmt: off
     Order(_("Artist"),
           ("artist", "album",
            (("discnumber", "tracknumber", "title"), "$title", ("title",)))),
@@ -150,6 +151,7 @@ DEFAULT_ORDERS = [
           ('artist',
            (('date', 'album'), "$date - $album", ('date', 'album')),
            (("discnumber", "tracknumber", "title"), "$title", ("title",)))),
+    # fmt: on
 ]
 
 

--- a/xlgui/panel/collection.py
+++ b/xlgui/panel/collection.py
@@ -33,19 +33,9 @@ import itertools
 import logging
 
 from xl.nls import gettext as _
-from xl import (
-    common,
-    event,
-    formatter,
-    settings,
-    trax
-)
+from xl import common, event, formatter, settings, trax
 import xlgui
-from xlgui import (
-    guiutil,
-    icons,
-    panel
-)
+from xlgui import guiutil, icons, panel
 from xlgui.panel import menus
 from xlgui.widgets import menu
 from xlgui.widgets.common import DragTreeView
@@ -85,8 +75,7 @@ class Order(object):
     def __init__(self, name, levels, use_compilations=True):
         self.__name = name
         self.__levels = map(self.__parse_level, levels)
-        self.__formatters = [formatter.TrackFormatter(l[1]) for l
-                             in self.__levels]
+        self.__formatters = [formatter.TrackFormatter(l[1]) for l in self.__levels]
         self.__use_compilations = use_compilations
 
     @staticmethod
@@ -127,6 +116,7 @@ class Order(object):
     def format_track(self, level, track):
         return self.__formatters[level].format(track)
 
+
 DEFAULT_ORDERS = [
     # fmt: off
     Order(_("Artist"),
@@ -159,6 +149,7 @@ class CollectionPanel(panel.Panel):
     """
         The collection panel
     """
+
     __gsignals__ = {
         'append-items': (GObject.SignalFlags.RUN_LAST, None, (object, bool)),
         'replace-items': (GObject.SignalFlags.RUN_LAST, None, (object,)),
@@ -168,8 +159,14 @@ class CollectionPanel(panel.Panel):
 
     ui_info = ('collection.ui', 'CollectionPanel')
 
-    def __init__(self, parent, collection, name=None,
-                 _show_collection_empty_message=False, label=_('Collection')):
+    def __init__(
+        self,
+        parent,
+        collection,
+        name=None,
+        _show_collection_empty_message=False,
+        label=_('Collection'),
+    ):
         """
             Initializes the collection panel
 
@@ -200,8 +197,9 @@ class CollectionPanel(panel.Panel):
         self.tracks = []
         self.sorted_tracks = []
 
-        event.add_ui_callback(self._check_collection_empty, 'libraries_modified',
-                              collection)
+        event.add_ui_callback(
+            self._check_collection_empty, 'libraries_modified', collection
+        )
 
         self.menu = menus.CollectionContextMenu(self)
 
@@ -216,7 +214,8 @@ class CollectionPanel(panel.Panel):
         self.repopulate_choices()
 
         self.filter = guiutil.SearchEntry(
-            self.builder.get_object('collection_search_entry'))
+            self.builder.get_object('collection_search_entry')
+        )
 
     def repopulate_choices(self):
         self.choice.set_model(None)
@@ -230,8 +229,7 @@ class CollectionPanel(panel.Panel):
         self.choice.set_active(active)
 
     def _check_collection_empty(self, *e):
-        if self._show_collection_empty_message and \
-                not self.collection.libraries:
+        if self._show_collection_empty_message and not self.collection.libraries:
             # should show empty panel
             if self.panel_stack.get_visible_child() == self.panel_content:
                 self.panel_stack.set_visible_child(self.panel_empty)
@@ -244,21 +242,23 @@ class CollectionPanel(panel.Panel):
         """
             Uses signal_autoconnect to connect the various events
         """
-        self.builder.connect_signals({
-            'on_collection_combo_box_changed': lambda *e: self.load_tree(),
-            'on_refresh_button_press_event': self.on_refresh_button_press_event,
-            'on_refresh_button_key_press_event':
-                self.on_refresh_button_key_press_event,
-            'on_collection_search_entry_activate':
-                self.on_collection_search_entry_activate,
-            'on_add_music_button_clicked': self.on_add_music_button_clicked
-        })
+        self.builder.connect_signals(
+            {
+                'on_collection_combo_box_changed': lambda *e: self.load_tree(),
+                'on_refresh_button_press_event': self.on_refresh_button_press_event,
+                'on_refresh_button_key_press_event': self.on_refresh_button_key_press_event,
+                'on_collection_search_entry_activate': self.on_collection_search_entry_activate,
+                'on_add_music_button_clicked': self.on_add_music_button_clicked,
+            }
+        )
         self.tree.connect('key-release-event', self.on_key_released)
         event.add_ui_callback(self.refresh_tags_in_tree, 'track_tags_changed')
-        event.add_ui_callback(self.refresh_tracks_in_tree,
-                              'tracks_added', self.collection)
-        event.add_ui_callback(self.refresh_tracks_in_tree,
-                              'tracks_removed', self.collection)
+        event.add_ui_callback(
+            self.refresh_tracks_in_tree, 'tracks_added', self.collection
+        )
+        event.add_ui_callback(
+            self.refresh_tracks_in_tree, 'tracks_removed', self.collection
+        )
 
     def on_refresh_button_press_event(self, button, event):
         """
@@ -267,9 +267,11 @@ class CollectionPanel(panel.Panel):
         if event.triggers_context_menu():
             m = menu.Menu(None)
             m.attach_to_widget(button)
-            m.add_simple(_('Rescan Collection'),
-                         xlgui.get_controller().on_rescan_collection,
-                         Gtk.STOCK_REFRESH)
+            m.add_simple(
+                _('Rescan Collection'),
+                xlgui.get_controller().on_rescan_collection,
+                Gtk.STOCK_REFRESH,
+            )
             m.popup(event)
             return
 
@@ -331,15 +333,20 @@ class CollectionPanel(panel.Panel):
             Sets up the various images that will be used in the tree
         """
         self.artist_image = icons.MANAGER.pixbuf_from_icon_name(
-            'artist', Gtk.IconSize.SMALL_TOOLBAR)
+            'artist', Gtk.IconSize.SMALL_TOOLBAR
+        )
         self.date_image = icons.MANAGER.pixbuf_from_icon_name(
-            'office-calendar', Gtk.IconSize.SMALL_TOOLBAR)
+            'office-calendar', Gtk.IconSize.SMALL_TOOLBAR
+        )
         self.album_image = icons.MANAGER.pixbuf_from_icon_name(
-            'image-x-generic', Gtk.IconSize.SMALL_TOOLBAR)
+            'image-x-generic', Gtk.IconSize.SMALL_TOOLBAR
+        )
         self.title_image = icons.MANAGER.pixbuf_from_icon_name(
-            'audio-x-generic', Gtk.IconSize.SMALL_TOOLBAR)
+            'audio-x-generic', Gtk.IconSize.SMALL_TOOLBAR
+        )
         self.genre_image = icons.MANAGER.pixbuf_from_icon_name(
-            'genre', Gtk.IconSize.SMALL_TOOLBAR)
+            'genre', Gtk.IconSize.SMALL_TOOLBAR
+        )
 
     def drag_data_received(self, *e):
         """
@@ -391,11 +398,13 @@ class CollectionPanel(panel.Panel):
 
         if settings.get_option('gui/ellipsize_text_in_panels', False):
             from gi.repository import Pango
+
             cell.set_property('ellipsize-set', True)
             cell.set_property('ellipsize', Pango.EllipsizeMode.END)
 
         self.tree.set_row_separator_func(
-            (lambda m, i, d: m.get_value(i, 1) is None), None)
+            (lambda m, i, d: m.get_value(i, 1) is None), None
+        )
 
         self.model = Gtk.TreeStore(GdkPixbuf.Pixbuf, str, object)
 
@@ -424,9 +433,9 @@ class CollectionPanel(panel.Panel):
         """
             Called when the user clicks on the tree
         """
-        #selection = self.tree.get_selection()
+        # selection = self.tree.get_selection()
         (x, y) = map(int, event.get_coords())
-        #path = self.tree.get_path_at_pos(x, y)
+        # path = self.tree.get_path_at_pos(x, y)
         if event.type == Gdk.EventType._2BUTTON_PRESS:
             replace = settings.get_option('playlist/replace_content', False)
             self.append_to_playlist(replace=replace)
@@ -459,9 +468,11 @@ class CollectionPanel(panel.Panel):
         return " ".join(queries)
 
     def refresh_tags_in_tree(self, type, track, tags):
-        if settings.get_option('gui/sync_on_tag_change', True) and \
-                bool(tags & self.order.all_sort_tags()) and \
-                self.collection.loc_is_member(track.get_loc_for_io()):
+        if (
+            settings.get_option('gui/sync_on_tag_change', True)
+            and bool(tags & self.order.all_sort_tags())
+            and self.collection.loc_is_member(track.get_loc_for_io())
+        ):
             self._refresh_tags_in_tree()
 
     def refresh_tracks_in_tree(self, type, obj, loc):
@@ -484,8 +495,9 @@ class CollectionPanel(panel.Panel):
     def resort_tracks(self):
         # import time
         # print("sorting...", time.clock())
-        self.sorted_tracks = trax.sort_tracks(self.order.get_sort_tags(0),
-                                              self.collection.get_tracks())
+        self.sorted_tracks = trax.sort_tracks(
+            self.order.get_sort_tags(0), self.collection.get_tracks()
+        )
         # print("sorted.", time.clock())
 
     def load_tree(self):
@@ -508,9 +520,7 @@ class CollectionPanel(panel.Panel):
             self.resort_tracks()
 
         # save the active view setting
-        settings.set_option(
-            'gui/collection_active_view',
-            self.choice.get_active())
+        settings.set_option('gui/collection_active_view', self.choice.get_active())
 
         keyword = self.keyword.strip()
         tags = list(SEARCH_TAGS)
@@ -518,8 +528,10 @@ class CollectionPanel(panel.Panel):
         tags = list(set(tags))  # uniquify list to speed up search
 
         self.tracks = list(
-            trax.search_tracks_from_string(self.sorted_tracks,
-                                           keyword, case_sensitive=False, keyword_tags=tags))
+            trax.search_tracks_from_string(
+                self.sorted_tracks, keyword, case_sensitive=False, keyword_tags=tags
+            )
+        )
 
         self.load_subtree(None)
 
@@ -557,8 +569,7 @@ class CollectionPanel(panel.Panel):
 
         if rest:
             item = rest.pop(0)
-            GLib.idle_add(self._expand_node_by_name, search_num,
-                          parent, item, rest)
+            GLib.idle_add(self._expand_node_by_name, search_num, parent, item, rest)
 
     def load_subtree(self, parent):
         """
@@ -571,9 +582,10 @@ class CollectionPanel(panel.Panel):
         if parent is None:
             depth = 0
         else:
-            if self.model.iter_n_children(parent) != 1 or \
-                self.model.get_value(
-                    self.model.iter_children(parent), 1) is not None:
+            if (
+                self.model.iter_n_children(parent) != 1
+                or self.model.get_value(self.model.iter_children(parent), 1) is not None
+            ):
                 previously_loaded = True
             iter_sep = self.model.iter_children(parent)
             depth = self.model.iter_depth(parent) + 1
@@ -615,13 +627,13 @@ class CollectionPanel(panel.Panel):
         for srtr in srtrs:
             stagvals = [unicode(srtr.track.get_tag_sort(x)) for x in tags]
             stagval = " ".join(stagvals)
-            if (last_val != stagval or bottom):
+            if last_val != stagval or bottom:
                 tagval = self.order.format_track(depth, srtr.track)
-                match_query = " ".join([
-                    srtr.track.get_tag_search(t, format=True) for t in tags])
+                match_query = " ".join(
+                    [srtr.track.get_tag_search(t, format=True) for t in tags]
+                )
                 if bottom:
-                    match_query += " " + \
-                        srtr.track.get_tag_search("__loc", format=True)
+                    match_query += " " + srtr.track.get_tag_search("__loc", format=True)
 
                 # Different *sort tags can cause stagval to not match
                 # but the below code will produce identical entries in
@@ -650,8 +662,7 @@ class CollectionPanel(panel.Panel):
                     first = False
 
                     last_matchq = match_query
-                    iter = self.model.append(parent,
-                                             [image, tagval, match_query])
+                    iter = self.model.append(parent, [image, tagval, match_query])
                     path = self.model.get_path(iter)
                     expanded = False
                     if not bottom:
@@ -668,7 +679,9 @@ class CollectionPanel(panel.Panel):
                         if depth > 0:
                             # for some reason, nested iters are always
                             # off by one in the terminal entry.
-                            newpath = Gtk.TreePath.new_from_indices(newpath[:-1] + [newpath[-1] - 1])
+                            newpath = Gtk.TreePath.new_from_indices(
+                                newpath[:-1] + [newpath[-1] - 1]
+                            )
                         to_expand.append(newpath)
                         expanded = True
 
@@ -679,11 +692,12 @@ class CollectionPanel(panel.Panel):
             self.model.set_value(iter, 1, val)
             count = 0
 
-        if settings.get_option("gui/expand_enabled", True) and \
-                len(to_expand) < \
-                settings.get_option("gui/expand_maximum_results", 100) and \
-                len(self.keyword.strip()) >= \
-                settings.get_option("gui/expand_minimum_term_length", 2):
+        if (
+            settings.get_option("gui/expand_enabled", True)
+            and len(to_expand) < settings.get_option("gui/expand_maximum_results", 100)
+            and len(self.keyword.strip())
+            >= settings.get_option("gui/expand_minimum_term_length", 2)
+        ):
             for row in to_expand:
                 GLib.idle_add(self.tree.expand_row, row, False)
 
@@ -762,5 +776,6 @@ class CollectionDragTreeView(DragTreeView):
         matcher = trax.TracksMatcher(search)
         for i in trax.search_tracks(self.container.tracks, [matcher]):
             yield i.track
+
 
 # vim: et sts=4 sw=4

--- a/xlgui/panel/device.py
+++ b/xlgui/panel/device.py
@@ -64,22 +64,28 @@ class DeviceTransferThread(common.ProgressThread):
         """
             Runs the thread
         """
-        event.add_ui_callback(self.on_track_transfer_progress,
-                              'track_transfer_progress', self.device.transfer)
+        event.add_ui_callback(
+            self.on_track_transfer_progress,
+            'track_transfer_progress',
+            self.device.transfer,
+        )
         try:
             self.device.start_transfer()
         finally:
-            event.remove_callback(self.on_track_transfer_progress,
-                                  'track_transfer_progress', self.device.transfer)
+            event.remove_callback(
+                self.on_track_transfer_progress,
+                'track_transfer_progress',
+                self.device.transfer,
+            )
 
 
 class ReceptiveCollectionPanel(CollectionPanel):
-
     def drag_data_received(self, widget, context, x, y, data, info, stamp):
         uris = data.get_uris()
         tracks, playlists = self.tree.get_drag_data(uris)
-        tracks = [t for t in tracks if not
-                  self.collection.loc_is_member(t.get_loc_for_io())]
+        tracks = [
+            t for t in tracks if not self.collection.loc_is_member(t.get_loc_for_io())
+        ]
 
         self.add_tracks_func(tracks)
 
@@ -100,6 +106,7 @@ class DevicePanel(panel.Panel):
     """
         generic panel for devices
     """
+
     __gsignals__ = {
         'append-items': (GObject.SignalFlags.RUN_LAST, None, (object, bool)),
         'replace-items': (GObject.SignalFlags.RUN_LAST, None, (object,)),
@@ -118,25 +125,31 @@ class DevicePanel(panel.Panel):
 
         self.notebook = self.builder.get_object("device_notebook")
 
-        self.collectionpanel = ReceptiveCollectionPanel(parent,
-                                                        collection=device.collection, name=name, label=label)
+        self.collectionpanel = ReceptiveCollectionPanel(
+            parent, collection=device.collection, name=name, label=label
+        )
         self.collectionpanel.add_tracks_func = self.add_tracks_func
 
-        self.collectionpanel.connect('append-items',
-                                     lambda *e: self.emit('append-items', *e[1:]))
-        self.collectionpanel.connect('replace-items',
-                                     lambda *e: self.emit('replace-items', *e[1:]))
-        self.collectionpanel.connect('queue-items',
-                                     lambda *e: self.emit('queue-items', *e[1:]))
-        self.collectionpanel.connect('collection-tree-loaded',
-                                     lambda *e: self.emit('collection-tree-loaded'))
+        self.collectionpanel.connect(
+            'append-items', lambda *e: self.emit('append-items', *e[1:])
+        )
+        self.collectionpanel.connect(
+            'replace-items', lambda *e: self.emit('replace-items', *e[1:])
+        )
+        self.collectionpanel.connect(
+            'queue-items', lambda *e: self.emit('queue-items', *e[1:])
+        )
+        self.collectionpanel.connect(
+            'collection-tree-loaded', lambda *e: self.emit('collection-tree-loaded')
+        )
 
     def add_tracks_func(self, tracks):
         self.device.add_tracks(tracks)
         thread = DeviceTransferThread(self.device)
         thread.connect('done', lambda *e: self.load_tree())
-        self.main.controller.progress_manager.add_monitor(thread,
-                                                          _("Transferring to %s...") % self.name, 'drive-harddisk')
+        self.main.controller.progress_manager.add_monitor(
+            thread, _("Transferring to %s...") % self.name, 'drive-harddisk'
+        )
 
     def get_panel(self):
         return self.collectionpanel.get_panel()
@@ -169,12 +182,13 @@ class FlatPlaylistDevicePanel(panel.Panel):
 
         self.fppanel = FlatPlaylistPanel(self, name, label)
 
-        self.fppanel.connect('append-items',
-                             lambda *e: self.emit('append-items', *e[1:]))
-        self.fppanel.connect('replace-items',
-                             lambda *e: self.emit('replace-items', *e[1:]))
-        self.fppanel.connect('queue-items',
-                             lambda *e: self.emit('queue-items', *e[1:]))
+        self.fppanel.connect(
+            'append-items', lambda *e: self.emit('append-items', *e[1:])
+        )
+        self.fppanel.connect(
+            'replace-items', lambda *e: self.emit('replace-items', *e[1:])
+        )
+        self.fppanel.connect('queue-items', lambda *e: self.emit('queue-items', *e[1:]))
 
     def get_panel(self):
         return self.fppanel.get_panel()
@@ -185,5 +199,4 @@ class FlatPlaylistDevicePanel(panel.Panel):
 
     def load_tree(self, *e):
         # TODO: handle *all* the playlists
-        self.fppanel.set_playlist(
-            self.device.get_playlists()[0])
+        self.fppanel.set_playlist(self.device.get_playlists()[0])

--- a/xlgui/panel/flatplaylist.py
+++ b/xlgui/panel/flatplaylist.py
@@ -29,9 +29,7 @@ from gi.repository import Gtk
 
 from xl import trax
 from xl.nls import gettext as _
-from xlgui import (
-    panel
-)
+from xlgui import panel
 from xlgui.panel import menus
 from xlgui.widgets.common import DragTreeView
 
@@ -40,6 +38,7 @@ class FlatPlaylistPanel(panel.Panel):
     """
         Flat playlist panel; represents a single playlist
     """
+
     __gsignals__ = {
         'append-items': (GObject.SignalFlags.RUN_LAST, None, (object, bool)),
         'replace-items': (GObject.SignalFlags.RUN_LAST, None, (object,)),
@@ -61,10 +60,12 @@ class FlatPlaylistPanel(panel.Panel):
         self._connect_events()
 
     def _connect_events(self):
-        self.builder.connect_signals({
-            'on_add_button_clicked': self._on_add_button_clicked,
-            'on_import_button_clicked': self._on_import_button_clicked,
-        })
+        self.builder.connect_signals(
+            {
+                'on_add_button_clicked': self._on_add_button_clicked,
+                'on_import_button_clicked': self._on_import_button_clicked,
+            }
+        )
 
     def _on_add_button_clicked(self, *e):
         self.emit('append-items', self.tracks, False)

--- a/xlgui/panel/lyrics.py
+++ b/xlgui/panel/lyrics.py
@@ -28,12 +28,7 @@ from gi.repository import Gtk
 from gi.repository import GLib
 
 from xl.nls import gettext as _
-from xl import (
-    common,
-    event,
-    player,
-    providers,
-)
+from xl import common, event, player, providers
 from xl import settings as xl_settings
 from xl import lyrics as xl_lyrics
 from xlgui import guiutil, panel
@@ -50,20 +45,34 @@ class LyricsPanel(panel.Panel):
 
         self.__lyrics_found = []
         self.__css_provider = Gtk.CssProvider()
-        
-        WIDGET_LIST = \
-            ['lyrics_top_box', 'refresh_button', 'refresh_button_stack',
-             'refresh_icon', 'refresh_spinner', 'track_text',
-             'scrolled_window', 'lyrics_text', 'lyrics_source_label',
-             'track_text_buffer', 'lyrics_text_buffer']
+
+        WIDGET_LIST = [
+            'lyrics_top_box',
+            'refresh_button',
+            'refresh_button_stack',
+            'refresh_icon',
+            'refresh_spinner',
+            'track_text',
+            'scrolled_window',
+            'lyrics_text',
+            'lyrics_source_label',
+            'track_text_buffer',
+            'lyrics_text_buffer',
+        ]
         for name in WIDGET_LIST:
-            setattr(self, '_' + LyricsPanel.__name__ + '__' + name, self.builder.get_object(name))
+            setattr(
+                self,
+                '_' + LyricsPanel.__name__ + '__' + name,
+                self.builder.get_object(name),
+            )
         self.__initialize_widgets()
 
         event.add_ui_callback(self.__on_playback_track_start, 'playback_track_start')
         event.add_ui_callback(self.__on_track_tags_changed, 'track_tags_changed')
         event.add_ui_callback(self.__on_playback_player_end, 'playback_player_end')
-        event.add_ui_callback(self.__on_lyrics_search_method_added, 'lyrics_search_method_added')
+        event.add_ui_callback(
+            self.__on_lyrics_search_method_added, 'lyrics_search_method_added'
+        )
         event.add_ui_callback(self.__on_option_set, 'plugin_lyricsviewer_option_set')
 
         self.__update_lyrics()
@@ -77,18 +86,23 @@ class LyricsPanel(panel.Panel):
 
         track_text_style = Gtk.CssProvider()
         style_context = self.__track_text.get_style_context()
-        style_context.add_provider(track_text_style, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        style_context.add_provider(
+            track_text_style, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
         track_text_style.load_from_data("textview {font-weight: bold; }")
 
         style_context = self.__lyrics_text.get_style_context()
-        style_context.add_provider(self.__css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        style_context.add_provider(
+            self.__css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
 
-        lyricsprefs.DEFAULT_FONT = self.__lyrics_text.get_default_attributes().font.to_string()
+        lyricsprefs.DEFAULT_FONT = (
+            self.__lyrics_text.get_default_attributes().font.to_string()
+        )
         # trigger initial setup through options
         self.__on_option_set(None, xl_settings, 'plugin/lyricsviewer/lyrics_font')
 
-        self.__refresh_button.connect(
-            'clicked', self.__on_refresh_button_clicked)
+        self.__refresh_button.connect('clicked', self.__on_refresh_button_clicked)
 
     def __on_option_set(self, _event, settings, option):
         if option == 'plugin/lyricsviewer/lyrics_font':
@@ -141,8 +155,11 @@ class LyricsPanel(panel.Panel):
         track_text = ''
         try:
             try:
-                track_text = track.get_tag_raw('artist')[0] + \
-                    " - " + track.get_tag_raw('title')[0]
+                track_text = (
+                    track.get_tag_raw('artist')[0]
+                    + " - "
+                    + track.get_tag_raw('title')[0]
+                )
             except Exception:
                 raise xl_lyrics.LyricsNotFoundException
             lyrics_found = xl_lyrics.MANAGER.find_all_lyrics(track, refresh)
@@ -185,11 +202,9 @@ class LyricsPanel(panel.Panel):
     def __set_top_box_widgets(self, state, init=False):
         if state or init:
             self.__refresh_spinner.stop()
-            self.__refresh_button_stack.set_visible_child(
-                self.__refresh_icon)
+            self.__refresh_button_stack.set_visible_child(self.__refresh_icon)
         else:
-            self.__refresh_button_stack.set_visible_child(
-                self.__refresh_spinner)
+            self.__refresh_button_stack.set_visible_child(self.__refresh_spinner)
             self.__refresh_spinner.start()
 
         self.__refresh_button.set_sensitive(state)

--- a/xlgui/panel/menus.py
+++ b/xlgui/panel/menus.py
@@ -48,10 +48,7 @@
 
 from xl.nls import gettext as _
 from xl import common
-from xlgui.widgets import (
-    menu,
-    menuitems
-)
+from xlgui.widgets import menu, menuitems
 
 ### Generic track selection menus
 
@@ -89,8 +86,12 @@ class TrackPanelMenu(menu.ProviderMenu):
 
     def get_context(self):
         context = common.LazyDict(self._parent)
-        context['selected-tracks'] = lambda name, parent: parent.tree.get_selected_tracks()
-        context['selection-empty'] = lambda name, parent: parent.tree.get_selection_empty()
+        context[
+            'selected-tracks'
+        ] = lambda name, parent: parent.tree.get_selected_tracks()
+        context[
+            'selection-empty'
+        ] = lambda name, parent: parent.tree.get_selection_empty()
         return context
 
 
@@ -98,17 +99,25 @@ class TrackPanelMenu(menu.ProviderMenu):
 
 
 def __create_collection_panel_context_menu():
-
     def collection_delete_tracks_func(panel, context, tracks):
         panel.collection.delete_tracks(tracks)
 
     items = []
     items.append(menu.simple_separator('cp-sep', after=['properties']))
-    items.append(menuitems.OpenDirectoryMenuItem('open-directory', after=[items[-1].name]))
-    items.append(menuitems.TrashMenuItem('trash-tracks', after=[items[-1].name], delete_tracks_func=collection_delete_tracks_func))
+    items.append(
+        menuitems.OpenDirectoryMenuItem('open-directory', after=[items[-1].name])
+    )
+    items.append(
+        menuitems.TrashMenuItem(
+            'trash-tracks',
+            after=[items[-1].name],
+            delete_tracks_func=collection_delete_tracks_func,
+        )
+    )
 
     for item in items:
         item.register('collection-panel-context-menu')
+
 
 __create_collection_panel_context_menu()
 
@@ -121,31 +130,43 @@ class CollectionContextMenu(menu.MultiProviderMenu):
     '''
 
     def __init__(self, panel):
-        menu.MultiProviderMenu.__init__(self,
-                                        ['track-panel-menu', 'collection-panel-context-menu'], panel)
+        menu.MultiProviderMenu.__init__(
+            self, ['track-panel-menu', 'collection-panel-context-menu'], panel
+        )
 
     def get_context(self):
         context = common.LazyDict(self._parent)
-        context['selected-tracks'] = lambda name, parent: parent.tree.get_selected_tracks()
-        context['selection-empty'] = lambda name, parent: parent.tree.get_selection_empty()
+        context[
+            'selected-tracks'
+        ] = lambda name, parent: parent.tree.get_selected_tracks()
+        context[
+            'selection-empty'
+        ] = lambda name, parent: parent.tree.get_selection_empty()
         return context
+
 
 ### Files panel menu
 
 
 def __create_files_panel_context_menu():
-
     def trash_tracks_func(parent, context, tracks):
         menuitems.generic_trash_tracks_func(parent, context, tracks)
         parent.refresh(None)
 
     items = []
     items.append(menu.simple_separator('fp-sep', after=['properties']))
-    items.append(menuitems.OpenDirectoryMenuItem('open-directory', after=[items[-1].name]))
-    items.append(menuitems.TrashMenuItem('trash-tracks', after=[items[-1].name], trash_tracks_func=trash_tracks_func))
+    items.append(
+        menuitems.OpenDirectoryMenuItem('open-directory', after=[items[-1].name])
+    )
+    items.append(
+        menuitems.TrashMenuItem(
+            'trash-tracks', after=[items[-1].name], trash_tracks_func=trash_tracks_func
+        )
+    )
 
     for item in items:
         item.register('files-panel-context-menu')
+
 
 __create_files_panel_context_menu()
 
@@ -158,16 +179,24 @@ class FilesContextMenu(menu.MultiProviderMenu):
     '''
 
     def __init__(self, panel):
-        menu.MultiProviderMenu.__init__(self,
-                                        ['track-panel-menu', 'files-panel-context-menu'], panel)
+        menu.MultiProviderMenu.__init__(
+            self, ['track-panel-menu', 'files-panel-context-menu'], panel
+        )
 
     def get_context(self):
         context = common.LazyDict(self._parent)
-        context['needs-computing'] = lambda name, parent: parent.tree.get_selection_is_computed()
-        context['selected-tracks'] = lambda name, parent: parent.tree.get_selected_tracks()
-        context['selection-empty'] = lambda name, parent: parent.tree.get_selection_empty()
+        context[
+            'needs-computing'
+        ] = lambda name, parent: parent.tree.get_selection_is_computed()
+        context[
+            'selected-tracks'
+        ] = lambda name, parent: parent.tree.get_selected_tracks()
+        context[
+            'selection-empty'
+        ] = lambda name, parent: parent.tree.get_selection_empty()
 
         return context
+
 
 ### Playlist panel menus
 
@@ -176,22 +205,34 @@ def __create_playlist_panel_menus():
 
     # w, n, o, c: window, name, parent, context
 
-    menu.simple_menu_item('new-playlist', [], _('_New Playlist'), 'tab-new',
-                          lambda w, n, o, c: o.add_new_playlist()) \
-        .register('playlist-panel-menu')
+    menu.simple_menu_item(
+        'new-playlist',
+        [],
+        _('_New Playlist'),
+        'tab-new',
+        lambda w, n, o, c: o.add_new_playlist(),
+    ).register('playlist-panel-menu')
 
-    menu.simple_menu_item('new-smart-playlist', ['new-playlist'],
-                          _('New _Smart Playlist'), 'tab-new',
-                          lambda w, n, o, c: o.add_smart_playlist()) \
-        .register('playlist-panel-menu')
+    menu.simple_menu_item(
+        'new-smart-playlist',
+        ['new-playlist'],
+        _('New _Smart Playlist'),
+        'tab-new',
+        lambda w, n, o, c: o.add_smart_playlist(),
+    ).register('playlist-panel-menu')
 
-    menu.simple_menu_item('import-playlist', ['new-smart-playlist'],
-                          _('_Import Playlist'), 'document-open',
-                          lambda w, n, o, c: o.import_playlist()) \
-        .register('playlist-panel-menu')
+    menu.simple_menu_item(
+        'import-playlist',
+        ['new-smart-playlist'],
+        _('_Import Playlist'),
+        'document-open',
+        lambda w, n, o, c: o.import_playlist(),
+    ).register('playlist-panel-menu')
 
-    menu.simple_separator('top-sep', after=['import-playlist']) \
-        .register('playlist-panel-menu')
+    menu.simple_separator('top-sep', after=['import-playlist']).register(
+        'playlist-panel-menu'
+    )
+
 
 __create_playlist_panel_menus()
 
@@ -214,17 +255,28 @@ def __create_playlist_panel_playlist_menus():
 
     items.append(menu.simple_separator('pp-top-sep', ['properties']))
 
-    items.append(menuitems.RenamePlaylistMenuItem('rename-playlist', after=[items[-1].name]))
-    items.append(menuitems.EditPlaylistMenuItem('edit-playlist', after=[items[-1].name]))
-    items.append(menuitems.ExportPlaylistMenuItem('export-playlist', after=[items[-1].name]))
-    items.append(menuitems.ExportPlaylistFilesMenuItem('export-files', after=[items[-1].name]))
+    items.append(
+        menuitems.RenamePlaylistMenuItem('rename-playlist', after=[items[-1].name])
+    )
+    items.append(
+        menuitems.EditPlaylistMenuItem('edit-playlist', after=[items[-1].name])
+    )
+    items.append(
+        menuitems.ExportPlaylistMenuItem('export-playlist', after=[items[-1].name])
+    )
+    items.append(
+        menuitems.ExportPlaylistFilesMenuItem('export-files', after=[items[-1].name])
+    )
 
     items.append(menu.simple_separator('pp-sep', after=[items[-1].name]))
 
-    items.append(menuitems.DeletePlaylistMenuItem('delete-playlist', after=[items[-1].name]))
+    items.append(
+        menuitems.DeletePlaylistMenuItem('delete-playlist', after=[items[-1].name])
+    )
 
     for item in items:
         item.register('playlist-panel-context-menu')
+
 
 __create_playlist_panel_playlist_menus()
 
@@ -237,17 +289,28 @@ class PlaylistsPanelPlaylistMenu(menu.MultiProviderMenu):
     '''
 
     def __init__(self, parent):
-        menu.MultiProviderMenu.__init__(self,
-                                        ['playlist-panel-menu', 'track-panel-menu', 'playlist-panel-context-menu'],
-                                        parent)
+        menu.MultiProviderMenu.__init__(
+            self,
+            ['playlist-panel-menu', 'track-panel-menu', 'playlist-panel-context-menu'],
+            parent,
+        )
 
     def get_context(self):
         context = common.LazyDict(self._parent)
-        context['needs-computing'] = lambda name, parent: parent.tree.get_selection_is_computed()
-        context['selected-playlist'] = lambda name, parent: parent.tree.get_selected_page(raw=True)
-        context['selected-tracks'] = lambda name, parent: parent.tree.get_selected_tracks()
-        context['selection-empty'] = lambda name, parent: parent.tree.get_selection_empty()
+        context[
+            'needs-computing'
+        ] = lambda name, parent: parent.tree.get_selection_is_computed()
+        context[
+            'selected-playlist'
+        ] = lambda name, parent: parent.tree.get_selected_page(raw=True)
+        context[
+            'selected-tracks'
+        ] = lambda name, parent: parent.tree.get_selected_tracks()
+        context[
+            'selection-empty'
+        ] = lambda name, parent: parent.tree.get_selection_empty()
         return context
+
 
 ### Radio panel menu
 
@@ -256,9 +319,14 @@ def __create_radio_panel_menus():
 
     # w, n, o, c: window, name, parent, context
 
-    menu.simple_menu_item('new-station', [], _('_New Station'), 'list-add',
-                          lambda w, n, o, c: o._on_add_button_clicked()) \
-        .register('radio-panel-menu')
+    menu.simple_menu_item(
+        'new-station',
+        [],
+        _('_New Station'),
+        'list-add',
+        lambda w, n, o, c: o._on_add_button_clicked(),
+    ).register('radio-panel-menu')
+
 
 __create_radio_panel_menus()
 
@@ -269,13 +337,21 @@ class RadioPanelPlaylistMenu(menu.MultiProviderMenu):
     '''
 
     def __init__(self, parent):
-        menu.MultiProviderMenu.__init__(self,
-                                        ['radio-panel-menu', 'track-panel-menu', 'playlist-panel-context-menu'],
-                                        parent)
+        menu.MultiProviderMenu.__init__(
+            self,
+            ['radio-panel-menu', 'track-panel-menu', 'playlist-panel-context-menu'],
+            parent,
+        )
 
     def get_context(self):
         context = common.LazyDict(self._parent)
-        context['selected-playlist'] = lambda name, parent: parent.tree.get_selected_page(raw=True)
-        context['selected-tracks'] = lambda name, parent: parent.tree.get_selected_tracks()
-        context['selection-empty'] = lambda name, parent: parent.tree.get_selection_empty()
+        context[
+            'selected-playlist'
+        ] = lambda name, parent: parent.tree.get_selected_page(raw=True)
+        context[
+            'selected-tracks'
+        ] = lambda name, parent: parent.tree.get_selected_tracks()
+        context[
+            'selection-empty'
+        ] = lambda name, parent: parent.tree.get_selection_empty()
         return context

--- a/xlgui/panel/playlists.py
+++ b/xlgui/panel/playlists.py
@@ -31,33 +31,21 @@ from gi.repository import GdkPixbuf
 from gi.repository import GObject
 
 
-from xl import (
-    common,
-    event,
-    playlist as xl_playlist,
-    radio,
-    settings,
-    trax
-)
+from xl import common, event, playlist as xl_playlist, radio, settings, trax
 from xl.nls import gettext as _
-from xlgui import (
-    icons,
-    panel
-)
+from xlgui import icons, panel
 from xlgui.panel import menus
-from xlgui.widgets import (
-    dialogs
-)
+from xlgui.widgets import dialogs
 
 from xlgui.widgets.common import DragTreeView
 from xlgui.widgets.smart_playlist_editor import SmartPlaylistEditor
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
 class TrackWrapper(object):
-
     def __init__(self, track, playlist):
         self.track = track
         self.playlist = playlist
@@ -81,6 +69,7 @@ class BasePlaylistPanelMixin(GObject.GObject):
 
         Used by the radio and playlists panels to display playlists
     """
+
     # HACK: Notice that this is not __gsignals__; descendants need to manually
     # merge this in. This is because new PyGObject doesn't like __gsignals__
     # coming from mixin. See:
@@ -101,7 +90,8 @@ class BasePlaylistPanelMixin(GObject.GObject):
         GObject.GObject.__init__(self)
         self.playlist_nodes = {}  # {playlist: iter} cache for custom playlists
         self.track_image = icons.MANAGER.pixbuf_from_icon_name(
-            'audio-x-generic', Gtk.IconSize.SMALL_TOOLBAR)
+            'audio-x-generic', Gtk.IconSize.SMALL_TOOLBAR
+        )
         # {Playlist: Gtk.Dialog} mapping to keep track of open "are you sure
         # you want to delete" dialogs
         self.deletion_dialogs = {}
@@ -122,11 +112,9 @@ class BasePlaylistPanelMixin(GObject.GObject):
         def on_response(dialog, response):
             if response == Gtk.ResponseType.YES:
                 if isinstance(selected_playlist, xl_playlist.SmartPlaylist):
-                    self.smart_manager.remove_playlist(
-                        selected_playlist.name)
+                    self.smart_manager.remove_playlist(selected_playlist.name)
                 else:
-                    self.playlist_manager.remove_playlist(
-                        selected_playlist.name)
+                    self.playlist_manager.remove_playlist(selected_playlist.name)
                     # Remove from {playlist: iter} cache.
                     del self.playlist_nodes[selected_playlist]
                 # Remove from UI.
@@ -136,10 +124,13 @@ class BasePlaylistPanelMixin(GObject.GObject):
             del self.deletion_dialogs[selected_playlist]
             dialog.destroy()
 
-        dialog = Gtk.MessageDialog(self.parent,
-                                   Gtk.DialogFlags.DESTROY_WITH_PARENT,
-                                   Gtk.MessageType.QUESTION, Gtk.ButtonsType.YES_NO,
-                                   _('Delete the playlist "%s"?') % selected_playlist.name)
+        dialog = Gtk.MessageDialog(
+            self.parent,
+            Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            Gtk.MessageType.QUESTION,
+            Gtk.ButtonsType.YES_NO,
+            _('Delete the playlist "%s"?') % selected_playlist.name,
+        )
         dialog.connect('response', on_response)
         self.deletion_dialogs[selected_playlist] = dialog
         dialog.present()
@@ -155,7 +146,10 @@ class BasePlaylistPanelMixin(GObject.GObject):
         # Ask for new name
         dialog = dialogs.TextEntryDialog(
             _("Enter the new name you want for your playlist"),
-            _("Rename Playlist"), playlist.name, parent=self.parent)
+            _("Rename Playlist"),
+            playlist.name,
+            parent=self.parent,
+        )
 
         result = dialog.run()
         name = dialog.get_value()
@@ -167,8 +161,9 @@ class BasePlaylistPanelMixin(GObject.GObject):
 
         if name in self.playlist_manager.playlists:
             # name is already in use
-            dialogs.error(self.parent, _("The "
-                                         "playlist name you entered is already in use."))
+            dialogs.error(
+                self.parent, _("The " "playlist name you entered is already in use.")
+            )
             return
 
         selection = self.tree.get_selection()
@@ -205,22 +200,23 @@ class BasePlaylistPanelMixin(GObject.GObject):
         iter = self.model.get_iter(path)
         item = self.model.get_value(iter, 2)
         if item is not None:
-            if isinstance(item, (xl_playlist.Playlist,
-                                 xl_playlist.SmartPlaylist)):
+            if isinstance(item, (xl_playlist.Playlist, xl_playlist.SmartPlaylist)):
                 # for smart playlists
                 if hasattr(item, 'get_playlist'):
                     try:
                         item = item.get_playlist(self.collection)
                     except Exception as e:
                         logger.exception("Error loading smart playlist")
-                        dialogs.error(self.parent, _("Error loading smart playlist: %s") % str(e))
+                        dialogs.error(
+                            self.parent, _("Error loading smart playlist: %s") % str(e)
+                        )
                         return
                 else:
                     # Get an up to date copy
                     item = self.playlist_manager.get_playlist(item.name)
                     # item.set_is_custom(True)
 
-#                self.controller.main.add_playlist(item)
+                #                self.controller.main.add_playlist(item)
                 self.emit('playlist-selected', item)
             else:
                 self.emit('append-items', [item.track], True)
@@ -237,7 +233,8 @@ class BasePlaylistPanelMixin(GObject.GObject):
         if name:
             if name in self.playlist_manager.playlists:
                 name = dialogs.ask_for_playlist_name(
-                    self.get_panel().get_toplevel(), self.playlist_manager, name)
+                    self.get_panel().get_toplevel(), self.playlist_manager, name
+                )
         else:
             if tracks:
                 artists = []
@@ -245,14 +242,14 @@ class BasePlaylistPanelMixin(GObject.GObject):
                 albums = []
 
                 for track in tracks:
-                    artist = track.get_tag_display('artist',
-                                                   artist_compilations=False)
+                    artist = track.get_tag_display('artist', artist_compilations=False)
 
                     if artist is not None:
                         artists += [artist]
 
-                    composer = track.get_tag_display('composer',
-                                                     artist_compilations=False)
+                    composer = track.get_tag_display(
+                        'composer', artist_compilations=False
+                    )
 
                     if composer is not None:
                         composers += composer
@@ -273,12 +270,14 @@ class BasePlaylistPanelMixin(GObject.GObject):
                         # TRANSLATORS: Playlist title suggestion with more
                         # than two values
                         name = _('%(first)s, %(second)s and others') % {
-                            'first': artists[0], 'second': artists[1]
+                            'first': artists[0],
+                            'second': artists[1],
                         }
                     elif len(artists) > 1:
                         # TRANSLATORS: Playlist title suggestion with two values
                         name = _('%(first)s and %(second)s') % {
-                            'first': artists[0], 'second': artists[1]
+                            'first': artists[0],
+                            'second': artists[1],
                         }
                 elif len(composers) > 0:
                     name = composers[0]
@@ -287,12 +286,14 @@ class BasePlaylistPanelMixin(GObject.GObject):
                         # TRANSLATORS: Playlist title suggestion with more
                         # than two values
                         name = _('%(first)s, %(second)s and others') % {
-                            'first': composers[0], 'second': composers[1]
+                            'first': composers[0],
+                            'second': composers[1],
                         }
                     elif len(composers) > 1:
                         # TRANSLATORS: Playlist title suggestion with two values
                         name = _('%(first)s and %(second)s') % {
-                            'first': composers[0], 'second': composers[1]
+                            'first': composers[0],
+                            'second': composers[1],
                         }
                 elif len(albums) > 0:
                     name = albums[0]
@@ -301,18 +302,21 @@ class BasePlaylistPanelMixin(GObject.GObject):
                         # TRANSLATORS: Playlist title suggestion with more
                         # than two values
                         name = _('%(first)s, %(second)s and others') % {
-                            'first': albums[0], 'second': albums[1]
+                            'first': albums[0],
+                            'second': albums[1],
                         }
                     elif len(albums) > 1:
                         # TRANSLATORS: Playlist title suggestion with two values
                         name = _('%(first)s and %(second)s') % {
-                            'first': albums[0], 'second': albums[1]
+                            'first': albums[0],
+                            'second': albums[1],
                         }
                 else:
                     name = ''
 
             name = dialogs.ask_for_playlist_name(
-                self.get_panel().get_toplevel(), self.playlist_manager, name)
+                self.get_panel().get_toplevel(), self.playlist_manager, name
+            )
 
         if name is not None:
             # Create the playlist from all of the tracks
@@ -331,7 +335,8 @@ class BasePlaylistPanelMixin(GObject.GObject):
             return
 
         expanded = self.tree.row_expanded(
-            self.model.get_path(self.playlist_nodes[playlist]))
+            self.model.get_path(self.playlist_nodes[playlist])
+        )
 
         self._clear_node(self.playlist_nodes[playlist])
         parent = self.playlist_nodes[playlist]
@@ -344,7 +349,8 @@ class BasePlaylistPanelMixin(GObject.GObject):
 
         if expanded:
             self.tree.expand_row(
-                self.model.get_path(self.playlist_nodes[playlist]), False)
+                self.model.get_path(self.playlist_nodes[playlist]), False
+            )
 
     def remove_selected_track(self):
         """
@@ -366,12 +372,12 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
     """
         The playlists panel
     """
+
     __gsignals__ = BasePlaylistPanelMixin._gsignals_
 
     ui_info = ('playlists.ui', 'PlaylistsPanel')
 
-    def __init__(self, parent, playlist_manager,
-                 smart_manager, collection, name):
+    def __init__(self, parent, playlist_manager, smart_manager, collection, name):
         """
             Intializes the playlists panel
 
@@ -386,8 +392,9 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
 
         self.playlist_name_info = 500
         self.track_target = Gtk.TargetEntry.new("text/uri-list", 0, 0)
-        self.playlist_target = Gtk.TargetEntry.new("playlist_name", Gtk.TargetFlags.SAME_WIDGET,
-                                                   self.playlist_name_info)
+        self.playlist_target = Gtk.TargetEntry.new(
+            "playlist_name", Gtk.TargetFlags.SAME_WIDGET, self.playlist_name_info
+        )
         self.deny_targets = [Gtk.TargetEntry.new('', 0, 0)]
 
         self.tree = PlaylistDragTreeView(self)
@@ -395,8 +402,10 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
         self.tree.set_headers_visible(False)
         self.tree.connect('drag-motion', self.drag_motion)
         self.tree.drag_source_set(
-            Gdk.ModifierType.BUTTON1_MASK, [self.track_target, self.playlist_target],
-            Gdk.DragAction.COPY | Gdk.DragAction.MOVE)
+            Gdk.ModifierType.BUTTON1_MASK,
+            [self.track_target, self.playlist_target],
+            Gdk.DragAction.COPY | Gdk.DragAction.MOVE,
+        )
 
         self.scroll = Gtk.ScrolledWindow()
         self.scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
@@ -409,6 +418,7 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
         cell = Gtk.CellRendererText()
         if settings.get_option('gui/ellipsize_text_in_panels', False):
             from gi.repository import Pango
+
             cell.set_property('ellipsize-set', True)
             cell.set_property('ellipsize', Pango.EllipsizeMode.END)
         col = Gtk.TreeViewColumn('Text')
@@ -422,9 +432,11 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
 
         # icons
         self.folder = icons.MANAGER.pixbuf_from_icon_name(
-            'folder', Gtk.IconSize.SMALL_TOOLBAR)
+            'folder', Gtk.IconSize.SMALL_TOOLBAR
+        )
         self.playlist_image = icons.MANAGER.pixbuf_from_icon_name(
-            'music-library', Gtk.IconSize.SMALL_TOOLBAR)
+            'music-library', Gtk.IconSize.SMALL_TOOLBAR
+        )
 
         # menus
         self.playlist_menu = menus.PlaylistsPanelPlaylistMenu(self)
@@ -444,14 +456,21 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
         """
         model, it = self.tree.get_selection().get_selected()
         pl = model[it][2]
-        return (self.playlist_menu if isinstance(pl, xl_playlist.Playlist) else
-                self.smart_menu if isinstance(pl, xl_playlist.SmartPlaylist) else
-                self.track_menu if isinstance(pl, TrackWrapper) else
-                self.default_menu)
+        return (
+            self.playlist_menu
+            if isinstance(pl, xl_playlist.Playlist)
+            else self.smart_menu
+            if isinstance(pl, xl_playlist.SmartPlaylist)
+            else self.track_menu
+            if isinstance(pl, TrackWrapper)
+            else self.default_menu
+        )
 
     def _connect_events(self):
         event.add_ui_callback(self.refresh_playlists, 'track_tags_changed')
-        event.add_ui_callback(self._on_playlist_added, 'playlist_added', self.playlist_manager)
+        event.add_ui_callback(
+            self._on_playlist_added, 'playlist_added', self.playlist_manager
+        )
 
         self.tree.connect('key-release-event', self.on_key_released)
 
@@ -465,8 +484,10 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
             wrapper so that multiple events dont cause multiple
             reloads in quick succession
         """
-        if settings.get_option('gui/sync_on_tag_change', True) and \
-                tags & {'title', 'artist'}:
+        if settings.get_option('gui/sync_on_tag_change', True) and tags & {
+            'title',
+            'artist',
+        }:
             self._refresh_playlists()
 
     @common.glib_wait(500)
@@ -488,9 +509,9 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
                 self.update_playlist_node(new_playlist)
                 return
 
-        self.playlist_nodes[new_playlist] = \
-            self.model.append(self.custom, [self.playlist_image, playlist_name,
-                                            new_playlist])
+        self.playlist_nodes[new_playlist] = self.model.append(
+            self.custom, [self.playlist_image, playlist_name, new_playlist]
+        )
         self.tree.expand_row(self.model.get_path(self.custom), False)
         self._load_playlist_nodes(new_playlist)
 
@@ -498,22 +519,25 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
         """
             Loads the currently saved playlists
         """
-        self.smart = self.model.append(None, [self.folder,
-                                              _("Smart Playlists"), None])
+        self.smart = self.model.append(None, [self.folder, _("Smart Playlists"), None])
 
-        self.custom = self.model.append(None, [self.folder,
-                                               _("Custom Playlists"), None])
+        self.custom = self.model.append(
+            None, [self.folder, _("Custom Playlists"), None]
+        )
 
         names = sorted(self.smart_manager.playlists[:])
         for name in names:
-            self.model.append(self.smart, [self.playlist_image, name,
-                                           self.smart_manager.get_playlist(name)])
+            self.model.append(
+                self.smart,
+                [self.playlist_image, name, self.smart_manager.get_playlist(name)],
+            )
 
         names = sorted(self.playlist_manager.playlists[:])
         for name in names:
             playlist = self.playlist_manager.get_playlist(name)
             self.playlist_nodes[playlist] = self.model.append(
-                self.custom, [self.playlist_image, name, playlist])
+                self.custom, [self.playlist_image, name, playlist]
+            )
             self._load_playlist_nodes(playlist)
 
         self.tree.expand_row(self.model.get_path(self.smart), False)
@@ -556,8 +580,9 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
         """
             Shows a dialog for adding a new smart playlist
         """
-        pl = SmartPlaylistEditor.create(self.collection, self.smart_manager,
-                                        self.parent)
+        pl = SmartPlaylistEditor.create(
+            self.collection, self.smart_manager, self.parent
+        )
         if pl:
             self.model.append(self.smart, [self.playlist_image, pl.name, pl])
 
@@ -572,8 +597,9 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
         """
             Shows a dialog for editing a smart playlist
         """
-        pl = SmartPlaylistEditor.edit(pl, self.collection, self.smart_manager,
-                                      self.parent)
+        pl = SmartPlaylistEditor.edit(
+            pl, self.collection, self.smart_manager, self.parent
+        )
         if pl:
             selection = self.tree.get_selection()
             model, it = selection.get_selected()
@@ -600,26 +626,24 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
                         drop_target = self.model.get_value(drop_target_iter, 2)
                         if position == Gtk.TreeViewDropPosition.BEFORE:
                             # Put the playlist before drop_target
-                            self.model.move_before(drag_source_iter,
-                                                   drop_target_iter)
-                            self.playlist_manager.move(playlist_name,
-                                                       drop_target.name, after=False)
+                            self.model.move_before(drag_source_iter, drop_target_iter)
+                            self.playlist_manager.move(
+                                playlist_name, drop_target.name, after=False
+                            )
                         else:
                             # put the playlist after drop_target
-                            self.model.move_after(drag_source_iter,
-                                                  drop_target_iter)
-                            self.playlist_manager.move(playlist_name,
-                                                       drop_target.name, after=True)
+                            self.model.move_after(drag_source_iter, drop_target_iter)
+                            self.playlist_manager.move(
+                                playlist_name, drop_target.name, after=True
+                            )
             # Even though we are doing a move we still don't
             # call the delete method because we take care
             # of it above by moving instead of inserting/deleting
             context.finish(True, False, etime)
         else:
-            self._drag_data_received_uris(tv, context, x, y, selection,
-                                          info, etime)
+            self._drag_data_received_uris(tv, context, x, y, selection, info, etime)
 
-    def _drag_data_received_uris(self, tv, context, x, y, selection,
-                                 info, etime):
+    def _drag_data_received_uris(self, tv, context, x, y, selection, info, etime):
         """
             Called by drag_data_received when the user drags URIs onto us
         """
@@ -636,8 +660,10 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
                 current_playlist = drop_target.playlist
                 drop_target_index = current_playlist.index(drop_target.track)
                 # Adjust insert position based on drop position
-                if (position == Gtk.TreeViewDropPosition.BEFORE or
-                        position == Gtk.TreeViewDropPosition.INTO_OR_BEFORE):
+                if (
+                    position == Gtk.TreeViewDropPosition.BEFORE
+                    or position == Gtk.TreeViewDropPosition.INTO_OR_BEFORE
+                ):
                     # By default adding tracks inserts it before so we do not
                     # have to modify the insert index
                     insert_index = drop_target_index
@@ -652,7 +678,8 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
             # to make this work properly in all cases
             try:
                 remove_track_index = current_playlist.index(
-                    self.tree.get_selected_track())
+                    self.tree.get_selected_track()
+                )
             except ValueError:
                 remove_track_index = None
             if insert_index is not None and remove_track_index is not None:
@@ -687,8 +714,7 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
             # Do we save in the case when a user drags a file onto a playlist
             # in the playlist panel? note that the playlist does not have to
             # be open for this to happen
-            self.playlist_manager.save_playlist(current_playlist,
-                                                overwrite=True)
+            self.playlist_manager.save_playlist(current_playlist, overwrite=True)
         else:
             # If the user dragged files prompt for a new playlist name
             # else if they dragged a playlist add the playlist
@@ -699,14 +725,13 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
             # First see if they dragged any playlist files
             for new_playlist in playlists:
                 self.playlist_nodes[new_playlist] = self.model.append(
-                    self.custom, [self.playlist_image, new_playlist.name,
-                                  new_playlist])
+                    self.custom, [self.playlist_image, new_playlist.name, new_playlist]
+                )
                 self._load_playlist_nodes(new_playlist)
 
                 # We are adding a completely new playlist with tracks so
                 # we save it
-                self.playlist_manager.save_playlist(new_playlist,
-                                                    overwrite=True)
+                self.playlist_manager.save_playlist(new_playlist, overwrite=True)
 
             # After processing playlist proceed to ask the user for the
             # name of the new playlist to add and add the tracks to it
@@ -741,8 +766,7 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
                 return
 
             for track in tracks:
-                DragTreeView.dragged_data[track.get_loc_for_io()] = \
-                    track
+                DragTreeView.dragged_data[track.get_loc_for_io()] = track
 
             uris = trax.util.get_uris_from_tracks(tracks)
             selection_data.set_uris(uris)
@@ -760,8 +784,7 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
             Called on the destination widget
         """
         # Reset any target to be default to moving tracks
-        self.tree.enable_model_drag_dest([self.track_target],
-                                         Gdk.DragAction.DEFAULT)
+        self.tree.enable_model_drag_dest([self.track_target], Gdk.DragAction.DEFAULT)
         # Determine where the drag is coming from
         dragging_playlist = False
         if tv == self.tree:
@@ -779,14 +802,17 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
             if isinstance(drop_target, xl_playlist.Playlist):
                 if dragging_playlist:
                     # If we drag onto  we copy, if we drag between we move
-                    if position == Gtk.TreeViewDropPosition.INTO_OR_BEFORE or \
-                            position == Gtk.TreeViewDropPosition.INTO_OR_AFTER:
+                    if (
+                        position == Gtk.TreeViewDropPosition.INTO_OR_BEFORE
+                        or position == Gtk.TreeViewDropPosition.INTO_OR_AFTER
+                    ):
                         Gdk.drag_status(context, Gdk.DragAction.COPY, time)
                     else:
                         Gdk.drag_status(context, Gdk.DragAction.MOVE, time)
                         # Change target as well
-                        self.tree.enable_model_drag_dest([self.playlist_target],
-                                                         Gdk.DragAction.DEFAULT)
+                        self.tree.enable_model_drag_dest(
+                            [self.playlist_target], Gdk.DragAction.DEFAULT
+                        )
                 else:
                     Gdk.drag_status(context, Gdk.DragAction.COPY, time)
             elif isinstance(drop_target, TrackWrapper):
@@ -794,23 +820,24 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
                 # make it a move operation if we are only dragging
                 # tracks within our widget
                 # We do a copy if we are draggin from another playlist
-                if Gtk.drag_get_source_widget(context) == tv and \
-                        not dragging_playlist:
+                if Gtk.drag_get_source_widget(context) == tv and not dragging_playlist:
                     Gdk.drag_status(context, Gdk.DragAction.MOVE, time)
                 else:
                     Gdk.drag_status(context, Gdk.DragAction.COPY, time)
             else:
                 # Prevent drop operation by changing the targets
-                self.tree.enable_model_drag_dest(self.deny_targets,
-                                                 Gdk.DragAction.DEFAULT)
+                self.tree.enable_model_drag_dest(
+                    self.deny_targets, Gdk.DragAction.DEFAULT
+                )
                 return False
             return True
         else:  # No drop info
             if dragging_playlist:
                 context.drag_status(Gdk.DragAction.MOVE, time)
                 # Change target as well
-                self.tree.enable_model_drag_dest([self.playlist_target],
-                                                 Gdk.DragAction.DEFAULT)
+                self.tree.enable_model_drag_dest(
+                    [self.playlist_target], Gdk.DragAction.DEFAULT
+                )
 
     def on_key_released(self, widget, event):
         """
@@ -824,17 +851,21 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
                 # Based on what is selected determines what
                 # menu we will show
                 if isinstance(pl, xl_playlist.Playlist):
-                    Gtk.Menu.popup(self.playlist_menu, None,
-                                   None, None, None, 0, event.time)
+                    Gtk.Menu.popup(
+                        self.playlist_menu, None, None, None, None, 0, event.time
+                    )
                 elif isinstance(pl, xl_playlist.SmartPlaylist):
-                    Gtk.Menu.popup(self.smart_menu, None,
-                                   None, None, None, 0, event.time)
+                    Gtk.Menu.popup(
+                        self.smart_menu, None, None, None, None, 0, event.time
+                    )
                 elif isinstance(pl, TrackWrapper):
-                    Gtk.Menu.popup(self.track_menu, None,
-                                   None, None, None, 0, event.time)
+                    Gtk.Menu.popup(
+                        self.track_menu, None, None, None, None, 0, event.time
+                    )
                 else:
-                    Gtk.Menu.popup(self.default_menu, None,
-                                   None, None, None, 0, event.time)
+                    Gtk.Menu.popup(
+                        self.default_menu, None, None, None, None, 0, event.time
+                    )
             return True
 
         if event.keyval == Gdk.KEY_Left:
@@ -856,8 +887,9 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
                 pl = self.model.get_value(iter, 2)
                 # Based on what is selected determines what
                 # menu we will show
-                if isinstance(pl, xl_playlist.Playlist) or \
-                        isinstance(pl, xl_playlist.SmartPlaylist):
+                if isinstance(pl, xl_playlist.Playlist) or isinstance(
+                    pl, xl_playlist.SmartPlaylist
+                ):
                     self.remove_playlist(pl)
                 elif isinstance(pl, TrackWrapper):
                     self.remove_selected_track()
@@ -920,8 +952,7 @@ class PlaylistDragTreeView(DragTreeView):
         """
         item = self.get_selected_item(raw=raw)
 
-        if isinstance(item, (xl_playlist.Playlist,
-                             xl_playlist.SmartPlaylist)):
+        if isinstance(item, (xl_playlist.Playlist, xl_playlist.SmartPlaylist)):
             return item
         else:
             return None

--- a/xlgui/panel/radio.py
+++ b/xlgui/panel/radio.py
@@ -33,24 +33,13 @@ from gi.repository import Gtk
 
 import xl.radio
 import xl.playlist
-from xl import (
-    event,
-    common,
-    settings,
-    trax
-)
+from xl import event, common, settings, trax
 from xl.nls import gettext as _
 import xlgui.panel.playlists as playlistpanel
 from xlgui.panel import menus
-from xlgui import (
-    icons,
-    panel
-)
+from xlgui import icons, panel
 from xlgui.widgets.common import DragTreeView
-from xlgui.widgets import (
-    dialogs,
-    menu
-)
+from xlgui.widgets import dialogs, menu
 
 
 class RadioException(Exception):
@@ -65,6 +54,7 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
     """
         The Radio Panel
     """
+
     __gsignals__ = {
         'playlist-selected': (GObject.SignalFlags.RUN_LAST, None, (object,)),
         'append-items': (GObject.SignalFlags.RUN_LAST, None, (object, bool)),
@@ -76,8 +66,7 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
     ui_info = ('radio.ui', 'RadioPanel')
     _radiopanel = None
 
-    def __init__(self, parent, collection,
-                 radio_manager, station_manager, name):
+    def __init__(self, parent, collection, radio_manager, station_manager, name):
         """
             Initializes the radio panel
         """
@@ -95,7 +84,8 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
         self._setup_tree()
         self._setup_widgets()
         self.playlist_image = icons.MANAGER.pixbuf_from_icon_name(
-            'music-library', Gtk.IconSize.SMALL_TOOLBAR)
+            'music-library', Gtk.IconSize.SMALL_TOOLBAR
+        )
 
         # menus
         self.playlist_menu = menus.RadioPanelPlaylistMenu(self)
@@ -118,11 +108,13 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
         elif isinstance(item, playlistpanel.TrackWrapper):
             return self.track_menu
         else:
-            station = (item if isinstance(item, xl.radio.RadioStation)
-                       else item.station if isinstance(item,
-                                                       (xl.radio.RadioList,
-                                                        xl.radio.RadioItem))
-                       else None)
+            station = (
+                item
+                if isinstance(item, xl.radio.RadioStation)
+                else item.station
+                if isinstance(item, (xl.radio.RadioList, xl.radio.RadioItem))
+                else None
+            )
             if station and hasattr(station, 'get_menu'):
                 return station.get_menu(self)
 
@@ -133,9 +125,9 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
         for name in self.playlist_manager.playlists:
             pl = self.playlist_manager.get_playlist(name)
             if pl is not None:
-                self.playlist_nodes[pl] = self.model.append(self.custom,
-                                                            [self.playlist_image,
-                                                             pl.name, pl])
+                self.playlist_nodes[pl] = self.model.append(
+                    self.custom, [self.playlist_image, pl.name, pl]
+                )
                 self._load_playlist_nodes(pl)
         self.tree.expand_row(self.model.get_path(self.custom), False)
 
@@ -151,12 +143,12 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
         """
         node = self.model.append(self.radio_root, [self.folder, str(driver), driver])
         self.nodes[driver] = node
-        self.load_nodes[driver] = self.model.append(node, [self.refresh_image,
-                                                           _('Loading streams...'), None])
+        self.load_nodes[driver] = self.model.append(
+            node, [self.refresh_image, _('Loading streams...'), None]
+        )
         self.tree.expand_row(self.model.get_path(self.radio_root), False)
 
-        if settings.get_option('gui/radio/%s_station_expanded' %
-                               driver.name, False):
+        if settings.get_option('gui/radio/%s_station_expanded' % driver.name, False):
             self.tree.expand_row(self.model.get_path(node), False)
 
     def _remove_driver_cb(self, type, object, driver):
@@ -188,22 +180,19 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
             Connects events used in this panel
         """
 
-        self.builder.connect_signals({
-            'on_add_button_clicked': self._on_add_button_clicked,
-        })
+        self.builder.connect_signals(
+            {'on_add_button_clicked': self._on_add_button_clicked}
+        )
         self.tree.connect('row-expanded', self.on_row_expand)
         self.tree.connect('row-collapsed', self.on_collapsed)
         self.tree.connect('row-activated', self.on_row_activated)
         self.tree.connect('key-release-event', self.on_key_released)
 
-        event.add_ui_callback(self._add_driver_cb, 'station_added',
-                              self.manager)
-        event.add_ui_callback(self._remove_driver_cb, 'station_removed',
-                              self.manager)
+        event.add_ui_callback(self._add_driver_cb, 'station_added', self.manager)
+        event.add_ui_callback(self._remove_driver_cb, 'station_removed', self.manager)
 
     def _on_add_button_clicked(self, *e):
-        dialog = dialogs.MultiTextEntryDialog(self.parent,
-                                              _("Add Radio Station"))
+        dialog = dialogs.MultiTextEntryDialog(self.parent, _("Add Radio Station"))
 
         dialog.add_field(_("Name:"))
         url_field = dialog.add_field(_("URL:"))
@@ -227,6 +216,7 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
     @common.threaded
     def _do_add_playlist(self, name, uri):
         from xl import playlist, trax
+
         if playlist.is_valid_playlist(uri):
             pl = playlist.import_playlist(uri)
             pl.name = name
@@ -240,8 +230,9 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
 
     @common.idle_add()
     def _add_to_tree(self, pl):
-        self.playlist_nodes[pl] = self.model.append(self.custom,
-                                                    [self.playlist_image, pl.name, pl])
+        self.playlist_nodes[pl] = self.model.append(
+            self.custom, [self.playlist_image, pl.name, pl]
+        )
         self._load_playlist_nodes(pl)
 
     def _setup_tree(self):
@@ -258,6 +249,7 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
         text = Gtk.CellRendererText()
         if settings.get_option('gui/ellipsize_text_in_panels', False):
             from gi.repository import Pango
+
             text.set_property('ellipsize-set', True)
             text.set_property('ellipsize', Pango.EllipsizeMode.END)
         icon = Gtk.CellRendererPixbuf()
@@ -272,15 +264,17 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
         self.tree.set_model(self.model)
 
         self.track = icons.MANAGER.pixbuf_from_icon_name(
-            'audio-x-generic', Gtk.IconSize.SMALL_TOOLBAR)
+            'audio-x-generic', Gtk.IconSize.SMALL_TOOLBAR
+        )
         self.folder = icons.MANAGER.pixbuf_from_icon_name(
-            'folder', Gtk.IconSize.SMALL_TOOLBAR)
-        self.refresh_image = icons.MANAGER.pixbuf_from_icon_name(
-            'view-refresh')
+            'folder', Gtk.IconSize.SMALL_TOOLBAR
+        )
+        self.refresh_image = icons.MANAGER.pixbuf_from_icon_name('view-refresh')
 
         self.custom = self.model.append(None, [self.folder, _("Saved Stations"), None])
-        self.radio_root = self.model.append(None, [self.folder, _("Radio "
-                                                                  "Streams"), None])
+        self.radio_root = self.model.append(
+            None, [self.folder, _("Radio " "Streams"), None]
+        )
 
         scroll = Gtk.ScrolledWindow()
         scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
@@ -321,8 +315,10 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
             if paths and paths[0]:
                 iter = self.model.get_iter(paths[0])
                 item = self.model.get_value(iter, 2)
-                if isinstance(item, (xl.radio.RadioStation, xl.radio.RadioList,
-                                     xl.radio.RadioItem)):
+                if isinstance(
+                    item,
+                    (xl.radio.RadioStation, xl.radio.RadioList, xl.radio.RadioItem),
+                ):
                     if isinstance(item, xl.radio.RadioStation):
                         station = item
                     else:
@@ -332,9 +328,13 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
                         menu = station.get_menu(self)
                         menu.popup(event)
                 elif isinstance(item, xl.playlist.Playlist):
-                    Gtk.Menu.popup(self.playlist_menu, None, None, None, None, 0, event.time)
+                    Gtk.Menu.popup(
+                        self.playlist_menu, None, None, None, None, 0, event.time
+                    )
                 elif isinstance(item, playlistpanel.TrackWrapper):
-                    Gtk.Menu.popup(self.track_menu, None, None, None, None, 0, event.time)
+                    Gtk.Menu.popup(
+                        self.track_menu, None, None, None, None, 0, event.time
+                    )
             return True
 
         if event.keyval == Gdk.KEY_Left:
@@ -404,8 +404,9 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
         (tracks, playlists) = self.tree.get_drag_data(locs, False)
         # First see if they dragged any playlist files
         for new_playlist in playlists:
-            self.model.append(self.custom, [self.playlist_image,
-                                            new_playlist.name, new_playlist])
+            self.model.append(
+                self.custom, [self.playlist_image, new_playlist.name, new_playlist]
+            )
             # We are adding a completely new playlist with tracks so we save it
             self.playlist_manager.save_playlist(new_playlist, overwrite=True)
 
@@ -413,8 +414,8 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
         # name of the new playlist to add and add the tracks to it
         if len(tracks) > 0:
             dialog = dialogs.TextEntryDialog(
-                _("Enter the name you want for your new playlist"),
-                _("New Playlist"))
+                _("Enter the name you want for your new playlist"), _("New Playlist")
+            )
             result = dialog.run()
             if result == Gtk.ResponseType.OK:
                 name = dialog.get_value()
@@ -422,9 +423,10 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
                     # Create the playlist from all of the tracks
                     new_playlist = xl.playlist.Playlist(name)
                     new_playlist.extend(tracks)
-                    self.playlist_nodes[new_playlist] = self.model.append(self.custom,
-                                                                          [self.playlist_image,
-                                                                           new_playlist.name, new_playlist])
+                    self.playlist_nodes[new_playlist] = self.model.append(
+                        self.custom,
+                        [self.playlist_image, new_playlist.name, new_playlist],
+                    )
                     self.tree.expand_row(self.model.get_path(self.custom), False)
                     # We are adding a completely new playlist with tracks so we save it
                     self.playlist_manager.save_playlist(new_playlist)
@@ -470,18 +472,16 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
 
         if isinstance(object, (xl.radio.RadioList, xl.radio.RadioStation)):
             self._clear_node(iter)
-            self.load_nodes[object] = self.model.append(iter,
-                                                        [self.refresh_image, _("Loading streams..."), None])
+            self.load_nodes[object] = self.model.append(
+                iter, [self.refresh_image, _("Loading streams..."), None]
+            )
 
             self.complete_reload[object] = True
             self.tree.expand_row(self.model.get_path(iter), False)
 
     @staticmethod
     def set_station_expanded_value(station, value):
-        settings.set_option(
-            'gui/radio/%s_station_expanded' % station,
-            True,
-        )
+        settings.set_option('gui/radio/%s_station_expanded' % station, True)
 
     def on_row_expand(self, tree, iter, path):
         """
@@ -492,8 +492,9 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
         if not isinstance(driver, xl.playlist.Playlist):
             self.model.set_value(iter, 0, self.folder)
 
-        if isinstance(driver, xl.radio.RadioStation) or \
-                isinstance(driver, xl.radio.RadioList):
+        if isinstance(driver, xl.radio.RadioStation) or isinstance(
+            driver, xl.radio.RadioList
+        ):
             if not self.nodes[driver] in self.loaded_nodes:
                 self._load_station(iter, driver)
 
@@ -545,13 +546,15 @@ class RadioPanel(panel.Panel, playlistpanel.BasePlaylistPanelMixin):
         self.loaded_nodes.append(self.nodes[object])
         for item in items:
             if isinstance(item, xl.radio.RadioList):
-                node = self.model.append(self.nodes[object], [self.folder, item.name, item])
+                node = self.model.append(
+                    self.nodes[object], [self.folder, item.name, item]
+                )
                 self.nodes[item] = node
-                self.load_nodes[item] = self.model.append(node, [self.refresh_image,
-                                                                 _("Loading streams..."), None])
+                self.load_nodes[item] = self.model.append(
+                    node, [self.refresh_image, _("Loading streams..."), None]
+                )
             else:
-                self.model.append(self.nodes[object], [self.track, item.name,
-                                                       item])
+                self.model.append(self.nodes[object], [self.track, item.name, item])
 
         try:
             self.model.remove(self.load_nodes[object])

--- a/xlgui/panels.py
+++ b/xlgui/panels.py
@@ -27,15 +27,9 @@
 import logging
 
 from xl.nls import gettext as _
-from xl import (
-    providers,
-    settings
-)
+from xl import providers, settings
 
-from xlgui.widgets import (
-    menu,
-    notebook
-)
+from xlgui.widgets import menu, notebook
 from xlgui.panel import lyrics
 
 
@@ -47,19 +41,23 @@ class PanelData(object):
     __slots__ = ['tab', 'menuitem', 'panel', 'position', 'shown']
 
     def __init__(self, tab, panel, position, menuitem):
-        self.tab = tab              # Notebook tab
-        self.menuitem = menuitem    # Menuitem
-        self.panel = panel          # Panel provider
-        self.position = position    # Position in notebook
-        self.shown = True           # Whether the panel is shown
+        self.tab = tab  # Notebook tab
+        self.menuitem = menuitem  # Menuitem
+        self.panel = panel  # Panel provider
+        self.position = position  # Position in notebook
+        self.shown = True  # Whether the panel is shown
 
     @property
     def opts(self):
         return (self.shown, self.position)
 
     def __repr__(self):
-        return '<PanelData tab: %s, panel: %s, position: %s, shown: %s>' % \
-            (self.tab, self.panel, self.position, self.shown)
+        return '<PanelData tab: %s, panel: %s, position: %s, shown: %s>' % (
+            self.tab,
+            self.panel,
+            self.position,
+            self.shown,
+        )
 
 
 class PanelNotebook(notebook.SmartNotebook, providers.ProviderHandler):
@@ -82,7 +80,7 @@ class PanelNotebook(notebook.SmartNotebook, providers.ProviderHandler):
         notebook.SmartNotebook.__init__(self, vertical=True)
 
         self.exaile = exaile
-        self.panels = {}    # key: name, value: PanelData object
+        self.panels = {}  # key: name, value: PanelData object
 
         self.set_add_tab_on_empty(False)
 
@@ -97,9 +95,9 @@ class PanelNotebook(notebook.SmartNotebook, providers.ProviderHandler):
         self.view_menu = menu.ProviderMenu('panel-tab-context', None)
 
         # setup/register the view menu
-        menu.simple_menu_item('panel-menu', ['show-playing-track'], _('P_anels'),
-                              submenu=self.view_menu) \
-            .register('menubar-view-menu')
+        menu.simple_menu_item(
+            'panel-menu', ['show-playing-track'], _('P_anels'), submenu=self.view_menu
+        ).register('menubar-view-menu')
 
         providers.ProviderHandler.__init__(self, 'main-panel', simple_init=True)
 
@@ -145,15 +143,20 @@ class PanelNotebook(notebook.SmartNotebook, providers.ProviderHandler):
         tab = notebook.NotebookTab(self, panel, vertical=True)
         tab.provider = provider
 
-        item = menu.check_menu_item(provider.name, [],
-                                    panel.get_page_name(),
-                                    lambda *a: self.panels[provider.name].shown,
-                                    lambda *a: self.toggle_panel(provider.name))
+        item = menu.check_menu_item(
+            provider.name,
+            [],
+            panel.get_page_name(),
+            lambda *a: self.panels[provider.name].shown,
+            lambda *a: self.toggle_panel(provider.name),
+        )
 
         providers.register('panel-tab-context', item)
 
         self.add_tab(tab, panel)
-        self.panels[provider.name] = PanelData(tab, provider, self.get_n_pages() - 1, item)
+        self.panels[provider.name] = PanelData(
+            tab, provider, self.get_n_pages() - 1, item
+        )
 
         self.save_panel_settings()
 
@@ -216,14 +219,18 @@ class PanelNotebook(notebook.SmartNotebook, providers.ProviderHandler):
     def on_gui_loaded(self):
 
         last_selected_panel = settings.get_option(
-            'gui/last_selected_panel', 'collection')
+            'gui/last_selected_panel', 'collection'
+        )
 
-        order = settings.get_option('gui/panels',
-                                    {'collection': (True, 0),
-                                     'radio': (True, 1),
-                                     'playlists': (True, 2),
-                                     'files': (True, 3)
-                                     })
+        order = settings.get_option(
+            'gui/panels',
+            {
+                'collection': (True, 0),
+                'radio': (True, 1),
+                'playlists': (True, 2),
+                'files': (True, 3),
+            },
+        )
 
         selected_panel = None
 
@@ -260,30 +267,33 @@ def _register_builtin_panels(exaile, window):
 
     logger.info("Loading panels...")
 
-    providers.register('main-panel',
-                       collection.CollectionPanel(window,
-                                                  exaile.collection,
-                                                  'collection',
-                                                  _show_collection_empty_message=True)
-                       )
+    providers.register(
+        'main-panel',
+        collection.CollectionPanel(
+            window, exaile.collection, 'collection', _show_collection_empty_message=True
+        ),
+    )
 
-    providers.register('main-panel',
-                       radio.RadioPanel(window, exaile.collection,
-                                        exaile.radio, exaile.stations, 'radio')
-                       )
+    providers.register(
+        'main-panel',
+        radio.RadioPanel(
+            window, exaile.collection, exaile.radio, exaile.stations, 'radio'
+        ),
+    )
 
-    providers.register('main-panel',
-                       playlists.PlaylistsPanel(window,
-                                                exaile.playlists,
-                                                exaile.smart_playlists,
-                                                exaile.collection,
-                                                'playlists')
-                       )
+    providers.register(
+        'main-panel',
+        playlists.PlaylistsPanel(
+            window,
+            exaile.playlists,
+            exaile.smart_playlists,
+            exaile.collection,
+            'playlists',
+        ),
+    )
 
-    providers.register('main-panel',
-                       files.FilesPanel(window, exaile.collection, 'files')
-                       )
+    providers.register(
+        'main-panel', files.FilesPanel(window, exaile.collection, 'files')
+    )
 
-    providers.register('main-panel',
-                       lyrics.LyricsPanel(window, 'lyrics')
-                       )
+    providers.register('main-panel', lyrics.LyricsPanel(window, 'lyrics'))

--- a/xlgui/playlist_container.py
+++ b/xlgui/playlist_container.py
@@ -30,11 +30,7 @@ from gi.repository import Gtk
 import re
 from datetime import datetime
 from xl.nls import gettext as _
-from xl import (
-    event,
-    providers,
-    settings,
-)
+from xl import event, providers, settings
 from xl.playlist import Playlist, PlaylistManager
 from xlgui.widgets import menu
 from xlgui.accelerators import Accelerator
@@ -42,12 +38,13 @@ from xlgui.widgets.notebook import (
     SmartNotebook,
     NotebookTab,
     NotebookAction,
-    NotebookActionService
+    NotebookActionService,
 )
 from xlgui.widgets.playlist import PlaylistPage
 from xlgui.widgets.queue import QueuePage
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -56,6 +53,7 @@ class NewPlaylistNotebookAction(NotebookAction, Gtk.Button):
         Playlist notebook action which allows for creating new playlists
         regularly as well as by dropping tracks, files and directories on it
     """
+
     __gsignals__ = {'clicked': 'override'}
     name = 'new-playlist'
     position = Gtk.PackType.START
@@ -64,8 +62,7 @@ class NewPlaylistNotebookAction(NotebookAction, Gtk.Button):
         NotebookAction.__init__(self, notebook)
         Gtk.Button.__init__(self)
 
-        self.set_image(Gtk.Image.new_from_icon_name('tab-new',
-                                                    Gtk.IconSize.BUTTON))
+        self.set_image(Gtk.Image.new_from_icon_name('tab-new', Gtk.IconSize.BUTTON))
         self.set_relief(Gtk.ReliefStyle.NONE)
 
         self.__default_tooltip_text = _('New Playlist')
@@ -105,11 +102,11 @@ class NewPlaylistNotebookAction(NotebookAction, Gtk.Button):
         # Forward signal to the PlaylistView in the newly added tab
         tab.page.view.emit('drag-data-received', context, x, y, selection, info, time)
 
+
 providers.register('playlist-notebook-actions', NewPlaylistNotebookAction)
 
 
 class PlaylistNotebook(SmartNotebook):
-
     def __init__(self, manager_name, player, hotkey):
         SmartNotebook.__init__(self)
 
@@ -126,9 +123,13 @@ class PlaylistNotebook(SmartNotebook):
         item = menu.simple_separator('clear-sep', [])
         item.register('playlist-closed-tab-menu', self)
 
-        item = menu.simple_menu_item('clear-history', ['clear-sep'],
-                                     _("_Clear Tab History"), 'edit-clear-all',
-                                     self.clear_closed_tabs)
+        item = menu.simple_menu_item(
+            'clear-history',
+            ['clear-sep'],
+            _("_Clear Tab History"),
+            'edit-clear-all',
+            self.clear_closed_tabs,
+        )
         item.register('playlist-closed-tab-menu', self)
 
         # Simple factory for 'Recently Closed Tabs' MenuItem
@@ -149,15 +150,16 @@ class PlaylistNotebook(SmartNotebook):
         item.register('playlist-tab-context-menu')
 
         # Add menu to View menu
-        #item = menu.MenuItem('tab-history', factory, ['clear-playlist'])
-        #providers.register('menubar-view-menu', item)
+        # item = menu.MenuItem('tab-history', factory, ['clear-playlist'])
+        # providers.register('menubar-view-menu', item)
 
         # setup notebook actions
         self.actions = NotebookActionService(self, 'playlist-notebook-actions')
 
         # Add hotkey
-        self.accelerator = Accelerator(hotkey, _('Restore closed tab'),
-                                       lambda *x: self.restore_closed_tab(0))
+        self.accelerator = Accelerator(
+            hotkey, _('Restore closed tab'), lambda *x: self.restore_closed_tab(0)
+        )
         providers.register('mainwindow-accelerators', self.accelerator)
 
         # Load saved tabs
@@ -167,7 +169,7 @@ class PlaylistNotebook(SmartNotebook):
             'left': Gtk.PositionType.LEFT,
             'right': Gtk.PositionType.RIGHT,
             'top': Gtk.PositionType.TOP,
-            'bottom': Gtk.PositionType.BOTTOM
+            'bottom': Gtk.PositionType.BOTTOM,
         }
 
         self.connect('page-added', self.on_page_added)
@@ -204,15 +206,15 @@ class PlaylistNotebook(SmartNotebook):
             name = page.get_page_name().decode('utf-8', errors='replace')
             name_parts = [
                 # 'Playlist 99' => 'Playlist '
-                name[0:len(default_name_parts[0])],
+                name[0 : len(default_name_parts[0])],
                 # 'Playlist 99' => ''
-                name[len(name) - len(default_name_parts[1]):]
+                name[len(name) - len(default_name_parts[1]) :],
             ]
 
             # Playlist name matches our format
             if name_parts == default_name_parts:
                 # Extract possible number between name parts
-                number = name[len(name_parts[0]):len(name) - len(name_parts[1])]
+                number = name[len(name_parts[0]) : len(name) - len(name_parts[1])]
 
                 try:
                     number = int(number)
@@ -246,8 +248,7 @@ class PlaylistNotebook(SmartNotebook):
         names.sort()
         # holds the order#'s of the already added tabs
         added_tabs = {}
-        name_re = re.compile(
-            r'^order(?P<tab>\d+)\.(?P<tag>[^.]*)\.(?P<name>.*)$')
+        name_re = re.compile(r'^order(?P<tab>\d+)\.(?P<tag>[^.]*)\.(?P<name>.*)$')
         for i, name in enumerate(names):
             match = name_re.match(name)
             if not match or not match.group('tab') or not match.group('name'):
@@ -255,8 +256,12 @@ class PlaylistNotebook(SmartNotebook):
                 continue
 
             logger.debug("Adding playlist %d: %s", i, name)
-            logger.debug("Tab:%s; Tag:%s; Name:%s", match.group('tab'),
-                         match.group('tag'), match.group('name'))
+            logger.debug(
+                "Tab:%s; Tag:%s; Name:%s",
+                match.group('tab'),
+                match.group('tag'),
+                match.group('name'),
+            )
             pl = self.tab_manager.get_playlist(name)
             pl.name = match.group('name')
 
@@ -347,8 +352,9 @@ class PlaylistNotebook(SmartNotebook):
         # closed tab history
         if not self._moving_tab:
 
-            if settings.get_option('gui/save_closed_tabs', True) and \
-                isinstance(child, PlaylistPage):
+            if settings.get_option('gui/save_closed_tabs', True) and isinstance(
+                child, PlaylistPage
+            ):
                 self.save_closed_tab(child.playlist)
 
             # Destroy it unless it's the queue page
@@ -372,29 +378,38 @@ class PlaylistNotebook(SmartNotebook):
         def factory(menu_, parent, context):
             item = None
 
-            dt = (datetime.now() - close_time)
+            dt = datetime.now() - close_time
             if dt.seconds > 60:
-                display_name = _('{playlist_name} ({track_count} tracks, closed {minutes} min ago)').format(
+                display_name = _(
+                    '{playlist_name} ({track_count} tracks, closed {minutes} min ago)'
+                ).format(
                     playlist_name=playlist.name,
                     track_count=len(playlist),
-                    minutes=dt.seconds // 60
+                    minutes=dt.seconds // 60,
                 )
             else:
-                display_name = _('{playlist_name} ({track_count} tracks, closed {seconds} sec ago)').format(
+                display_name = _(
+                    '{playlist_name} ({track_count} tracks, closed {seconds} sec ago)'
+                ).format(
                     playlist_name=playlist.name,
                     track_count=len(playlist),
-                    seconds=dt.seconds
+                    seconds=dt.seconds,
                 )
             item = Gtk.ImageMenuItem.new_with_mnemonic(display_name)
-            item.set_image(Gtk.Image.new_from_icon_name('music-library', Gtk.IconSize.MENU))
+            item.set_image(
+                Gtk.Image.new_from_icon_name('music-library', Gtk.IconSize.MENU)
+            )
 
             # Add accelerator to top item
             if self.tab_history[0][1].name == item_name:
                 key, mods = Gtk.accelerator_parse(self.accelerator.keys)
-                item.add_accelerator('activate', menu.FAKEACCELGROUP, key, mods,
-                                     Gtk.AccelFlags.VISIBLE)
+                item.add_accelerator(
+                    'activate', menu.FAKEACCELGROUP, key, mods, Gtk.AccelFlags.VISIBLE
+                )
 
-            item.connect('activate', lambda w: self.restore_closed_tab(item_name=item_name))
+            item.connect(
+                'activate', lambda w: self.restore_closed_tab(item_name=item_name)
+            )
 
             return item
 
@@ -496,8 +511,12 @@ class PlaylistContainer(Gtk.Box):
         Gtk.Box.__init__(self)
 
         self.notebooks = []
-        self.notebooks.append(PlaylistNotebook(manager_name, player, '<Primary><Shift>t'))
-        self.notebooks.append(PlaylistNotebook(manager_name + '2', player, '<Primary><Alt>t'))
+        self.notebooks.append(
+            PlaylistNotebook(manager_name, player, '<Primary><Shift>t')
+        )
+        self.notebooks.append(
+            PlaylistNotebook(manager_name + '2', player, '<Primary><Alt>t')
+        )
 
         self.notebooks[1].set_add_tab_on_empty(False)
 
@@ -519,17 +538,25 @@ class PlaylistContainer(Gtk.Box):
             self.notebooks[0].add_default_tab()
 
         # menu item
-        item = menu.simple_menu_item('move-tab', [], _('_Move to Other View'), None,
-                                     lambda w, n, p, c: self._move_tab(p.tab),
-                                     condition_fn=lambda n, p, c: True if p.tab.notebook in self.notebooks else False)
+        item = menu.simple_menu_item(
+            'move-tab',
+            [],
+            _('_Move to Other View'),
+            None,
+            lambda w, n, p, c: self._move_tab(p.tab),
+            condition_fn=lambda n, p, c: True
+            if p.tab.notebook in self.notebooks
+            else False,
+        )
         providers.register('playlist-tab-context-menu', item)
         providers.register('queue-tab-context', item)
 
         # connect events
         for notebook in self.notebooks:
             notebook.connect('page-reordered', self.on_page_reordered)
-            notebook.connect_after('page-removed',
-                                   lambda *a: self._update_notebook_display())
+            notebook.connect_after(
+                'page-removed', lambda *a: self._update_notebook_display()
+            )
 
         self._update_notebook_display()
 
@@ -613,8 +640,10 @@ class PlaylistContainer(Gtk.Box):
         self.get_current_tab().focus()
 
     def on_page_reordered(self, notebook, child, page_number):
-        if self.queuepage.tab.notebook is notebook and \
-                notebook.page_num(self.queuepage) != 0:
+        if (
+            self.queuepage.tab.notebook is notebook
+            and notebook.page_num(self.queuepage) != 0
+        ):
             notebook.reorder_child(self.queuepage, 0)
 
     def save_current_tabs(self):

--- a/xlgui/preferences/__init__.py
+++ b/xlgui/preferences/__init__.py
@@ -43,7 +43,7 @@ from . import (
     playback,
     playlists,
     plugin,
-    widgets
+    widgets,
 )
 
 logger = logging.getLogger(__name__)
@@ -54,8 +54,7 @@ class PreferencesDialog(object):
         Preferences Dialog
     """
 
-    PAGES = (playlists, appearance, playback,
-             collection, cover, lyrics)
+    PAGES = (playlists, appearance, playback, collection, cover, lyrics)
     PREFERENCES_DIALOG = None
 
     def __init__(self, parent, main):
@@ -74,7 +73,8 @@ class PreferencesDialog(object):
         self.builder = Gtk.Builder()
         self.builder.set_translation_domain('exaile')
         self.builder.add_from_file(
-            xdg.get_data_path('ui', 'preferences', 'preferences_dialog.ui'))
+            xdg.get_data_path('ui', 'preferences', 'preferences_dialog.ui')
+        )
         self.builder.connect_signals(self)
 
         self.window = self.builder.get_object('PreferencesDialog')
@@ -91,7 +91,8 @@ class PreferencesDialog(object):
         title_cellrenderer.props.ypad = 3
 
         self.default_icon = icons.MANAGER.pixbuf_from_icon_name(
-            'document-properties', Gtk.IconSize.MENU)
+            'document-properties', Gtk.IconSize.MENU
+        )
 
         # sets up the default panes
         for page in self.PAGES:
@@ -102,15 +103,16 @@ class PreferencesDialog(object):
                     icon = page.icon
                 else:
                     icon = icons.MANAGER.pixbuf_from_icon_name(
-                        page.icon, Gtk.IconSize.MENU)
+                        page.icon, Gtk.IconSize.MENU
+                    )
 
             self.model.append(None, [page, page.name, icon])
 
         # Use icon name to allow overrides
         plugin_icon = icons.MANAGER.pixbuf_from_icon_name(
-            'extension', Gtk.IconSize.MENU)
-        self.plug_root = self.model.append(None,
-                                           [plugin, _('Plugins'), plugin_icon])
+            'extension', Gtk.IconSize.MENU
+        )
+        self.plug_root = self.model.append(None, [plugin, _('Plugins'), plugin_icon])
 
         self._load_plugin_pages()
 
@@ -118,8 +120,8 @@ class PreferencesDialog(object):
         selection.connect('changed', self.switch_pane)
         # Disallow selection on rows with no widget to show
         selection.set_select_function(
-            (lambda sel, model, path, issel, dat: model[path][0] is not None),
-            None)
+            (lambda sel, model, path, issel, dat: model[path][0] is not None), None
+        )
 
         GLib.idle_add(selection.select_path, (0,))
 
@@ -146,12 +148,12 @@ class PreferencesDialog(object):
                     icon = page.icon
                 else:
                     icon = icons.MANAGER.pixbuf_from_icon_name(
-                        page.icon, Gtk.IconSize.MENU)
+                        page.icon, Gtk.IconSize.MENU
+                    )
 
             self.model.append(self.plug_root, [page, page.name, icon])
 
-        GLib.idle_add(self.tree.expand_row,
-                      self.model.get_path(self.plug_root), False)
+        GLib.idle_add(self.tree.expand_row, self.model.get_path(self.plug_root), False)
 
     def _clear_children(self, node):
         remove = []
@@ -238,8 +240,7 @@ class PreferencesDialog(object):
             try:
                 klass = getattr(page, attr)
 
-                if inspect.isclass(klass) and \
-                        issubclass(klass, widgets.Preference):
+                if inspect.isclass(klass) and issubclass(klass, widgets.Preference):
                     widget = builder.get_object(klass.name)
 
                     if not widget:
@@ -248,7 +249,8 @@ class PreferencesDialog(object):
 
                     if issubclass(klass, widgets.Conditional):
                         klass.condition_widget = builder.get_object(
-                            klass.condition_preference_name)
+                            klass.condition_preference_name
+                        )
                     elif issubclass(klass, widgets.MultiConditional):
                         for name in klass.condition_preference_names:
                             klass.condition_widgets[name] = builder.get_object(name)
@@ -273,5 +275,6 @@ class PreferencesDialog(object):
         else:
             PreferencesDialog.PREFERENCES_DIALOG = self
             self.window.show_all()
+
 
 # vim: et sts=4 sw=4

--- a/xlgui/preferences/appearance.py
+++ b/xlgui/preferences/appearance.py
@@ -75,6 +75,7 @@ class GtkDarkThemePreference(widgets.CheckPreference):
     default = False
     name = 'gui/gtk_dark_hint'
 
+
 class UseAlphaTransparencyPreference(widgets.CheckPreference):
     default = False
     name = 'gui/use_alpha'
@@ -99,6 +100,7 @@ class TrackCountsPreference(widgets.CheckPreference):
         return_value = widgets.CheckPreference.apply(self, value)
 
         import xlgui
+
         xlgui.get_controller().get_panel('collection').load_tree()
 
         return return_value
@@ -112,7 +114,9 @@ class UseTrayPreference(widgets.CheckPreference, widgets.Conditional):
         widgets.CheckPreference.__init__(self, preferences, widget)
         widgets.Conditional.__init__(self)
         if not tray.is_supported():
-            self.widget.set_tooltip_text(_("Tray icons are not supported on your platform"))
+            self.widget.set_tooltip_text(
+                _("Tray icons are not supported on your platform")
+            )
 
     def on_check_condition(self):
         return tray.is_supported()
@@ -149,6 +153,7 @@ class TabPlacementPreference(widgets.ComboPreference):
 
     def __init__(self, preferences, widget):
         widgets.ComboPreference.__init__(self, preferences, widget)
+
 
 """
 class ProgressBarTextFormatPreference(widgets.ComboEntryPreference):

--- a/xlgui/preferences/collection.py
+++ b/xlgui/preferences/collection.py
@@ -53,6 +53,7 @@ class CollectionStripArtistPreference(widgets.ListPreference):
 
     def _populate_popup_cb(self, entry, menu):
         from gi.repository import Gtk
+
         entry = Gtk.MenuItem.new_with_mnemonic(_('Reset to _Defaults'))
         entry.connect('activate', self._reset_to_defaults_cb)
         entry.show()
@@ -70,5 +71,6 @@ class CollectionStripArtistPreference(widgets.ListPreference):
 class FileBasedCompilationsPreference(widgets.CheckPreference):
     default = True
     name = 'collection/file_based_compilations'
+
 
 # vim:ts=4 et sw=4

--- a/xlgui/preferences/cover.py
+++ b/xlgui/preferences/cover.py
@@ -24,11 +24,7 @@
 # do so. If you do not wish to do so, delete this exception statement
 # from your version.
 
-from xl import (
-    covers,
-    settings,
-    xdg
-)
+from xl import covers, settings, xdg
 from xl.nls import gettext as _
 from xlgui.preferences import widgets
 
@@ -66,8 +62,7 @@ class LocalFilePreferredNamesPreference(widgets.Preference, widgets.CheckConditi
         """
             Converts the list to a string value
         """
-        self.widget.set_text(', '.join(settings.get_option(
-            self.name, self.default)))
+        self.widget.set_text(', '.join(settings.get_option(self.name, self.default)))
 
 
 class CoverOrderPreference(widgets.OrderListPreference):
@@ -75,6 +70,7 @@ class CoverOrderPreference(widgets.OrderListPreference):
         This little preference item shows kind of a complicated preference
         widget in action.  The defaults are dynamic.
     """
+
     name = 'covers/preferred_order'
 
     def __init__(self, preferences, widget):
@@ -88,8 +84,7 @@ class CoverOrderPreference(widgets.OrderListPreference):
 
     def apply(self):
         if widgets.OrderListPreference.apply(self):
-            covers.MANAGER.set_preferred_order(
-                self._get_value())
+            covers.MANAGER.set_preferred_order(self._get_value())
         return True
 
 

--- a/xlgui/preferences/playback.py
+++ b/xlgui/preferences/playback.py
@@ -173,6 +173,7 @@ class EngineConditional(widgets.Conditional):
     """
         True if the specified engine is selected
     """
+
     condition_preference_name = 'player/engine'
     conditional_engine = ''
 
@@ -250,5 +251,6 @@ class CrossfadeDurationPreference(widgets.SpinPreference, EngineConditional):
     def __init__(self, preferences, widget):
         widgets.SpinPreference.__init__(self, preferences, widget)
         EngineConditional.__init__(self)
+
 
 # vim: et sts=4 sw=4

--- a/xlgui/preferences/playlists.py
+++ b/xlgui/preferences/playlists.py
@@ -57,6 +57,7 @@ class EnqueueTrackByDefaultPreference(widgets.CheckPreference):
     default = False
     name = 'playlist/enqueue_by_default'
 
+
 # FIXME: Is this still relevant?
 # class QueueSavePreferences(widgets.CheckPreference):
 #    default = True

--- a/xlgui/preferences/plugin.py
+++ b/xlgui/preferences/plugin.py
@@ -28,16 +28,12 @@ from gi.repository import GLib
 from gi.repository import Gtk
 
 import xl.unicode
-from xl import (
-    event,
-    main,
-    plugins,
-    xdg
-)
+from xl import event, main, plugins, xdg
 from xlgui.widgets import common, dialogs
 from xl.nls import gettext as _, ngettext
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 name = _('Plugins')
@@ -58,8 +54,7 @@ class PluginManager(object):
         self.plugins = main.exaile().plugins
 
         self.message = dialogs.MessageBar(
-            parent=builder.get_object('preferences_pane'),
-            buttons=Gtk.ButtonsType.CLOSE
+            parent=builder.get_object('preferences_pane'), buttons=Gtk.ButtonsType.CLOSE
         )
         self.message.connect('response', self.on_messagebar_response)
 
@@ -70,8 +65,7 @@ class PluginManager(object):
             reload_cellrenderer = common.ClickableCellRendererPixbuf()
             reload_cellrenderer.props.icon_name = 'view-refresh'
             reload_cellrenderer.props.xalign = 1
-            reload_cellrenderer.connect('clicked',
-                                        self.on_reload_cellrenderer_clicked)
+            reload_cellrenderer.connect('clicked', self.on_reload_cellrenderer_clicked)
 
             name_column = builder.get_object('name_column')
             name_column.pack_start(reload_cellrenderer, True)
@@ -93,8 +87,12 @@ class PluginManager(object):
         selection.connect('changed', self.on_selection_changed)
         self._load_plugin_list()
 
-        self._evt_rm1 = event.add_ui_callback(self.on_plugin_event, 'plugin_enabled', None, True)
-        self._evt_rm2 = event.add_ui_callback(self.on_plugin_event, 'plugin_disabled', None, False)
+        self._evt_rm1 = event.add_ui_callback(
+            self.on_plugin_event, 'plugin_enabled', None, True
+        )
+        self._evt_rm2 = event.add_ui_callback(
+            self.on_plugin_event, 'plugin_disabled', None, False
+        )
         self.list.connect('destroy', self.on_destroy)
 
         GLib.idle_add(selection.select_path, (0,))
@@ -131,8 +129,16 @@ class PluginManager(object):
                 icon = None
 
             enabled = plugin_name in self.plugins.enabled_plugins
-            plugin_data = (plugin_name, info['Name'], str(info['Version']),
-                           enabled, icon, broken, compatible, True)
+            plugin_data = (
+                plugin_name,
+                info['Name'],
+                str(info['Version']),
+                enabled,
+                icon,
+                broken,
+                compatible,
+                True,
+            )
 
             if 'Category' in info:
                 cat = plugins_dict.setdefault(info['Category'], [])
@@ -147,12 +153,15 @@ class PluginManager(object):
             if item[0] == uncategorized:
                 return '\xff' * 10
             return xl.unicode.strxfrm(item[0])
+
         plugins_dict = sorted(plugins_dict.iteritems(), key=categorykey)
 
         for category, plugins_list in plugins_dict:
             plugins_list.sort(key=lambda x: xl.unicode.strxfrm(x[1]))
 
-            it = self.model.append(None, (None, category, '', False, '', False, True, False))
+            it = self.model.append(
+                None, (None, category, '', False, '', False, True, False)
+            )
 
             for plugin_data in plugins_list:
                 pit = self.model.append(it, plugin_data)
@@ -165,12 +174,10 @@ class PluginManager(object):
         self.list.expand_all()
 
         if failed_list:
-            self.message.show_error(_('Could not load plugin info!'),
-                                    ngettext(
-                'Failed plugin: %s',
-                'Failed plugins: %s',
-                len(failed_list)
-            ) % ', '.join(failed_list)
+            self.message.show_error(
+                _('Could not load plugin info!'),
+                ngettext('Failed plugin: %s', 'Failed plugins: %s', len(failed_list))
+                % ', '.join(failed_list),
             )
 
     def on_destroy(self, widget):
@@ -219,12 +226,15 @@ class PluginManager(object):
             Shows a dialog allowing the user to choose a plugin to install
             from the filesystem
         """
-        dialog = Gtk.FileChooserDialog(_('Choose a Plugin'),
-                                       self.preferences.parent,
-                                       buttons=(
-            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-            Gtk.STOCK_ADD, Gtk.ResponseType.OK
-        )
+        dialog = Gtk.FileChooserDialog(
+            _('Choose a Plugin'),
+            self.preferences.parent,
+            buttons=(
+                Gtk.STOCK_CANCEL,
+                Gtk.ResponseType.CANCEL,
+                Gtk.STOCK_ADD,
+                Gtk.ResponseType.OK,
+            ),
         )
 
         filter = Gtk.FileFilter()
@@ -246,8 +256,7 @@ class PluginManager(object):
             try:
                 self.plugins.install_plugin(dialog.get_filename())
             except plugins.InvalidPluginError as e:
-                self.message.show_error(
-                    _('Plugin file installation failed!'), str(e))
+                self.message.show_error(_('Plugin file installation failed!'), str(e))
 
                 return
 
@@ -273,10 +282,11 @@ class PluginManager(object):
 
         self.author_label.set_label(",\n".join(info['Authors']))
 
-        self.description.get_buffer().set_text(
-            info['Description'].replace(r'\n', "\n"))
+        self.description.get_buffer().set_text(info['Description'].replace(r'\n', "\n"))
 
-        self.name_label.set_markup("<b>%s</b> <small>%s</small>" % (info['Name'], info['Version']))
+        self.name_label.set_markup(
+            "<b>%s</b> <small>%s</small>" % (info['Name'], info['Version'])
+        )
 
     def on_enabled_cellrenderer_toggled(self, cellrenderer, path):
         """
@@ -306,8 +316,7 @@ class PluginManager(object):
 
     def on_plugin_event(self, evtname, obj, plugin_name, enabled):
 
-        if hasattr(self.plugins.loaded_plugins[plugin_name],
-                   'get_preferences_pane'):
+        if hasattr(self.plugins.loaded_plugins[plugin_name], 'get_preferences_pane'):
             self.preferences._load_plugin_pages()
 
         path = self.plugin_to_path[plugin_name]

--- a/xlgui/preferences/widgets.py
+++ b/xlgui/preferences/widgets.py
@@ -532,8 +532,8 @@ class SelectionListPreference(Preference):
 
         __gtype_name__ = 'InternalWidget'
 
-        model, tree, toggle_renderer, text_renderer, enabled_column, \
-            title_column, = GtkTemplate.Child.widgets(6)
+        (model, tree, toggle_renderer, text_renderer, enabled_column, \
+            title_column,) = GtkTemplate.Child.widgets(6)
         selectionlp = None
 
         def __init__(self, preference):

--- a/xlgui/preferences/widgets.py
+++ b/xlgui/preferences/widgets.py
@@ -46,6 +46,7 @@ class Preference(object):
     """
         Representing a Gtk.Entry preferences item
     """
+
     default = ''
     restart_required = False
 
@@ -66,13 +67,16 @@ class Preference(object):
                 parent=preferences.builder.get_object('preferences_box'),
                 type=Gtk.MessageType.QUESTION,
                 buttons=Gtk.ButtonsType.CLOSE,
-                text=_('Restart Exaile?'))
+                text=_('Restart Exaile?'),
+            )
             self.message.set_secondary_text(
-                _('A restart is required for this change to take effect.'))
+                _('A restart is required for this change to take effect.')
+            )
 
             button = self.message.add_button(_('Restart'), Gtk.ResponseType.ACCEPT)
-            button.set_image(Gtk.Image.new_from_icon_name(
-                'view-refresh', Gtk.IconSize.BUTTON))
+            button.set_image(
+                Gtk.Image.new_from_icon_name('view-refresh', Gtk.IconSize.BUTTON)
+            )
 
             self.message.connect('response', self.on_message_response)
 
@@ -86,13 +90,15 @@ class Preference(object):
         """
             Sets up the function to be called when this preference is changed
         """
-        self.widget.connect('focus-out-event',
-                            self.change, self.name, self._get_value())
+        self.widget.connect(
+            'focus-out-event', self.change, self.name, self._get_value()
+        )
 
         try:
-            self.widget.connect('activate',
-                                lambda *e: self.change(self.widget, None, self.name,
-                                                       self._get_value()))
+            self.widget.connect(
+                'activate',
+                lambda *e: self.change(self.widget, None, self.name, self._get_value()),
+            )
         except TypeError:
             pass
 
@@ -109,8 +115,7 @@ class Preference(object):
         if not self.widget:
             logger.error("Widget not found: %s", self.name)
             return
-        self.widget.set_text(str(settings.get_option(
-            self.name, self.default)))
+        self.widget.set_text(str(settings.get_option(self.name, self.default)))
 
     def apply(self, value=None):
         """
@@ -165,13 +170,15 @@ class Conditional(object):
         Allows for reactions on changes
         of other preference items
     """
+
     condition_preference_name = ''
     condition_widget = None
 
     def __init__(self):
         event.add_ui_callback(self.on_option_set, 'option_set')
-        GLib.idle_add(self.on_option_set,
-                      'option_set', settings, self.condition_preference_name)
+        GLib.idle_add(
+            self.on_option_set, 'option_set', settings, self.condition_preference_name
+        )
 
     def get_condition_value(self):
         '''
@@ -237,13 +244,18 @@ class MultiConditional(object):
     """
         Allows for reactions on changes of multiple preference items
     """
+
     condition_preference_names = []
     condition_widgets = {}
 
     def __init__(self):
         event.add_ui_callback(self.on_option_set, 'option_set')
-        GLib.idle_add(self.on_option_set,
-                      'option_set', settings, self.condition_preference_names[0])
+        GLib.idle_add(
+            self.on_option_set,
+            'option_set',
+            settings,
+            self.condition_preference_names[0],
+        )
 
     def get_condition_value(self, name):
         '''
@@ -321,16 +333,15 @@ class HashedPreference(Preference):
         Options:
         * type (Which hashfunction to use, default: md5)
     """
+
     type = 'md5'
 
     def __init__(self, preferences, widget):
         Preference.__init__(self, preferences, widget)
 
         self.widget.set_visibility(True)
-        self._delete_text_id = self.widget.connect('delete-text',
-                                                   self.on_delete_text)
-        self._insert_text_id = self.widget.connect('insert-text',
-                                                   self.on_insert_text)
+        self._delete_text_id = self.widget.connect('delete-text', self.on_delete_text)
+        self._insert_text_id = self.widget.connect('insert-text', self.on_insert_text)
 
     def _setup_change(self):
         """
@@ -342,8 +353,7 @@ class HashedPreference(Preference):
         """
             Determines if changes are to be expected
         """
-        if self._delete_text_id is None and \
-           self._insert_text_id is None:
+        if self._delete_text_id is None and self._insert_text_id is None:
             return True
 
         return False
@@ -372,10 +382,8 @@ class HashedPreference(Preference):
 
         self.widget.set_text(value)
         self.widget.set_visibility(True)
-        self._delete_text_id = self.widget.connect('delete-text',
-                                                   self.on_delete_text)
-        self._insert_text_id = self.widget.connect('insert-text',
-                                                   self.on_insert_text)
+        self._delete_text_id = self.widget.connect('delete-text', self.on_delete_text)
+        self._insert_text_id = self.widget.connect('insert-text', self.on_insert_text)
 
         return True
 
@@ -413,8 +421,7 @@ class CheckPreference(Preference):
         Preference.__init__(self, preferences, widget)
 
     def _setup_change(self):
-        self.widget.connect('toggled',
-                            self.change)
+        self.widget.connect('toggled', self.change)
 
     def _set_value(self):
         self.widget.set_active(settings.get_option(self.name, self.default))
@@ -497,6 +504,7 @@ class SelectionListPreference(Preference):
         * items: list of :class:`SelectionListPreference.Item` objects
         * default: list of item ids
     """
+
     class Item(object):
         """
             Convenience class for preference item description
@@ -523,8 +531,7 @@ class SelectionListPreference(Preference):
         description = property(lambda self: self.__description)
         fixed = property(lambda self: self.__fixed)
 
-    @GtkTemplate('ui', 'preferences', 'widgets',
-                 'selection_list_preference.ui')
+    @GtkTemplate('ui', 'preferences', 'widgets', 'selection_list_preference.ui')
     class InternalWidget(Gtk.ScrolledWindow):
         """
             Internal class for making GtkTemplate work with subclassing
@@ -532,8 +539,14 @@ class SelectionListPreference(Preference):
 
         __gtype_name__ = 'InternalWidget'
 
-        (model, tree, toggle_renderer, text_renderer, enabled_column, \
-            title_column,) = GtkTemplate.Child.widgets(6)
+        (
+            model,
+            tree,
+            toggle_renderer,
+            text_renderer,
+            enabled_column,
+            title_column,
+        ) = GtkTemplate.Child.widgets(6)
         selectionlp = None
 
         def __init__(self, preference):
@@ -544,19 +557,21 @@ class SelectionListPreference(Preference):
             self.tree.enable_model_drag_source(
                 Gdk.ModifierType.BUTTON1_MASK,
                 [('GTK_TREE_MODEL_ROW', Gtk.TargetFlags.SAME_WIDGET, 0)],
-                Gdk.DragAction.MOVE
+                Gdk.DragAction.MOVE,
             )
             self.tree.enable_model_drag_dest(
                 [('GTK_TREE_MODEL_ROW', Gtk.TargetFlags.SAME_WIDGET, 0)],
-                Gdk.DragAction.MOVE
+                Gdk.DragAction.MOVE,
             )
             self.tree.connect('drag-end', self.selectionlp.change)
 
-            self.enabled_column.set_cell_data_func(self.toggle_renderer,
-                                                   self.enabled_data_function)
+            self.enabled_column.set_cell_data_func(
+                self.toggle_renderer, self.enabled_data_function
+            )
 
-            self.title_column.set_cell_data_func(self.text_renderer,
-                                                 self.title_data_function)
+            self.title_column.set_cell_data_func(
+                self.text_renderer, self.title_data_function
+            )
 
         @GtkTemplate.Callback
         def on_row_activated(self, tree, path, column):
@@ -677,11 +692,11 @@ class SelectionListPreference(Preference):
             return
 
         # Filter out invalid items
-        selected_items = [item for item in selected_items
-                          if item in available_items]
+        selected_items = [item for item in selected_items if item in available_items]
         # Cut out unselected items
-        unselected_items = [item for item in available_items
-                            if item not in selected_items]
+        unselected_items = [
+            item for item in available_items if item not in selected_items
+        ]
         # Move unselected items to the end
         items = selected_items + unselected_items
         new_order = [available_items.index(item) for item in items]
@@ -843,6 +858,7 @@ class ListPreference(Preference):
         # shlex is broken with unicode, so we feed it UTF-8 and decode
         # afterwards.
         import shlex
+
         values = shlex.split(self.widget.get_text())
         values = [unicode(value, 'utf-8') for value in values]
         return values
@@ -892,7 +908,6 @@ class FloatPreference(Preference):
 
 
 class IntPreference(FloatPreference):
-
     def _get_value(self):
         return int(self.widget.get_text())
 
@@ -1064,8 +1079,7 @@ class ComboEntryPreference(Preference):
             Sets up the function to be called
             when this preference is changed
         """
-        self.widget.connect('changed', self.change, self.name,
-                            self._get_value())
+        self.widget.connect('changed', self.change, self.name, self._get_value())
 
     def _set_value(self):
         """
@@ -1115,13 +1129,14 @@ class ComboEntryPreference(Preference):
             if match[:i] and match[:i] == text[match_pos:]:
                 # Delete halfway typed text
                 self.widget.get_child().delete_text(
-                    match_pos, match_pos + len(match[:i]))
+                    match_pos, match_pos + len(match[:i])
+                )
                 # Insert match at matched position
-                self.widget.get_child().insert_text(
-                    match, match_pos)
+                self.widget.get_child().insert_text(match, match_pos)
                 # Update cursor position
                 self.widget.get_child().set_position(match_pos + len(match))
 
         return True
+
 
 # vim: et sts=4 sw=4

--- a/xlgui/progress.py
+++ b/xlgui/progress.py
@@ -41,8 +41,7 @@ class ProgressMonitor(Gtk.Box):
 
     __gtype_name__ = 'ProgressMonitor'
 
-    label,          \
-        progressbar = GtkTemplate.Child.widgets(2)
+    label, progressbar = GtkTemplate.Child.widgets(2)
 
     def __init__(self, manager, thread, description, image=None):
         """
@@ -70,8 +69,9 @@ class ProgressMonitor(Gtk.Box):
         self.show_all()
         GLib.timeout_add(100, self.pulsate_progress)
 
-        self.progress_update_id = self.thread.connect('progress-update',
-                                                      self.on_progress_update)
+        self.progress_update_id = self.thread.connect(
+            'progress-update', self.on_progress_update
+        )
         self.done_id = self.thread.connect('done', self.on_done)
         self.thread.start()
 

--- a/xlgui/properties.py
+++ b/xlgui/properties.py
@@ -41,23 +41,18 @@ from gi.repository import Pango
 
 from xl.nls import gettext as _
 from xl.metadata import CoverImage
-from xl import (
-    common,
-    settings,
-    trax,
-    xdg
-)
+from xl import common, settings, trax, xdg
 
 from xlgui.widgets import dialogs
 from xlgui.guiutil import GtkTemplate
 from xl.metadata.tags import tag_data, get_default_tagdata
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
 class TrackPropertiesDialog(GObject.GObject):
-
     def __init__(self, parent, tracks, current_position=0, with_extras=False):
         """
             :param parent: the parent window for modal operation
@@ -84,7 +79,7 @@ class TrackPropertiesDialog(GObject.GObject):
 
         self.message = dialogs.MessageBar(
             parent=self.builder.get_object('main_content'),
-            buttons=Gtk.ButtonsType.CLOSE
+            buttons=Gtk.ButtonsType.CLOSE,
         )
 
         self.remove_tag_button = self.builder.get_object('remove_tag_button')
@@ -120,7 +115,7 @@ class TrackPropertiesDialog(GObject.GObject):
             'comment',
             '__startoffset',
             '__stopoffset',
-            'lyrics'
+            'lyrics',
         ]
 
         self.def_tags = OrderedDict([(tag, tag_data[tag]) for tag in def_tags])
@@ -142,23 +137,11 @@ class TrackPropertiesDialog(GObject.GObject):
         tag_type = tag_info.type
 
         if tag_type == 'int':
-            field = TagNumField(
-                tag_info.min,
-                tag_info.max,
-                all_button=ab
-            )
+            field = TagNumField(tag_info.min, tag_info.max, all_button=ab)
         elif tag_type == 'dblnum':
-            field = TagDblNumField(
-                tag_info.min,
-                tag_info.max,
-                all_button=ab
-            )
+            field = TagDblNumField(tag_info.min, tag_info.max, all_button=ab)
         elif tag_type == 'time':
-            field = TagNumField(
-                tag_info.min,
-                tag_info.max,
-                all_button=ab
-            )
+            field = TagNumField(tag_info.min, tag_info.max, all_button=ab)
         elif tag_type == 'image':
             field = TagImageField()
         elif tag_type == 'multiline':
@@ -224,8 +207,9 @@ class TrackPropertiesDialog(GObject.GObject):
             try:
                 for tag in trackdata:
                     if not tag.startswith("__"):
-                        if tag in ("tracknumber", "discnumber") \
-                           and trackdata[tag] == ["0/0"]:
+                        if tag in ("tracknumber", "discnumber") and trackdata[tag] == [
+                            "0/0"
+                        ]:
                             poplist.append(tag)
                             continue
                         self._write_tag(track, tag, trackdata[tag])
@@ -269,8 +253,9 @@ class TrackPropertiesDialog(GObject.GObject):
             self.message.add_button(Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
             self.message.show_error(
                 _('Writing of tags failed'),
-                _('Tags could not be written to the following files:\n'
-                  '{files}').format(files='\n'.join(errors))
+                _(
+                    'Tags could not be written to the following files:\n' '{files}'
+                ).format(files='\n'.join(errors)),
             )
 
     def _build_from_track(self, position):
@@ -289,10 +274,8 @@ class TrackPropertiesDialog(GObject.GObject):
             self.next_button.set_sensitive(False)
 
         self.cur_track_label.set_text(
-            _("Editing track %(current)d of %(total)d") % {
-                'current': self.current_position + 1,
-                'total': len(self.tracks)
-            }
+            _("Editing track %(current)d of %(total)d")
+            % {'current': self.current_position + 1, 'total': len(self.tracks)}
         )
 
         trackdata = self.trackdata[position]
@@ -312,8 +295,10 @@ class TrackPropertiesDialog(GObject.GObject):
                 self.rows.append(row)
 
                 try:
-                    if self.trackdata[self.current_position][tag] != \
-                       self.trackdata_original[self.current_position][tag]:
+                    if (
+                        self.trackdata[self.current_position][tag]
+                        != self.trackdata_original[self.current_position][tag]
+                    ):
                         row.label.set_attributes(self.__changed_attributes)
                 except KeyError:
                     row.label.set_attributes(self.__changed_attributes)
@@ -336,7 +321,9 @@ class TrackPropertiesDialog(GObject.GObject):
                     self.rows.append(TagRow(self, self.tags_grid, field, tag, entry, i))
                 else:
                     field = PropertyField(tag_info.type)
-                    self.rows.append(TagRow(self, self.properties_grid, field, tag, entry, i))
+                    self.rows.append(
+                        TagRow(self, self.properties_grid, field, tag, entry, i)
+                    )
 
         self._check_for_changes()
         self._build_grids_from_rows()
@@ -375,13 +362,16 @@ class TrackPropertiesDialog(GObject.GObject):
 
     def _save_position(self):
         (width, height) = self.dialog.get_size()
-        if [width, height] != [settings.get_option('gui/trackprop_' + key, -1)
-                               for key in ['width', 'height']]:
+        if [width, height] != [
+            settings.get_option('gui/trackprop_' + key, -1)
+            for key in ['width', 'height']
+        ]:
             settings.set_option('gui/trackprop_height', height, save=False)
             settings.set_option('gui/trackprop_width', width, save=False)
         (x, y) = self.dialog.get_position()
-        if [x, y] != [settings.get_option('gui/trackprop_' + key, -1)
-                      for key in ['x', 'y']]:
+        if [x, y] != [
+            settings.get_option('gui/trackprop_' + key, -1) for key in ['x', 'y']
+        ]:
             settings.set_option('gui/trackprop_x', x, save=False)
             settings.set_option('gui/trackprop_y', y, save=False)
 
@@ -402,11 +392,13 @@ class TrackPropertiesDialog(GObject.GObject):
 
         if modified:
             if len(modified) != 1:
-                dialog = Gtk.MessageDialog(self.dialog,
-                                           Gtk.DialogFlags.MODAL, Gtk.MessageType.QUESTION,
-                                           Gtk.ButtonsType.YES_NO,
-                                           _('Are you sure you want to apply the changes to all tracks?'),
-                                           )
+                dialog = Gtk.MessageDialog(
+                    self.dialog,
+                    Gtk.DialogFlags.MODAL,
+                    Gtk.MessageType.QUESTION,
+                    Gtk.ButtonsType.YES_NO,
+                    _('Are you sure you want to apply the changes to all tracks?'),
+                )
                 response = dialog.run()
                 dialog.destroy()
 
@@ -431,6 +423,7 @@ class TrackPropertiesDialog(GObject.GObject):
 
     def _check_for_save(self):
         if self.trackdata != self.trackdata_original:
+
             def on_response(message, response):
                 """
                     Applies changes before closing if requested
@@ -447,7 +440,7 @@ class TrackPropertiesDialog(GObject.GObject):
             self.message.add_button(Gtk.STOCK_APPLY, Gtk.ResponseType.APPLY)
             self.message.show_question(
                 _('Apply changes before closing?'),
-                _('Your changes will be lost if you do not apply them now.')
+                _('Your changes will be lost if you do not apply them now.'),
             )
         else:
             self._save_position()
@@ -470,8 +463,7 @@ class TrackPropertiesDialog(GObject.GObject):
 
     def on_title_case_button_clicked(self, w):
         for row in self.rows:
-            if isinstance(row.field, TagField) \
-               or isinstance(row.field, TagTextField):
+            if isinstance(row.field, TagField) or isinstance(row.field, TagTextField):
                 val = row.field.get_value()
                 val = string.capwords(val, ' ')
                 row.field.set_value(val)
@@ -601,7 +593,6 @@ class TrackPropertiesDialog(GObject.GObject):
 
 
 class TagRow(object):
-
     def __init__(self, parent, parent_grid, field, tag_name, value, multi_id):
         self.parent = parent
         self.grid = parent_grid
@@ -635,8 +626,9 @@ class TagRow(object):
             self.label.create_pango_context()
 
         self.clear_button = Gtk.Button()
-        self.clear_button.set_image(Gtk.Image.new_from_icon_name(
-            'edit-clear', Gtk.IconSize.BUTTON))
+        self.clear_button.set_image(
+            Gtk.Image.new_from_icon_name('edit-clear', Gtk.IconSize.BUTTON)
+        )
         self.clear_button.set_relief(Gtk.ReliefStyle.NONE)
         self.clear_button.connect("clicked", self.clear)
 
@@ -648,9 +640,12 @@ class TagRow(object):
         # Remove mode settings
         self.remove_mode = False
         self.remove_button = Gtk.Button()
-        self.remove_button.set_image(Gtk.Image.new_from_icon_name(
-            'list-remove', Gtk.IconSize.BUTTON))
-        self.remove_button.connect("clicked", parent.remove_row, self.tag, self.multi_id)
+        self.remove_button.set_image(
+            Gtk.Image.new_from_icon_name('list-remove', Gtk.IconSize.BUTTON)
+        )
+        self.remove_button.connect(
+            "clicked", parent.remove_row, self.tag, self.multi_id
+        )
 
         self.field.register_update_func(parent.update_tag)
         self.field.register_all_func(parent.apply_all)
@@ -674,7 +669,6 @@ class TagRow(object):
 
 
 class TagField(Gtk.Box):
-
     def __init__(self, all_button=True):
         Gtk.Box.__init__(self, homogeneous=False, spacing=5)
 
@@ -730,7 +724,6 @@ def dummy_scroll_handler(widget, _):
 
 
 class TagTextField(Gtk.Box):
-
     def __init__(self, all_button=True):
         Gtk.Box.__init__(self, homogeneous=False, spacing=5)
 
@@ -772,11 +765,12 @@ class TagTextField(Gtk.Box):
                 self.all_button.set_active(False)
 
     def get_value(self):
-        return unicode(self.buffer.get_text(
-            self.buffer.get_start_iter(),
-            self.buffer.get_end_iter(),
-            True
-        ), 'utf-8')
+        return unicode(
+            self.buffer.get_text(
+                self.buffer.get_start_iter(), self.buffer.get_end_iter(), True
+            ),
+            'utf-8',
+        )
 
     def register_update_func(self, f):
         tag = self.parent_row.tag
@@ -788,7 +782,6 @@ class TagTextField(Gtk.Box):
 
 
 class TagNumField(Gtk.Box):
-
     def __init__(self, min=0, max=10000, step=1, page=10, all_button=True):
         Gtk.Box.__init__(self, homogeneous=False, spacing=5)
 
@@ -847,7 +840,6 @@ class TagNumField(Gtk.Box):
 
 
 class TagDblNumField(Gtk.Box):
-
     def __init__(self, min=0, max=10000, step=1, page=10, all_button=True):
         Gtk.Box.__init__(self, homogeneous=False, spacing=5)
 
@@ -944,8 +936,14 @@ class TagImageField(Gtk.Box):
 
     __gtype_name__ = 'TagImageField'
 
-    (button, image, type_model, description_entry, type_selection, \
-        info_label) = GtkTemplate.Child.widgets(6)
+    (
+        button,
+        image,
+        type_model,
+        description_entry,
+        type_selection,
+        info_label,
+    ) = GtkTemplate.Child.widgets(6)
 
     def __init__(self, all_button=True):
         Gtk.Box.__init__(self)
@@ -967,23 +965,17 @@ class TagImageField(Gtk.Box):
                 'title': _('JPEG image'),
                 # Type and options for GDK Pixbuf saving
                 'type': 'jpeg',
-                'options': {'quality': '90'}
+                'options': {'quality': '90'},
             },
-            'image/png': {
-                'title': _('PNG image'),
-                'type': 'png',
-                'options': {}
-            },
+            'image/png': {'title': _('PNG image'), 'type': 'png', 'options': {}},
             'image/': {
                 'title': _('Image'),
                 # Store unknown images as JPEG
                 'type': 'jpeg',
-                'options': {'quality': '90'}
+                'options': {'quality': '90'},
             },
             # TODO: Handle linked images
-            '-->': {
-                'title': _('Linked image')
-            }
+            '-->': {'title': _('Linked image')},
         }
 
         self.button.drag_dest_set(Gtk.DestDefaults.ALL, [], Gdk.DragAction.COPY)
@@ -1074,8 +1066,13 @@ class TagImageField(Gtk.Box):
             save_to_callback_function = self.pixbuf.save_to_callbackv
         except AttributeError:
             save_to_callback_function = self.pixbuf.save_to_callback
-        save_to_callback_function(gdk_pixbuf_save_func, None, mime['type'],
-                                  mime['options'].keys(), mime['options'].values())
+        save_to_callback_function(
+            gdk_pixbuf_save_func,
+            None,
+            mime['type'],
+            mime['options'].keys(),
+            mime['options'].values(),
+        )
 
         # Move to the beginning of the buffer to allow read operations
         writer.seek(0)
@@ -1089,7 +1086,9 @@ class TagImageField(Gtk.Box):
         if not self.update_func or self.batch_update:
             return
 
-        self.update_func(self, self.parent_row.tag, self.parent_row.multi_id, self.get_value)
+        self.update_func(
+            self, self.parent_row.tag, self.parent_row.multi_id, self.get_value
+        )
 
     def set_pixbuf(self, pixbuf, mime=None):
         """
@@ -1101,8 +1100,9 @@ class TagImageField(Gtk.Box):
             self.image.set_from_icon_name('list-add', Gtk.IconSize.DIALOG)
             self.info_label.set_markup('')
         else:
-            self.image.set_from_pixbuf(pixbuf.scale_simple(
-                100, 100, GdkPixbuf.InterpType.BILINEAR))
+            self.image.set_from_pixbuf(
+                pixbuf.scale_simple(100, 100, GdkPixbuf.InterpType.BILINEAR)
+            )
 
             width, height = pixbuf.get_width(), pixbuf.get_height()
             if mime is None:
@@ -1112,7 +1112,8 @@ class TagImageField(Gtk.Box):
                 # TRANSLATORS: do not translate 'format', 'width', and 'height'
                 markup = _('{format} ({width}x{height} pixels)').format(
                     format=self.mime_info.get(mime, self.mime_info['image/'])['title'],
-                    width=width, height=height
+                    width=width,
+                    height=height,
                 )
             self.info_label.set_markup(markup)
 
@@ -1125,8 +1126,12 @@ class TagImageField(Gtk.Box):
         dialog = dialogs.FileOperationDialog(
             title=_('Select image to set as cover'),
             parent=self.get_toplevel(),
-            buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                     Gtk.STOCK_OK, Gtk.ResponseType.OK)
+            buttons=(
+                Gtk.STOCK_CANCEL,
+                Gtk.ResponseType.CANCEL,
+                Gtk.STOCK_OK,
+                Gtk.ResponseType.OK,
+            ),
         )
         dialog.set_select_multiple(False)
         filefilter = Gtk.FileFilter()
@@ -1151,14 +1156,18 @@ class TagImageField(Gtk.Box):
                 self.set_pixbuf(pixbuf, info.get_mime_types()[0])
                 self.type_selection.set_active(self.default_type)
                 self.type_selection.set_sensitive(True)
-                self.description_entry.set_text(os.path.basename(filename).rsplit('.', 1)[0])
+                self.description_entry.set_text(
+                    os.path.basename(filename).rsplit('.', 1)[0]
+                )
                 self.description_entry.set_sensitive(True)
                 self.batch_update = False
                 self.call_update_func()
 
         dialog.destroy()
 
-    def _on_button_drag_data_received(self, widget, context, x, y, selection, info, time):
+    def _on_button_drag_data_received(
+        self, widget, context, x, y, selection, info, time
+    ):
         """
             Allows setting the cover image via drag and drop
         """
@@ -1175,7 +1184,9 @@ class TagImageField(Gtk.Box):
                 self.set_pixbuf(pixbuf, info['mime_types'][0])
                 self.type_selection.set_active(self.default_type)
                 self.description_entry.set_sensitive(True)
-                self.description_entry.set_text(os.path.basename(filename).rsplit('.', 1)[0])
+                self.description_entry.set_text(
+                    os.path.basename(filename).rsplit('.', 1)[0]
+                )
                 self.description_entry.set_sensitive(True)
                 self.batch_update = False
                 self.call_update_func()
@@ -1196,7 +1207,6 @@ class TagImageField(Gtk.Box):
 
 
 class PropertyField(Gtk.Box):
-
     def __init__(self, property_type='text'):
         Gtk.Box.__init__(self, homogeneous=False, spacing=5)
 
@@ -1211,8 +1221,9 @@ class PropertyField(Gtk.Box):
         if self.property_type == 'location':
             self.folder_button = Gtk.Button()
             self.folder_button.set_tooltip_text(_('Open Directory'))
-            self.folder_button.set_image(Gtk.Image.new_from_icon_name(
-                'folder-open', Gtk.IconSize.BUTTON))
+            self.folder_button.set_image(
+                Gtk.Image.new_from_icon_name('folder-open', Gtk.IconSize.BUTTON)
+            )
             self.pack_start(self.folder_button, False, False, 0)
             self.folder_button.connect("clicked", self.folder_button_clicked)
 
@@ -1257,7 +1268,6 @@ class PropertyField(Gtk.Box):
 
 
 class AllButton(Gtk.ToggleButton):
-
     def __init__(self, parent_field, id_num=0):
         Gtk.ToggleButton.__init__(self)
         self.set_tooltip_text(_("Apply current value to all tracks"))
@@ -1280,7 +1290,6 @@ class AllButton(Gtk.ToggleButton):
 
 
 class SavingProgressWindow(Gtk.Window):
-
     def __init__(self, parent, total, text=_("Saved %(count)s of %(total)s.")):
         Gtk.Window.__init__(self)
         self.count = 0
@@ -1314,12 +1323,8 @@ class SavingProgressWindow(Gtk.Window):
 
     def step(self):
         self.count += 1
-        self._progress.set_fraction(
-            common.clamp(self.count / float(self.total), 0, 1))
-        self._label.set_markup(self.text % {
-            'count': self.count,
-            'total': self.total
-        })
+        self._progress.set_fraction(common.clamp(self.count / float(self.total), 0, 1))
+        self._label.set_markup(self.text % {'count': self.count, 'total': self.total})
         while Gtk.events_pending():
             Gtk.main_iteration()
 

--- a/xlgui/properties.py
+++ b/xlgui/properties.py
@@ -944,8 +944,8 @@ class TagImageField(Gtk.Box):
 
     __gtype_name__ = 'TagImageField'
 
-    button, image, type_model, description_entry, type_selection, \
-        info_label = GtkTemplate.Child.widgets(6)
+    (button, image, type_model, description_entry, type_selection, \
+        info_label) = GtkTemplate.Child.widgets(6)
 
     def __init__(self, all_button=True):
         Gtk.Box.__init__(self)

--- a/xlgui/tray.py
+++ b/xlgui/tray.py
@@ -29,12 +29,7 @@ import logging
 from gi.repository import Gdk
 from gi.repository import Gtk
 
-from xl import (
-    event,
-    player,
-    providers,
-    settings
-)
+from xl import event, player, providers, settings
 from xl.nls import gettext as _
 from xlgui.widgets.info import TrackToolTip
 from xlgui.widgets import menu, menuitems, playlist, playback
@@ -59,21 +54,35 @@ def __create_tray_context_menu():
     sep = menu.simple_separator
     items = []
     # Play/Pause
-    items.append(playback.PlayPauseMenuItem('playback-playpause', player.PLAYER, after=[]))
+    items.append(
+        playback.PlayPauseMenuItem('playback-playpause', player.PLAYER, after=[])
+    )
     # Next
-    items.append(playback.NextMenuItem('playback-next', player.PLAYER, after=[items[-1].name]))
+    items.append(
+        playback.NextMenuItem('playback-next', player.PLAYER, after=[items[-1].name])
+    )
     # Prev
-    items.append(playback.PrevMenuItem('playback-prev', player.PLAYER, after=[items[-1].name]))
+    items.append(
+        playback.PrevMenuItem('playback-prev', player.PLAYER, after=[items[-1].name])
+    )
     # Stop
-    items.append(playback.StopMenuItem('playback-stop', player.PLAYER, after=[items[-1].name]))
+    items.append(
+        playback.StopMenuItem('playback-stop', player.PLAYER, after=[items[-1].name])
+    )
     # ----
     items.append(sep('playback-sep', [items[-1].name]))
     # Shuffle
-    items.append(playlist.ShuffleModesMenuItem('playlist-mode-shuffle', after=[items[-1].name]))
+    items.append(
+        playlist.ShuffleModesMenuItem('playlist-mode-shuffle', after=[items[-1].name])
+    )
     # Repeat
-    items.append(playlist.RepeatModesMenuItem('playlist-mode-repeat', after=[items[-1].name]))
+    items.append(
+        playlist.RepeatModesMenuItem('playlist-mode-repeat', after=[items[-1].name])
+    )
     # Dynamic
-    items.append(playlist.DynamicModesMenuItem('playlist-mode-dynamic', after=[items[-1].name]))
+    items.append(
+        playlist.DynamicModesMenuItem('playlist-mode-dynamic', after=[items[-1].name])
+    )
     # ----
     items.append(sep('playlist-mode-sep', [items[-1].name]))
     # Rating
@@ -84,8 +93,10 @@ def __create_tray_context_menu():
             return [current]
         else:
             return []
-    items.append(menuitems.RatingMenuItem('rating', [items[-1].name],
-                                          rating_get_tracks_func))
+
+    items.append(
+        menuitems.RatingMenuItem('rating', [items[-1].name], rating_get_tracks_func)
+    )
     # Remove
     items.append(playlist.RemoveCurrentMenuItem([items[-1].name]))
     # ----
@@ -94,11 +105,22 @@ def __create_tray_context_menu():
 
     def quit_cb(*args):
         from xl import main
+
         main.exaile().quit()
-    items.append(menu.simple_menu_item('quit-application', [items[-1].name],
-                                       _("_Quit Exaile"), 'application-exit', callback=quit_cb))
+
+    items.append(
+        menu.simple_menu_item(
+            'quit-application',
+            [items[-1].name],
+            _("_Quit Exaile"),
+            'application-exit',
+            callback=quit_cb,
+        )
+    )
     for item in items:
         providers.register('tray-icon-context', item)
+
+
 __create_tray_context_menu()
 
 
@@ -141,19 +163,35 @@ class BaseTrayIcon(object):
         self.connect('button-press-event', self.on_button_press_event)
         self.connect('scroll-event', self.on_scroll_event)
 
-        event.add_ui_callback(self.on_playback_change_state, 'playback_player_end', player.PLAYER)
-        event.add_ui_callback(self.on_playback_change_state, 'playback_track_start', player.PLAYER)
-        event.add_ui_callback(self.on_playback_change_state, 'playback_toggle_pause', player.PLAYER)
-        event.add_ui_callback(self.on_playback_change_state, 'playback_error', player.PLAYER)
+        event.add_ui_callback(
+            self.on_playback_change_state, 'playback_player_end', player.PLAYER
+        )
+        event.add_ui_callback(
+            self.on_playback_change_state, 'playback_track_start', player.PLAYER
+        )
+        event.add_ui_callback(
+            self.on_playback_change_state, 'playback_toggle_pause', player.PLAYER
+        )
+        event.add_ui_callback(
+            self.on_playback_change_state, 'playback_error', player.PLAYER
+        )
 
     def disconnect_events(self):
         """
             Disconnects various callbacks from events
         """
-        event.remove_callback(self.on_playback_change_state, 'playback_player_end', player.PLAYER)
-        event.remove_callback(self.on_playback_change_state, 'playback_track_start', player.PLAYER)
-        event.remove_callback(self.on_playback_change_state, 'playback_toggle_pause', player.PLAYER)
-        event.remove_callback(self.on_playback_change_state, 'playback_error', player.PLAYER)
+        event.remove_callback(
+            self.on_playback_change_state, 'playback_player_end', player.PLAYER
+        )
+        event.remove_callback(
+            self.on_playback_change_state, 'playback_track_start', player.PLAYER
+        )
+        event.remove_callback(
+            self.on_playback_change_state, 'playback_toggle_pause', player.PLAYER
+        )
+        event.remove_callback(
+            self.on_playback_change_state, 'playback_error', player.PLAYER
+        )
 
     def update_icon(self):
         """
@@ -203,8 +241,9 @@ class BaseTrayIcon(object):
         if event.button == Gdk.BUTTON_MIDDLE:
             playback.playpause(player.PLAYER)
         if event.triggers_context_menu():
-            self.menu.popup(None, None, self.get_menu_position, self,
-                            event.button, event.time)
+            self.menu.popup(
+                None, None, self.get_menu_position, self, event.button, event.time
+            )
 
     def on_scroll_event(self, widget, event):
         """

--- a/xlgui/widgets/common.py
+++ b/xlgui/widgets/common.py
@@ -37,11 +37,7 @@ from gi.repository import Gtk
 from itertools import imap
 from urllib2 import urlparse
 
-from xl import (
-    common,
-    playlist as xl_playlist,
-    trax
-)
+from xl import common, playlist as xl_playlist, trax
 
 from xlgui import icons
 from xlgui.guiutil import get_workarea_size
@@ -52,6 +48,7 @@ class AttachedWindow(Gtk.Window):
         A window attachable to arbitrary widgets,
         follows the movement of its parent
     """
+
     __gsignals__ = {'show': 'override'}
 
     def __init__(self, parent):
@@ -78,7 +75,9 @@ class AttachedWindow(Gtk.Window):
         workarea.x = workarea.y = 0
         workarea.width, workarea.height = get_workarea_size()
         parent_alloc = self.parent_widget.get_allocation()
-        toplevel_position = self.parent_widget.get_toplevel().get_window().get_position()
+        toplevel_position = (
+            self.parent_widget.get_toplevel().get_window().get_position()
+        )
         # Use absolute screen position
         parent_alloc.x += toplevel_position[0]
         parent_alloc.y += toplevel_position[1]
@@ -117,7 +116,9 @@ class AttachedWindow(Gtk.Window):
         if not isinstance(toplevel, Gtk.Window):  # Not anchored
             return
         self.set_transient_for(toplevel)
-        conns.append(toplevel.connect('configure-event', self._on_parent_window_configure_event))
+        conns.append(
+            toplevel.connect('configure-event', self._on_parent_window_configure_event)
+        )
         conns.append(toplevel.connect('hide', self._on_parent_window_hide))
 
     def _on_parent_window_configure_event(self, _widget, _event):
@@ -155,7 +156,8 @@ class AutoScrollTreeView(Gtk.TreeView):
         """
         if not self.__autoscroll_timeout_id:
             self.__autoscroll_timeout_id = GLib.timeout_add(
-                50, self._on_autoscroll_timeout)
+                50, self._on_autoscroll_timeout
+            )
 
     def _on_drag_leave(self, widget, context, timestamp):
         """
@@ -177,12 +179,16 @@ class AutoScrollTreeView(Gtk.TreeView):
         x, y = self.convert_widget_to_tree_coords(x, y)
         visible_rect = self.get_visible_rect()
         # Calculate offset from the top edge
-        offset = y - (visible_rect.y + 3 * self._SCROLL_EDGE_SIZE)  # 3: Scroll faster upwards
+        offset = y - (
+            visible_rect.y + 3 * self._SCROLL_EDGE_SIZE
+        )  # 3: Scroll faster upwards
 
         # Check if we are near the bottom edge instead
         if offset > 0:
             # Calculate offset based on the bottom edge
-            offset = y - (visible_rect.y + visible_rect.height - 2 * self._SCROLL_EDGE_SIZE)
+            offset = y - (
+                visible_rect.y + visible_rect.height - 2 * self._SCROLL_EDGE_SIZE
+            )
 
             # Skip if we are not near to top or bottom edge
             if offset < 0:
@@ -192,7 +198,7 @@ class AutoScrollTreeView(Gtk.TreeView):
         vadjustment.props.value = common.clamp(
             vadjustment.props.value + offset,
             0,
-            vadjustment.props.upper - vadjustment.props.page_size
+            vadjustment.props.upper - vadjustment.props.page_size,
         )
         self.set_vadjustment(vadjustment)
 
@@ -203,13 +209,17 @@ class DragTreeView(AutoScrollTreeView):
     """
         A TextView that does easy dragging/selecting/popup menu
     """
-    class EventData(namedtuple('DragTreeView_EventData',
-                               'event modifier triggers_menu target')):
+
+    class EventData(
+        namedtuple('DragTreeView_EventData', 'event modifier triggers_menu target')
+    ):
         """
             Objects that goes inside pending events list
         """
-        class Target(namedtuple('DragTreeView_EventData_Target',
-                                'path column is_selected')):
+
+        class Target(
+            namedtuple('DragTreeView_EventData_Target', 'path column is_selected')
+        ):
             """
                 Contains target path info
             """
@@ -232,18 +242,20 @@ class DragTreeView(AutoScrollTreeView):
 
         if source:
             self.drag_source_set(
-                Gdk.ModifierType.BUTTON1_MASK, self.targets,
-                Gdk.DragAction.COPY | Gdk.DragAction.MOVE)
+                Gdk.ModifierType.BUTTON1_MASK,
+                self.targets,
+                Gdk.DragAction.COPY | Gdk.DragAction.MOVE,
+            )
 
         if receive:
             self.drop_pos = drop_pos
-            self.drag_dest_set(Gtk.DestDefaults.ALL, self.targets,
-                               Gdk.DragAction.COPY | Gdk.DragAction.DEFAULT |
-                               Gdk.DragAction.MOVE)
-            self.connect('drag_data_received',
-                         self.container.drag_data_received)
-            self.connect('drag_data_delete',
-                         self.container.drag_data_delete)
+            self.drag_dest_set(
+                Gtk.DestDefaults.ALL,
+                self.targets,
+                Gdk.DragAction.COPY | Gdk.DragAction.DEFAULT | Gdk.DragAction.MOVE,
+            )
+            self.connect('drag_data_received', self.container.drag_data_received)
+            self.connect('drag_data_delete', self.container.drag_data_delete)
         self.receive = receive
         self.drag_context = None
         self.show_cover_drag_icon = True
@@ -272,8 +284,11 @@ class DragTreeView(AutoScrollTreeView):
         """
         target = self.get_path_at_pos(int(event.x), int(event.y))
         if target:
-            return DragTreeView.EventData.Target(path=target[0], column=target[1],
-                                                 is_selected=self.get_selection().path_is_selected(target[0]))
+            return DragTreeView.EventData.Target(
+                path=target[0],
+                column=target[1],
+                is_selected=self.get_selection().path_is_selected(target[0]),
+            )
 
     def set_cursor_at(self, target):
         """
@@ -305,8 +320,11 @@ class DragTreeView(AutoScrollTreeView):
         """
         self.drag_context = None
         self.unset_rows_drag_dest()
-        self.drag_dest_set(Gtk.DestDefaults.ALL, self.targets,
-                           Gdk.DragAction.COPY | Gdk.DragAction.MOVE)
+        self.drag_dest_set(
+            Gtk.DestDefaults.ALL,
+            self.targets,
+            Gdk.DragAction.COPY | Gdk.DragAction.MOVE,
+        )
 
     def on_drag_begin(self, widget, context):
         """
@@ -322,11 +340,17 @@ class DragTreeView(AutoScrollTreeView):
         get_tracks_for_path = getattr(self, 'get_tracks_for_path', None)
         if get_tracks_for_path:
             model, paths = self.get_selection().get_selected_rows()
-            drag_cover_icon = icons.MANAGER.get_drag_cover_icon(imap(get_tracks_for_path, paths))
+            drag_cover_icon = icons.MANAGER.get_drag_cover_icon(
+                imap(get_tracks_for_path, paths)
+            )
 
         if drag_cover_icon is None:
             # Set default icon
-            icon_name = 'gtk-dnd-multiple' if self.get_selection().count_selected_rows() > 1 else 'gtk-dnd'
+            icon_name = (
+                'gtk-dnd-multiple'
+                if self.get_selection().count_selected_rows() > 1
+                else 'gtk-dnd'
+            )
             Gtk.drag_set_icon_name(context, icon_name, 0, 0)
         else:
             Gtk.drag_set_icon_pixbuf(context, drag_cover_icon, 0, 0)
@@ -337,8 +361,7 @@ class DragTreeView(AutoScrollTreeView):
         """
         if not self.receive:
             return False
-        self.enable_model_drag_dest(self.targets,
-                                    Gdk.DragAction.DEFAULT)
+        self.enable_model_drag_dest(self.targets, Gdk.DragAction.DEFAULT)
         if self.drop_pos is None:
             return False
         info = treeview.get_dest_row_at_pos(x, y)
@@ -392,7 +415,9 @@ class DragTreeView(AutoScrollTreeView):
                 self.set_selection_status(False)
 
             # If it's not a DnD, it will be treated at button release event
-            self.pending_events.append(DragTreeView.EventData(event, modifier, triggers_menu, target))
+            self.pending_events.append(
+                DragTreeView.EventData(event, modifier, triggers_menu, target)
+            )
 
         # Calls `button_press` function on container (if present)
         try:
@@ -403,35 +428,37 @@ class DragTreeView(AutoScrollTreeView):
             return button_press_function(button, event)
 
     def on_button_release(self, button, event):
-            """
+        """
                 Called when a button is released
                 Treats the pending events added at button press event
 
                 Handles the popup menu that is displayed when you right click in
                 the TreeView list (calls `container.menu` if present)
             """
-            self.drag_context = None
+        self.drag_context = None
 
-            # Get pending event
-            try:
-                event_data = self.pending_events.pop()
-            except IndexError:
-                return False
-
-            self.reset_selection_status()
-
-            # Do not set cursor if has a modifier key pressed
-            if event_data.modifier == 0 and not (event_data.triggers_menu and event_data.target.is_selected):
-                self.set_cursor_at(event_data.target)
-
-            if event_data.triggers_menu:
-                # Uses menu from container (if present)
-                menu = getattr(self.container, 'menu', None)
-                if menu:
-                    menu.popup(event_data.event)
-                    return True
-
+        # Get pending event
+        try:
+            event_data = self.pending_events.pop()
+        except IndexError:
             return False
+
+        self.reset_selection_status()
+
+        # Do not set cursor if has a modifier key pressed
+        if event_data.modifier == 0 and not (
+            event_data.triggers_menu and event_data.target.is_selected
+        ):
+            self.set_cursor_at(event_data.target)
+
+        if event_data.triggers_menu:
+            # Uses menu from container (if present)
+            menu = getattr(self.container, 'menu', None)
+            if menu:
+                menu.popup(event_data.event)
+                return True
+
+        return False
 
     # TODO maybe move this somewhere else? (along with _handle_unknown_drag_data)
     def get_drag_data(self, locs, compile_tracks=True, existing_tracks=[]):
@@ -489,8 +516,11 @@ class DragTreeView(AutoScrollTreeView):
         # cause the gui to hang)
         if info.scheme in ('file', ''):
             try:
-                filetype = Gio.File.new_for_uri(loc).query_info(
-                    'standard::type', Gio.FileQueryInfoFlags.NONE, None).get_file_type()
+                filetype = (
+                    Gio.File.new_for_uri(loc)
+                    .query_info('standard::type', Gio.FileQueryInfoFlags.NONE, None)
+                    .get_file_type()
+                )
             except GLib.Error:
                 filetype = None
 
@@ -514,12 +544,13 @@ class ClickableCellRendererPixbuf(Gtk.CellRendererPixbuf):
         Custom :class:`Gtk.CellRendererPixbuf` emitting
         an *clicked* signal upon activation of the pixbuf
     """
+
     __gsignals__ = {
         'clicked': (
             GObject.SignalFlags.RUN_LAST,
             GObject.TYPE_BOOLEAN,
             (GObject.TYPE_PYOBJECT,),
-            GObject.signal_accumulator_true_handled
+            GObject.signal_accumulator_true_handled,
         )
     }
 
@@ -527,8 +558,7 @@ class ClickableCellRendererPixbuf(Gtk.CellRendererPixbuf):
         Gtk.CellRendererPixbuf.__init__(self)
         self.props.mode = Gtk.CellRendererMode.ACTIVATABLE
 
-    def do_activate(self, event, widget, path,
-                    background_area, cell_area, flags):
+    def do_activate(self, event, widget, path, background_area, cell_area, flags):
         """
             Emits the *clicked* signal
         """

--- a/xlgui/widgets/dialogs.py
+++ b/xlgui/widgets/dialogs.py
@@ -34,19 +34,14 @@ import logging
 from gi.repository import Pango
 import os.path
 
-from xl import (
-    metadata,
-    providers,
-    settings,
-    xdg
-)
+from xl import metadata, providers, settings, xdg
 from xl.common import clamp
 from xl.playlist import (
     is_valid_playlist,
     import_playlist,
     export_playlist,
     InvalidPlaylistTypeError,
-    PlaylistExportOptions
+    PlaylistExportOptions,
 )
 from xl.nls import gettext as _
 
@@ -74,8 +69,9 @@ def error(parent, message=None, markup=None, _flags=Gtk.DialogFlags.MODAL):
     """
     if message is markup is None:
         raise ValueError("message or markup must be specified")
-    dialog = Gtk.MessageDialog(parent, _flags, Gtk.MessageType.ERROR,
-                               Gtk.ButtonsType.CLOSE)
+    dialog = Gtk.MessageDialog(
+        parent, _flags, Gtk.MessageType.ERROR, Gtk.ButtonsType.CLOSE
+    )
     if markup is None:
         dialog.props.text = message
     else:
@@ -90,8 +86,9 @@ def info(parent, message=None, markup=None):
     """
     if message is markup is None:
         raise ValueError("message or markup must be specified")
-    dialog = Gtk.MessageDialog(parent, Gtk.DialogFlags.MODAL, Gtk.MessageType.INFO,
-                               Gtk.ButtonsType.OK)
+    dialog = Gtk.MessageDialog(
+        parent, Gtk.DialogFlags.MODAL, Gtk.MessageType.INFO, Gtk.ButtonsType.OK
+    )
     if markup is None:
         dialog.props.text = message
     else:
@@ -102,7 +99,12 @@ def info(parent, message=None, markup=None):
 
 def yesno(parent, message):
     '''Gets a Yes/No response from a user'''
-    dlg = Gtk.MessageDialog(parent=parent, type=Gtk.MessageType.QUESTION, buttons=Gtk.ButtonsType.YES_NO, message_format=message)
+    dlg = Gtk.MessageDialog(
+        parent=parent,
+        type=Gtk.MessageType.QUESTION,
+        buttons=Gtk.ButtonsType.YES_NO,
+        message_format=message,
+    )
     response = dlg.run()
     dlg.destroy()
     return response
@@ -122,7 +124,8 @@ class AboutDialog(Gtk.AboutDialog):
 
         self.set_transient_for(parent)
         logo = GdkPixbuf.Pixbuf.new_from_file(
-            xdg.get_data_path('images', 'exailelogo.png'))
+            xdg.get_data_path('images', 'exailelogo.png')
+        )
         self.set_logo(logo)
 
         import xl.version
@@ -148,22 +151,25 @@ class ShortcutsDialog(Gtk.Dialog):
               a minimum GTK version. This would also enable automatically
               localized (translated) accelerator names.
     '''
-    
+
     # doesn't work if we don't set the treeview here too..
     shortcuts_treeview, shortcuts_model = GtkTemplate.Child.widgets(2)
-    
+
     __gtype_name__ = 'ShortcutsDialog'
-    
+
     def __init__(self, parent=None):
         Gtk.Dialog.__init__(self)
         self.init_template()
-        
+
         self.set_transient_for(parent)
-        
-        for a in sorted(providers.get('mainwindow-accelerators'),
-                        key=lambda a: ('%04d' % (a.key)) + a.name):
-            self.shortcuts_model.append((Gtk.accelerator_get_label(a.key, a.mods),
-                                         a.helptext.replace('_', '')))
+
+        for a in sorted(
+            providers.get('mainwindow-accelerators'),
+            key=lambda a: ('%04d' % (a.key)) + a.name,
+        ):
+            self.shortcuts_model.append(
+                (Gtk.accelerator_get_label(a.key, a.mods), a.helptext.replace('_', ''))
+            )
 
     @GtkTemplate.Callback
     def on_close_clicked(self, widget):
@@ -189,8 +195,9 @@ class MultiTextEntryDialog(Gtk.Dialog):
         self.__entry_area.set_border_width(3)
         self.vbox.pack_start(self.__entry_area, True, True, 0)
 
-        self.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                         Gtk.STOCK_OK, Gtk.ResponseType.OK)
+        self.add_buttons(
+            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OK, Gtk.ResponseType.OK
+        )
 
         self.fields = []
 
@@ -248,14 +255,12 @@ class MultiTextEntryDialog(Gtk.Dialog):
                     if len(field.get_text()) > 0:
                         # Unset possible previous marks
                         field.set_icon_from_icon_name(
-                            Gtk.EntryIconPosition.SECONDARY,
-                            None
+                            Gtk.EntryIconPosition.SECONDARY, None
                         )
                     else:
                         # Mark via warning
                         field.set_icon_from_icon_name(
-                            Gtk.EntryIconPosition.SECONDARY,
-                            'dialog-warning'
+                            Gtk.EntryIconPosition.SECONDARY, 'dialog-warning'
                         )
         self.hide()
 
@@ -267,8 +272,15 @@ class TextEntryDialog(Gtk.Dialog):
         Shows a dialog with a single line of text
     """
 
-    def __init__(self, message, title, default_text=None, parent=None,
-                 cancelbutton=None, okbutton=None):
+    def __init__(
+        self,
+        message,
+        title,
+        default_text=None,
+        parent=None,
+        cancelbutton=None,
+        okbutton=None,
+    ):
         """
             Initializes the dialog
         """
@@ -276,11 +288,13 @@ class TextEntryDialog(Gtk.Dialog):
             cancelbutton = Gtk.STOCK_CANCEL
         if not okbutton:
             okbutton = Gtk.STOCK_OK
-        Gtk.Dialog.__init__(self, title=title, transient_for=parent,
-                            destroy_with_parent=True)
+        Gtk.Dialog.__init__(
+            self, title=title, transient_for=parent, destroy_with_parent=True
+        )
 
-        self.add_buttons(cancelbutton, Gtk.ResponseType.CANCEL,
-                         okbutton, Gtk.ResponseType.OK)
+        self.add_buttons(
+            cancelbutton, Gtk.ResponseType.CANCEL, okbutton, Gtk.ResponseType.OK
+        )
 
         label = Gtk.Label(label=message)
         label.set_xalign(0)
@@ -299,8 +313,7 @@ class TextEntryDialog(Gtk.Dialog):
             self.entry.set_text(default_text)
         main.pack_start(self.entry, False, False, 0)
 
-        self.entry.connect('activate',
-                           lambda e: self.response(Gtk.ResponseType.OK))
+        self.entry.connect('activate', lambda e: self.response(Gtk.ResponseType.OK))
 
     def get_value(self):
         """
@@ -325,12 +338,13 @@ class URIOpenDialog(TextEntryDialog):
     """
         A dialog specialized for opening an URI
     """
+
     __gsignals__ = {
         'uri-selected': (
             GObject.SignalFlags.RUN_LAST,
             GObject.TYPE_BOOLEAN,
             (GObject.TYPE_PYOBJECT,),
-            GObject.signal_accumulator_true_handled
+            GObject.signal_accumulator_true_handled,
         )
     }
 
@@ -339,10 +353,9 @@ class URIOpenDialog(TextEntryDialog):
             :param parent: a parent window for modal operation or None
             :type parent: :class:`Gtk.Window`
         """
-        TextEntryDialog.__init__(self,
-                                 message=_('Enter the URL to open'),
-                                 title=_('Open URL'),
-                                 parent=parent)
+        TextEntryDialog.__init__(
+            self, message=_('Enter the URL to open'), title=_('Open URL'), parent=parent
+        )
 
         self.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
 
@@ -392,6 +405,7 @@ class URIOpenDialog(TextEntryDialog):
             self.emit('uri-selected', self.get_value())
 
         # self.destroy()
+
     '''
         dialog = dialogs.TextEntryDialog(_('Enter the URL to open'),
         _('Open URL'))
@@ -434,8 +448,9 @@ class ListDialog(Gtk.Dialog):
         self.model = Gtk.ListStore(object)
         self.list = Gtk.TreeView(model=self.model)
         self.list.set_headers_visible(False)
-        self.list.connect('row-activated',
-                          lambda *e: self.response(Gtk.ResponseType.OK))
+        self.list.connect(
+            'row-activated', lambda *e: self.response(Gtk.ResponseType.OK)
+        )
         scroll.add(self.list)
         scroll.set_shadow_type(Gtk.ShadowType.IN)
         self.vbox.pack_start(scroll, True, True, 0)
@@ -443,8 +458,12 @@ class ListDialog(Gtk.Dialog):
         if write_only:
             self.add_buttons(Gtk.STOCK_OK, Gtk.ResponseType.OK)
         else:
-            self.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                             Gtk.STOCK_OK, Gtk.ResponseType.OK)
+            self.add_buttons(
+                Gtk.STOCK_CANCEL,
+                Gtk.ResponseType.CANCEL,
+                Gtk.STOCK_OK,
+                Gtk.ResponseType.OK,
+            )
 
         self.selection = self.list.get_selection()
 
@@ -498,6 +517,7 @@ class ListDialog(Gtk.Dialog):
         """
         object = model.get_value(iter, 0)
         cell.set_property('text', str(object))
+
 
 # TODO: combine this and list dialog
 
@@ -583,8 +603,14 @@ class FileOperationDialog(Gtk.FileChooserDialog):
         saved in. (similar to the one in GIMP)
     """
 
-    def __init__(self, title=None, parent=None, action=Gtk.FileChooserAction.OPEN,
-                 buttons=None, backend=None):
+    def __init__(
+        self,
+        title=None,
+        parent=None,
+        action=Gtk.FileChooserAction.OPEN,
+        buttons=None,
+        backend=None,
+    ):
         """
             Standard __init__ of the Gtk.FileChooserDialog.
             Also sets up the expander and list for extensions
@@ -656,12 +682,13 @@ class MediaOpenDialog(Gtk.FileChooserDialog):
     """
         A dialog for opening general media
     """
+
     __gsignals__ = {
         'uris-selected': (
             GObject.SignalFlags.RUN_LAST,
             GObject.TYPE_BOOLEAN,
             (GObject.TYPE_PYOBJECT,),
-            GObject.signal_accumulator_true_handled
+            GObject.signal_accumulator_true_handled,
         )
     }
     _last_location = None
@@ -671,12 +698,17 @@ class MediaOpenDialog(Gtk.FileChooserDialog):
             :param parent: a parent window for modal operation or None
             :type parent: :class:`Gtk.Window`
         """
-        Gtk.FileChooserDialog.__init__(self,
-                                       title=_('Choose Media to Open'),
-                                       parent=parent,
-                                       buttons=(
-                                           Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                                           Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
+        Gtk.FileChooserDialog.__init__(
+            self,
+            title=_('Choose Media to Open'),
+            parent=parent,
+            buttons=(
+                Gtk.STOCK_CANCEL,
+                Gtk.ResponseType.CANCEL,
+                Gtk.STOCK_OPEN,
+                Gtk.ResponseType.OK,
+            ),
+        )
 
         self.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
         self.set_local_only(False)
@@ -757,23 +789,31 @@ class DirectoryOpenDialog(Gtk.FileChooserDialog):
     """
         A dialog specialized for opening directories
     """
+
     __gsignals__ = {
         'uris-selected': (
             GObject.SignalFlags.RUN_LAST,
             GObject.TYPE_BOOLEAN,
             (GObject.TYPE_PYOBJECT,),
-            GObject.signal_accumulator_true_handled
+            GObject.signal_accumulator_true_handled,
         )
     }
     _last_location = None
 
-    def __init__(self, parent=None, title=_('Choose Directory to Open'), select_multiple=True):
-        Gtk.FileChooserDialog.__init__(self,
-                                       title,
-                                       parent=parent,
-                                       buttons=(
-                                           Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                                           Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
+    def __init__(
+        self, parent=None, title=_('Choose Directory to Open'), select_multiple=True
+    ):
+        Gtk.FileChooserDialog.__init__(
+            self,
+            title,
+            parent=parent,
+            buttons=(
+                Gtk.STOCK_CANCEL,
+                Gtk.ResponseType.CANCEL,
+                Gtk.STOCK_OPEN,
+                Gtk.ResponseType.OK,
+            ),
+        )
 
         self.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
         self.set_action(Gtk.FileChooserAction.SELECT_FOLDER)
@@ -823,12 +863,13 @@ class PlaylistImportDialog(Gtk.FileChooserDialog):
     """
         A dialog for importing a playlist
     """
+
     __gsignals__ = {
         'playlists-selected': (
             GObject.SignalFlags.RUN_LAST,
             GObject.TYPE_BOOLEAN,
             (GObject.TYPE_PYOBJECT,),
-            GObject.signal_accumulator_true_handled
+            GObject.signal_accumulator_true_handled,
         )
     }
     _last_location = None
@@ -838,12 +879,17 @@ class PlaylistImportDialog(Gtk.FileChooserDialog):
             :param parent: a parent window for modal operation or None
             :type parent: :class:`Gtk.Window`
         """
-        Gtk.FileChooserDialog.__init__(self,
-                                       title=_('Import Playlist'),
-                                       parent=parent,
-                                       buttons=(
-                                           Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                                           Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
+        Gtk.FileChooserDialog.__init__(
+            self,
+            title=_('Import Playlist'),
+            parent=parent,
+            buttons=(
+                Gtk.STOCK_CANCEL,
+                Gtk.ResponseType.CANCEL,
+                Gtk.STOCK_OPEN,
+                Gtk.ResponseType.OK,
+            ),
+        )
 
         self.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
         self.set_local_only(False)
@@ -913,7 +959,9 @@ class PlaylistImportDialog(Gtk.FileChooserDialog):
                     self.destroy()
                     return
                 except Exception as e:
-                    error(None, 'Invalid playlist "%s": (internal error): %s' % (uri, e))
+                    error(
+                        None, 'Invalid playlist "%s": (internal error): %s' % (uri, e)
+                    )
                     self.destroy()
                     return
 
@@ -926,12 +974,13 @@ class PlaylistExportDialog(FileOperationDialog):
     """
         A dialog specialized for playlist export
     """
+
     __gsignals__ = {
         'message': (
             GObject.SignalFlags.RUN_LAST,
             GObject.TYPE_BOOLEAN,
             (Gtk.MessageType, GObject.TYPE_STRING),
-            GObject.signal_accumulator_true_handled
+            GObject.signal_accumulator_true_handled,
         )
     }
 
@@ -942,15 +991,18 @@ class PlaylistExportDialog(FileOperationDialog):
             :param parent: a parent window for modal operation or None
             :type parent: :class:`Gtk.Window`
         """
-        FileOperationDialog.__init__(self,
-                                     title=_('Export Current Playlist'),
-                                     parent=parent,
-                                     action=Gtk.FileChooserAction.SAVE,
-                                     buttons=(
-                                         Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                                         Gtk.STOCK_SAVE, Gtk.ResponseType.OK
-                                     )
-                                     )
+        FileOperationDialog.__init__(
+            self,
+            title=_('Export Current Playlist'),
+            parent=parent,
+            action=Gtk.FileChooserAction.SAVE,
+            buttons=(
+                Gtk.STOCK_CANCEL,
+                Gtk.ResponseType.CANCEL,
+                Gtk.STOCK_SAVE,
+                Gtk.ResponseType.OK,
+            ),
+        )
 
         self.set_local_only(False)
 
@@ -1008,8 +1060,11 @@ class PlaylistExportDialog(FileOperationDialog):
             except InvalidPlaylistTypeError as e:
                 self.emit('message', Gtk.MessageType.ERROR, str(e))
             else:
-                self.emit('message', Gtk.MessageType.INFO,
-                          _('Playlist saved as <b>%s</b>.') % path)
+                self.emit(
+                    'message',
+                    Gtk.MessageType.INFO,
+                    _('Playlist saved as <b>%s</b>.') % path,
+                )
 
         # self.destroy()
 
@@ -1027,10 +1082,18 @@ class ConfirmCloseDialog(Gtk.MessageDialog):
 
         self.set_title(_('Close %s' % document_name))
         self.set_markup(_('<b>Save changes to %s before closing?</b>') % document_name)
-        self.format_secondary_text(_('Your changes will be lost if you don\'t save them'))
+        self.format_secondary_text(
+            _('Your changes will be lost if you don\'t save them')
+        )
 
-        self.add_buttons(_('Close Without Saving'), 100, Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                         Gtk.STOCK_SAVE, 110)
+        self.add_buttons(
+            _('Close Without Saving'),
+            100,
+            Gtk.STOCK_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_SAVE,
+            110,
+        )
 
     def run(self):
         self.show_all()
@@ -1047,27 +1110,26 @@ class MessageBar(Gtk.InfoBar):
         Gtk.MessageType.ERROR: Gtk.STOCK_DIALOG_ERROR,
     }
     buttons_map = {
-        Gtk.ButtonsType.OK: [
-            (Gtk.STOCK_OK, Gtk.ResponseType.OK)
-        ],
-        Gtk.ButtonsType.CLOSE: [
-            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
-        ],
-        Gtk.ButtonsType.CANCEL: [
-            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        ],
+        Gtk.ButtonsType.OK: [(Gtk.STOCK_OK, Gtk.ResponseType.OK)],
+        Gtk.ButtonsType.CLOSE: [(Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)],
+        Gtk.ButtonsType.CANCEL: [(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)],
         Gtk.ButtonsType.YES_NO: [
             (Gtk.STOCK_NO, Gtk.ResponseType.NO),
-            (Gtk.STOCK_YES, Gtk.ResponseType.YES)
+            (Gtk.STOCK_YES, Gtk.ResponseType.YES),
         ],
         Gtk.ButtonsType.OK_CANCEL: [
             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL),
-            (Gtk.STOCK_OK, Gtk.ResponseType.OK)
-        ]
+            (Gtk.STOCK_OK, Gtk.ResponseType.OK),
+        ],
     }
 
-    def __init__(self, parent=None, type=Gtk.MessageType.INFO,
-                 buttons=Gtk.ButtonsType.NONE, text=None):
+    def __init__(
+        self,
+        parent=None,
+        type=Gtk.MessageType.INFO,
+        buttons=Gtk.ButtonsType.NONE,
+        text=None,
+    ):
         """
             Report important messages to the user
 
@@ -1119,8 +1181,7 @@ class MessageBar(Gtk.InfoBar):
         content_area.show_all()
 
         self.action_area = self.get_action_area()
-        self.action_area.set_property('layout-style',
-                                      Gtk.ButtonBoxStyle.START)
+        self.action_area.set_property('layout-style', Gtk.ButtonBoxStyle.START)
 
         if buttons != Gtk.ButtonsType.NONE:
             for text, response in self.buttons_map[buttons]:
@@ -1141,13 +1202,14 @@ class MessageBar(Gtk.InfoBar):
         #    Pango.AttrScale(Pango.SCALE_LARGE, 0, -1))'''
 
         self.connect('response', self.on_response)
-        
+
         # Workaround for https://bugzilla.gnome.org/show_bug.cgi?id=710888
         # -> From pitivi: https://phabricator.freedesktop.org/D1103#34aa2703
         def _make_sure_revealer_does_nothing(widget):
             if not isinstance(widget, Gtk.Revealer):
                 return
             widget.set_transition_type(Gtk.RevealerTransitionType.NONE)
+
         self.forall(_make_sure_revealer_does_nothing)
 
     def set_text(self, text):
@@ -1179,13 +1241,11 @@ class MessageBar(Gtk.InfoBar):
         """
         if text is None:
             self.secondary_text.hide()
-            self.primary_text.set_attributes(
-                self.primary_text_attributes)
+            self.primary_text.set_attributes(self.primary_text_attributes)
         else:
             self.secondary_text.set_text(text)
             self.secondary_text.show()
-            self.primary_text.set_attributes(
-                self.primary_text_emphasized_attributes)
+            self.primary_text.set_attributes(self.primary_text_emphasized_attributes)
 
     def set_secondary_markup(self, markup):
         """
@@ -1198,13 +1258,11 @@ class MessageBar(Gtk.InfoBar):
         """
         if markup is None:
             self.secondary_text.hide()
-            self.primary_text.set_attributes(
-                self.primary_text_attributes)
+            self.primary_text.set_attributes(self.primary_text_attributes)
         else:
             self.secondary_text.set_markup(markup)
             self.secondary_text.show()
-            self.primary_text.set_attributes(
-                self.primary_text_emphasized_attributes)
+            self.primary_text.set_attributes(self.primary_text_emphasized_attributes)
 
     def set_image(self, image):
         """
@@ -1259,8 +1317,7 @@ class MessageBar(Gtk.InfoBar):
                 Gtk.MessageType.ERROR.
         """
         if type != Gtk.MessageType.OTHER:
-            self.image.set_from_stock(self.type_map[type],
-                                      Gtk.IconSize.DIALOG)
+            self.image.set_from_stock(self.type_map[type], Gtk.IconSize.DIALOG)
 
         Gtk.InfoBar.set_message_type(self, type)
 
@@ -1270,8 +1327,9 @@ class MessageBar(Gtk.InfoBar):
         """
         return self.message_area
 
-    def _show_message(self, message_type, text, secondary_text,
-                      markup, secondary_markup, timeout):
+    def _show_message(
+        self, message_type, text, secondary_text, markup, secondary_markup, timeout
+    ):
         """
             Helper for the various `show_*` methods. See `show_info` for
             documentation on the parameters.
@@ -1293,8 +1351,14 @@ class MessageBar(Gtk.InfoBar):
         if timeout > 0:
             GLib.timeout_add_seconds(timeout, self.hide)
 
-    def show_info(self, text=None, secondary_text=None,
-                  markup=None, secondary_markup=None, timeout=5):
+    def show_info(
+        self,
+        text=None,
+        secondary_text=None,
+        markup=None,
+        secondary_markup=None,
+        timeout=5,
+    ):
         """
             Convenience method which sets all
             required flags for an info message
@@ -1314,11 +1378,18 @@ class MessageBar(Gtk.InfoBar):
                 use 0 to disable this behavior
             :type timeout: int
         """
-        self._show_message(Gtk.MessageType.INFO, text, secondary_text,
-                           markup, secondary_markup, timeout)
+        self._show_message(
+            Gtk.MessageType.INFO,
+            text,
+            secondary_text,
+            markup,
+            secondary_markup,
+            timeout,
+        )
 
-    def show_question(self, text=None, secondary_text=None,
-                      markup=None, secondary_markup=None):
+    def show_question(
+        self, text=None, secondary_text=None, markup=None, secondary_markup=None
+    ):
         """
             Convenience method which sets all
             required flags for a question message
@@ -1328,11 +1399,13 @@ class MessageBar(Gtk.InfoBar):
             :param markup: the message to display, in Pango markup format
             :param secondary_markup: additional information, in Pango markup format
         """
-        self._show_message(Gtk.MessageType.QUESTION, text, secondary_text,
-                           markup, secondary_markup, 0)
+        self._show_message(
+            Gtk.MessageType.QUESTION, text, secondary_text, markup, secondary_markup, 0
+        )
 
-    def show_warning(self, text=None, secondary_text=None,
-                     markup=None, secondary_markup=None):
+    def show_warning(
+        self, text=None, secondary_text=None, markup=None, secondary_markup=None
+    ):
         """
             Convenience method which sets all
             required flags for a warning message
@@ -1342,11 +1415,13 @@ class MessageBar(Gtk.InfoBar):
             :param markup: the message to display, in Pango markup format
             :param secondary_markup: additional information, in Pango markup format
         """
-        self._show_message(Gtk.MessageType.WARNING, text, secondary_text,
-                           markup, secondary_markup, 0)
+        self._show_message(
+            Gtk.MessageType.WARNING, text, secondary_text, markup, secondary_markup, 0
+        )
 
-    def show_error(self, text=None, secondary_text=None,
-                   markup=None, secondary_markup=None):
+    def show_error(
+        self, text=None, secondary_text=None, markup=None, secondary_markup=None
+    ):
         """
             Convenience method which sets all
             required flags for a warning message
@@ -1356,8 +1431,9 @@ class MessageBar(Gtk.InfoBar):
             :param markup: the message to display, in Pango markup format
             :param secondary_markup: additional information, in Pango markup format
         """
-        self._show_message(Gtk.MessageType.ERROR, text, secondary_text,
-                           markup, secondary_markup, 0)
+        self._show_message(
+            Gtk.MessageType.ERROR, text, secondary_text, markup, secondary_markup, 0
+        )
 
     def on_response(self, widget, response):
         """
@@ -1365,6 +1441,7 @@ class MessageBar(Gtk.InfoBar):
         """
         if response == Gtk.ResponseType.CLOSE:
             self.hide()
+
 
 #
 # Message ID's used by the XMessageDialog
@@ -1380,11 +1457,17 @@ XRESPONSE_CANCEL = Gtk.ResponseType.CANCEL
 class XMessageDialog(Gtk.Dialog):
     '''Used to show a custom message dialog with custom buttons'''
 
-    def __init__(self, title, text, parent=None,
-                 show_yes=True, show_yes_all=True,
-                 show_no=True, show_no_all=True,
-                 show_cancel=True,
-                 ):
+    def __init__(
+        self,
+        title,
+        text,
+        parent=None,
+        show_yes=True,
+        show_yes_all=True,
+        show_no=True,
+        show_no_all=True,
+        show_cancel=True,
+    ):
 
         Gtk.Dialog.__init__(self, title=title, transient_for=parent)
 
@@ -1429,8 +1512,8 @@ class FileCopyDialog(Gtk.Dialog):
 
         Do not use run() on this dialog!
     '''
-    class CopyThread(Thread):
 
+    class CopyThread(Thread):
         def __init__(self, source, dest, callback_finish_single_copy, copy_flags):
             Thread.__init__(self, name='CopyThread')
             self.__source = source
@@ -1442,9 +1525,9 @@ class FileCopyDialog(Gtk.Dialog):
 
         def run(self):
             try:
-                result = self.__source.copy(self.__dest,
-                                            flags=self.__copy_flags,
-                                            cancellable=self.__cancel)
+                result = self.__source.copy(
+                    self.__dest, flags=self.__copy_flags, cancellable=self.__cancel
+                )
                 GLib.idle_add(self.__cb_single_copy, self.__source, result, None)
             except GLib.Error as err:
                 GLib.idle_add(self.__cb_single_copy, self.__source, False, err)
@@ -1452,7 +1535,14 @@ class FileCopyDialog(Gtk.Dialog):
         def cancel_copy(self):
             self.__cancel.cancel()
 
-    def __init__(self, file_uris, destination_uri, title, text=_("Saved %(count)s of %(total)s."), parent=None):
+    def __init__(
+        self,
+        file_uris,
+        destination_uri,
+        title,
+        text=_("Saved %(count)s of %(total)s."),
+        parent=None,
+    ):
 
         self.file_uris = file_uris
         self.destination_uri = destination_uri
@@ -1488,7 +1578,7 @@ class FileCopyDialog(Gtk.Dialog):
         self.show_all()
 
         # TODO: Make dialog cancelable
-        #self.cancel_button.connect('activate', lambda *e: self.cancel.cancel() )
+        # self.cancel_button.connect('activate', lambda *e: self.cancel.cancel() )
 
         self.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
 
@@ -1508,12 +1598,8 @@ class FileCopyDialog(Gtk.Dialog):
     def _step(self):
         '''Steps the progress bar'''
         self.count += 1
-        self._progress.set_fraction(
-            clamp(self.count / float(self.total), 0, 1))
-        self._label.set_markup(self.text % {
-            'count': self.count,
-            'total': self.total
-        })
+        self._progress.set_fraction(clamp(self.count / float(self.total), 0, 1))
+        self._label.set_markup(self.text % {'count': self.count, 'total': self.total})
 
     def _start_next_copy(self, overwrite=False):
 
@@ -1534,7 +1620,10 @@ class FileCopyDialog(Gtk.Dialog):
                 if self.overwrite_response == XRESPONSE_YES_ALL:
                     overwrite = True
 
-                elif self.overwrite_response == XRESPONSE_NO_ALL or self.overwrite_response == XRESPONSE_NO:
+                elif (
+                    self.overwrite_response == XRESPONSE_NO_ALL
+                    or self.overwrite_response == XRESPONSE_NO
+                ):
 
                     # only deny the overwrite once..
                     if self.overwrite_response == XRESPONSE_NO:
@@ -1562,15 +1651,21 @@ class FileCopyDialog(Gtk.Dialog):
 
         # TODO g_file_copy_async() isn't introspectable
         # see https://github.com/exaile/exaile/issues/198 for details
-        #self.source.copy_async( self.destination, self._finish_single_copy_async, flags=flags, cancellable=self.cancel )
+        # self.source.copy_async( self.destination, self._finish_single_copy_async, flags=flags, cancellable=self.cancel )
 
-        self.cpthr = self.CopyThread(self.source, self.destination, self._finish_single_copy, flags)
+        self.cpthr = self.CopyThread(
+            self.source, self.destination, self._finish_single_copy, flags
+        )
 
     def _finish_single_copy(self, source, success, error):
         if error:
-            self._on_error(_("Error occurred while copying %s: %s") % (
-                GLib.markup_escape_text(self.source.get_uri()),
-                GLib.markup_escape_text(str(error))))
+            self._on_error(
+                _("Error occurred while copying %s: %s")
+                % (
+                    GLib.markup_escape_text(self.source.get_uri()),
+                    GLib.markup_escape_text(str(error)),
+                )
+            )
         if success:
             self._step()
             self._start_next_copy()
@@ -1582,15 +1677,21 @@ class FileCopyDialog(Gtk.Dialog):
                 self._step()
                 self._start_next_copy()
         except GLib.Error as e:
-            self._on_error(_("Error occurred while copying %s: %s") % (
-                GLib.markup_escape_text(self.source.get_uri()),
-                GLib.markup_escape_text(str(e))))
+            self._on_error(
+                _("Error occurred while copying %s: %s")
+                % (
+                    GLib.markup_escape_text(self.source.get_uri()),
+                    GLib.markup_escape_text(str(e)),
+                )
+            )
 
     def _query_overwrite(self):
 
         self.hide()
 
-        text = _('File exists, overwrite %s ?') % GLib.markup_escape_text(self.destination.get_uri())
+        text = _('File exists, overwrite %s ?') % GLib.markup_escape_text(
+            self.destination.get_uri()
+        )
         dialog = XMessageDialog(self.parent, text)
         dialog.connect('response', self._on_query_overwrite_response, dialog)
         dialog.show_all()
@@ -1616,7 +1717,12 @@ class FileCopyDialog(Gtk.Dialog):
 
         self.hide()
 
-        dialog = Gtk.MessageDialog(self.parent, Gtk.DialogFlags.MODAL, Gtk.MessageType.ERROR, Gtk.ButtonsType.CLOSE)
+        dialog = Gtk.MessageDialog(
+            self.parent,
+            Gtk.DialogFlags.MODAL,
+            Gtk.MessageType.ERROR,
+            Gtk.ButtonsType.CLOSE,
+        )
         dialog.set_markup(message)
         dialog.connect('response', self._on_error_response, dialog)
         dialog.show()
@@ -1643,7 +1749,9 @@ def ask_for_playlist_name(parent, playlist_manager, name=None):
             _('Playlist name:'),
             _('Add new playlist...'),
             name,
-            parent=parent, okbutton=Gtk.STOCK_ADD)
+            parent=parent,
+            okbutton=Gtk.STOCK_ADD,
+        )
 
         result = dialog.run()
         if result != Gtk.ResponseType.OK:
@@ -1660,7 +1768,9 @@ def ask_for_playlist_name(parent, playlist_manager, name=None):
             return name
 
 
-def save(parent, output_fname, output_setting=None, extensions=None, title=_("Save As")):
+def save(
+    parent, output_fname, output_setting=None, extensions=None, title=_("Save As")
+):
     """
         A 'save' dialog utility function, which can be used to easily
         remember the last location the user saved something.
@@ -1676,10 +1786,17 @@ def save(parent, output_fname, output_setting=None, extensions=None, title=_("Sa
 
     uri = None
 
-    dialog = FileOperationDialog(title, parent,
-                                 Gtk.FileChooserAction.SAVE,
-                                 (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                                  Gtk.STOCK_SAVE, Gtk.ResponseType.ACCEPT))
+    dialog = FileOperationDialog(
+        title,
+        parent,
+        Gtk.FileChooserAction.SAVE,
+        (
+            Gtk.STOCK_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_SAVE,
+            Gtk.ResponseType.ACCEPT,
+        ),
+    )
 
     if extensions is not None:
         dialog.add_extensions(extensions)
@@ -1720,12 +1837,14 @@ def export_playlist_files(playlist, parent=None):
         else:
             pl = playlist
         pl_files = [track.get_loc_for_io() for track in pl]
-        dialog = FileCopyDialog(pl_files, uri,
-                                _('Exporting %s') % playlist.name, parent=parent)
+        dialog = FileCopyDialog(
+            pl_files, uri, _('Exporting %s') % playlist.name, parent=parent
+        )
         dialog.do_copy()
 
-    dialog = DirectoryOpenDialog(title=_('Choose directory to export files to'),
-                                 parent=parent)
+    dialog = DirectoryOpenDialog(
+        title=_('Choose directory to export files to'), parent=parent
+    )
     dialog.set_select_multiple(False)
     dialog.connect('uris-selected', lambda widget, uris: _on_uri(uris[0]))
     dialog.run()

--- a/xlgui/widgets/filter.py
+++ b/xlgui/widgets/filter.py
@@ -51,8 +51,8 @@ class FilterDialog(Gtk.Dialog):
 
     __gtype_name__ = 'FilterDialog'
 
-    name_entry, filter, \
-        match_any, random, lim_check, lim_spin \
+    (name_entry, filter, \
+        match_any, random, lim_check, lim_spin) \
         = GtkTemplate.Child.widgets(6)
 
     def __init__(self, title, parent, criteria):

--- a/xlgui/widgets/filter.py
+++ b/xlgui/widgets/filter.py
@@ -51,9 +51,14 @@ class FilterDialog(Gtk.Dialog):
 
     __gtype_name__ = 'FilterDialog'
 
-    (name_entry, filter, \
-        match_any, random, lim_check, lim_spin) \
-        = GtkTemplate.Child.widgets(6)
+    (
+        name_entry,
+        filter,
+        match_any,
+        random,
+        lim_check,
+        lim_spin,
+    ) = GtkTemplate.Child.widgets(6)
 
     def __init__(self, title, parent, criteria):
         """Create a filter dialog.
@@ -66,8 +71,12 @@ class FilterDialog(Gtk.Dialog):
         Gtk.Dialog.__init__(self, title=title, transient_for=parent)
         self.init_template()
 
-        self.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.REJECT,
-                         Gtk.STOCK_OK, Gtk.ResponseType.ACCEPT)
+        self.add_buttons(
+            Gtk.STOCK_CANCEL,
+            Gtk.ResponseType.REJECT,
+            Gtk.STOCK_OK,
+            Gtk.ResponseType.ACCEPT,
+        )
 
         f = FilterWidget(sorted(criteria, key=lambda k: _(k[0])))
         f.add_criteria_row()
@@ -229,8 +238,7 @@ class FilterWidget(Gtk.Grid):
         image = Gtk.Image()
         image.set_from_icon_name('list-remove', Gtk.IconSize.BUTTON)
         remove_btn.add(image)
-        remove_btn_handler_id = remove_btn.connect(
-            'clicked', self.__remove_clicked)
+        remove_btn_handler_id = remove_btn.connect('clicked', self.__remove_clicked)
         remove_btn.show_all()
 
         self.attach(criterion, 0, n, 1, 1)
@@ -357,6 +365,7 @@ class Criterion(Gtk.Box):
             if len(state) > 1:
                 self.child.set_state(state[1])
 
+
 # Sample fields
 
 
@@ -431,7 +440,6 @@ class MultiEntryField(Gtk.Box):
 
 
 class EntryField(Gtk.Entry):
-
     def __init__(self):
         Gtk.Entry.__init__(self)
 
@@ -445,7 +453,6 @@ class EntryField(Gtk.Entry):
 
 
 class QuotedEntryField(Gtk.Entry):
-
     def __init__(self):
         Gtk.Entry.__init__(self)
 
@@ -459,13 +466,11 @@ class QuotedEntryField(Gtk.Entry):
 
 
 class EntryLabelEntryField(MultiEntryField):
-
     def __init__(self, label):
         MultiEntryField.__init__(self, (50, label, 50))
 
 
 class SpinLabelField(Gtk.Box):
-
     def __init__(self, label='', top=999999, lower=-999999):
         Gtk.Box.__init__(self, spacing=5)
         self.spin = Gtk.SpinButton.new_with_range(lower, top, 1)
@@ -487,7 +492,6 @@ class SpinLabelField(Gtk.Box):
 
 
 class SpinButtonAndComboField(Gtk.Box):
-
     def __init__(self, items=()):
         Gtk.Box.__init__(self, spacing=5)
         self.items = items

--- a/xlgui/widgets/info.py
+++ b/xlgui/widgets/info.py
@@ -29,19 +29,10 @@ from gi.repository import GLib
 from gi.repository import Gtk
 from gi.repository import Pango
 
-from xl import (
-    event,
-    formatter,
-    main,
-    settings,
-    xdg
-)
+from xl import event, formatter, main, settings, xdg
 from xl.nls import gettext as _
 import xlgui
-from xlgui import (
-    cover,
-    guiutil
-)
+from xlgui import cover, guiutil
 from xlgui.widgets import playlist
 from xlgui.widgets.playback import PlaybackProgressBar
 
@@ -56,8 +47,7 @@ class TrackInfoPane(Gtk.Bin):
         self.__player = player
 
         builder = Gtk.Builder()
-        builder.add_from_file(xdg.get_data_path(
-            'ui', 'widgets', 'track_info.ui'))
+        builder.add_from_file(xdg.get_data_path('ui', 'widgets', 'track_info.ui'))
 
         info_box = builder.get_object('info_box')
         info_box.reparent(self)
@@ -65,13 +55,16 @@ class TrackInfoPane(Gtk.Bin):
         self.__auto_update = False
         self.__display_progress = False
         self.__formatter = formatter.TrackFormatter(
-            _('<span size="x-large" weight="bold">$title</span>\n'
-              'by $artist\n'
-              'from $album')
+            _(
+                '<span size="x-large" weight="bold">$title</span>\n'
+                'by $artist\n'
+                'from $album'
+            )
         )
         self.__formatter.connect('notify::format', self.on_notify_format)
-        self.__default_text = ('<span size="x-large" '
-                               'weight="bold">%s</span>\n\n' % _('Not Playing'))
+        self.__default_text = '<span size="x-large" ' 'weight="bold">%s</span>\n\n' % _(
+            'Not Playing'
+        )
         self.__cover_size = None
         self.__timer = None
         self.__track = None
@@ -81,8 +74,7 @@ class TrackInfoPane(Gtk.Bin):
         self.progress_box = builder.get_object('progress_box')
         self.playback_image = builder.get_object('playback_image')
         self.progressbar = PlaybackProgressBar(player)
-        guiutil.gtk_widget_replace(builder.get_object('progressbar'),
-                                   self.progressbar)
+        guiutil.gtk_widget_replace(builder.get_object('progressbar'), self.progressbar)
 
         self.cover = cover.CoverWidget(builder.get_object('cover_image'))
         self.cover.hide()
@@ -121,8 +113,12 @@ class TrackInfoPane(Gtk.Bin):
         if auto_update != self.__auto_update:
             self.__auto_update = auto_update
 
-            p_evts = ['playback_player_end', 'playback_track_start',
-                      'playback_toggle_pause', 'playback_error']
+            p_evts = [
+                'playback_player_end',
+                'playback_track_start',
+                'playback_toggle_pause',
+                'playback_error',
+            ]
             events = ['track_tags_changed', 'cover_set', 'cover_removed']
 
             if auto_update:
@@ -144,8 +140,7 @@ class TrackInfoPane(Gtk.Bin):
 
             :rtype: int
         """
-        return self.__cover_size or \
-            settings.get_option('gui/cover_width', 100)
+        return self.__cover_size or settings.get_option('gui/cover_width', 100)
 
     def set_cover_size(self, cover_size):
         """
@@ -233,21 +228,20 @@ class TrackInfoPane(Gtk.Bin):
 
         self.cover.set_track(track)
 
-        self.info_label.set_markup(self.__formatter.format(
-            track, markup_escape=True))
+        self.info_label.set_markup(self.__formatter.format(track, markup_escape=True))
         self.__update_widget_state()
 
     def __update_widget_state(self):
         if self.__display_progress:
-            if self.__track == self.__player.current and \
-               not self.__player.is_stopped():
+            if self.__track == self.__player.current and not self.__player.is_stopped():
 
                 if self.__player.is_paused():
                     icon_name = 'media-playback-pause'
                 else:
                     icon_name = 'media-playback-start'
                 self.playback_image.set_from_icon_name(
-                    icon_name, Gtk.IconSize.SMALL_TOOLBAR)
+                    icon_name, Gtk.IconSize.SMALL_TOOLBAR
+                )
 
             self.progress_box.set_no_show_all(False)
             self.progress_box.set_visible(True)
@@ -312,9 +306,11 @@ class TrackInfoPane(Gtk.Bin):
         """
             Updates the info pane on tag changes
         """
-        if self.__player is not None and \
-           not self.__player.is_stopped() and \
-           track is self.__track:
+        if (
+            self.__player is not None
+            and not self.__player.is_stopped()
+            and track is self.__track
+        ):
             self.set_track(track)
 
     def on_cover_set(self, event, covers, track):
@@ -346,8 +342,10 @@ class ToolTip(object):
                 for the tooltip
         """
         if self.__class__.__name__ == 'ToolTip':
-            raise TypeError("cannot create instance of abstract "
-                            "(non-instantiable) type `ToolTip'")
+            raise TypeError(
+                "cannot create instance of abstract "
+                "(non-instantiable) type `ToolTip'"
+            )
 
         self.__widget = widget
         self.__widget.unparent()  # Just to be sure
@@ -406,7 +404,7 @@ class StatusbarTextFormatter(formatter.Formatter):
         self._substitutions = {
             'collection_count': self.get_collection_count,
             'playlist_count': self.get_playlist_count,
-            'playlist_duration': self.get_playlist_duration
+            'playlist_duration': self.get_playlist_duration,
         }
 
     def get_collection_count(self):
@@ -450,9 +448,11 @@ class StatusbarTextFormatter(formatter.Formatter):
             else:
                 count = 0
         else:
-            raise ValueError('Invalid argument "%s" passed to parameter '
-                             '"selection" for "playlist_count", possible arguments are '
-                             '"none", "override" and "only"' % selection)
+            raise ValueError(
+                'Invalid argument "%s" passed to parameter '
+                '"selection" for "playlist_count", possible arguments are '
+                '"none", "override" and "only"' % selection
+            )
 
         if count == 0:
             return ''
@@ -479,12 +479,12 @@ class StatusbarTextFormatter(formatter.Formatter):
         if not isinstance(page, playlist.PlaylistPage):
             return ''
 
-        playlist_duration = sum(t.get_tag_raw('__length') or 0
-                                for t in page.playlist)
+        playlist_duration = sum(t.get_tag_raw('__length') or 0 for t in page.playlist)
         selection_tracks = page.view.get_selected_tracks()
         selection_count = len(selection_tracks)
-        selection_duration = sum(t.get_tag_raw('__length') or 0
-                                 for t in selection_tracks)
+        selection_duration = sum(
+            t.get_tag_raw('__length') or 0 for t in selection_tracks
+        )
 
         if selection == 'none':
             duration = playlist_duration
@@ -499,9 +499,11 @@ class StatusbarTextFormatter(formatter.Formatter):
             else:
                 duration = 0
         else:
-            raise ValueError('Invalid argument "%s" passed to parameter '
-                             '"selection" for "playlist_duration", possible arguments are '
-                             '"none", "override" and "only"' % selection)
+            raise ValueError(
+                'Invalid argument "%s" passed to parameter '
+                '"selection" for "playlist_duration", possible arguments are '
+                '"none", "override" and "only"' % selection
+            )
 
         if duration == 0:
             return ''
@@ -523,10 +525,13 @@ class Statusbar(object):
         # widgets of the status bar into it.
         self.status_bar = status_bar
         self.formatter = StatusbarTextFormatter(
-            settings.get_option('gui/statusbar_info_format',
-                                '${playlist_count:selection=override, suffix= }'
-                                '${playlist_duration:selection=override, format=long, prefix=(, suffix=)\, }'
-                                '$collection_count'))
+            settings.get_option(
+                'gui/statusbar_info_format',
+                '${playlist_count:selection=override, suffix= }'
+                '${playlist_duration:selection=override, format=long, prefix=(, suffix=)\, }'
+                '$collection_count',
+            )
+        )
 
         self.info_label = Gtk.Label()
 
@@ -539,7 +544,7 @@ class Statusbar(object):
 
         # TODO: GI
         # self.status_bar.set_app_paintable(True)
-        #self.status_bar.connect('draw', self.on_draw)
+        # self.status_bar.connect('draw', self.on_draw)
 
     def set_status(self, status, timeout=0):
         """

--- a/xlgui/widgets/menu.py
+++ b/xlgui/widgets/menu.py
@@ -37,6 +37,7 @@ def simple_separator(name, after):
     def factory(menu, parent, context):
         item = Gtk.SeparatorMenuItem()
         return item
+
     item = MenuItem(name, factory, after=after)
     item._pos = 'last'
     return item
@@ -53,9 +54,17 @@ def _get_accel(callback, display_name):
     return accelerator, callback, display_name
 
 
-def simple_menu_item(name, after, display_name=None, icon_name=None,
-                     callback=None, callback_args=[], submenu=None,
-                     condition_fn=None, sensitive_cb=None):
+def simple_menu_item(
+    name,
+    after,
+    display_name=None,
+    icon_name=None,
+    callback=None,
+    callback_args=[],
+    submenu=None,
+    condition_fn=None,
+    sensitive_cb=None,
+):
     """
         Factory function that should handle most cases for menus
 
@@ -75,7 +84,7 @@ def simple_menu_item(name, after, display_name=None, icon_name=None,
                              will be disabled
     """
     accelerator, callback, display_name = _get_accel(callback, display_name)
-    
+
     def factory(menu, parent, context):
         item = None
 
@@ -85,8 +94,7 @@ def simple_menu_item(name, after, display_name=None, icon_name=None,
         if display_name is not None:
             if icon_name is not None:
                 item = Gtk.ImageMenuItem.new_from_stock(display_name)
-                image = Gtk.Image.new_from_icon_name(icon_name,
-                                                     size=Gtk.IconSize.MENU)
+                image = Gtk.Image.new_from_icon_name(icon_name, size=Gtk.IconSize.MENU)
                 item.set_image(image)
             else:
                 item = Gtk.MenuItem.new_with_mnemonic(display_name)
@@ -97,18 +105,22 @@ def simple_menu_item(name, after, display_name=None, icon_name=None,
             item.set_submenu(submenu)
 
         if accelerator is not None:
-            item.add_accelerator('activate', FAKEACCELGROUP,
-                                 accelerator.key, accelerator.mods,
-                                 Gtk.AccelFlags.VISIBLE)
+            item.add_accelerator(
+                'activate',
+                FAKEACCELGROUP,
+                accelerator.key,
+                accelerator.mods,
+                Gtk.AccelFlags.VISIBLE,
+            )
 
         if callback is not None:
-            item.connect('activate', callback, name,
-                         parent, context, *callback_args)
-        
+            item.connect('activate', callback, name, parent, context, *callback_args)
+
         if sensitive_cb is not None and not sensitive_cb():
             item.set_sensitive(False)
-        
+
         return item
+
     return MenuItem(name, factory, after=after)
 
 
@@ -120,17 +132,20 @@ def check_menu_item(name, after, display_name, checked_func, callback):
         active = checked_func(name, parent, context)
         item.set_active(active)
         if accelerator is not None:
-            item.add_accelerator('activate', FAKEACCELGROUP,
-                                 accelerator.key, accelerator.mods,
-                                 Gtk.AccelFlags.VISIBLE)
+            item.add_accelerator(
+                'activate',
+                FAKEACCELGROUP,
+                accelerator.key,
+                accelerator.mods,
+                Gtk.AccelFlags.VISIBLE,
+            )
         item.connect('activate', callback, name, parent, context)
         return item
+
     return MenuItem(name, factory, after=after)
 
 
-def radio_menu_item(name, after, display_name, groupname, selected_func,
-                    callback):
-
+def radio_menu_item(name, after, display_name, groupname, selected_func, callback):
     def factory(menu, parent, context):
         for index, item in enumerate(menu._items):
             if hasattr(item, 'groupname') and item.groupname == groupname:
@@ -157,6 +172,7 @@ def radio_menu_item(name, after, display_name, groupname, selected_func,
 
         item.connect('activate', callback, name, parent, context)
         return item
+
     return RadioMenuItem(name, factory, after=after, groupname=groupname)
 
 
@@ -256,7 +272,7 @@ class Menu(Gtk.Menu):
         """
         self._items.append(item)
         self.reorder_items()
-    
+
     def add_simple(self, label, callback, icon_name=None):
         """
             Provide a simple mechanism to add menu items without a lot of hassle
@@ -269,8 +285,13 @@ class Menu(Gtk.Menu):
                       API to add items to that menu
         """
         self.add_item(
-            simple_menu_item('_i%s' % len(self._items), [], label,
-            icon_name=icon_name, callback=callback)
+            simple_menu_item(
+                '_i%s' % len(self._items),
+                [],
+                label,
+                icon_name=icon_name,
+                callback=callback,
+            )
         )
 
     def remove_item(self, item):
@@ -300,9 +321,10 @@ class Menu(Gtk.Menu):
             Reorders all menu items
         """
         pmap = {'first': 0, 'normal': 1, 'last': 2}
-        items = [common.PosetItem(i.name, i.after,
-                                  pmap[i._pos], value=i)
-                 for i in self._items]
+        items = [
+            common.PosetItem(i.name, i.after, pmap[i._pos], value=i)
+            for i in self._items
+        ]
         items = common.order_poset(items)
         self._items = [i.value for i in items]
 

--- a/xlgui/widgets/menuitems.py
+++ b/xlgui/widgets/menuitems.py
@@ -68,18 +68,20 @@ class RatingMenuItem(menu.MenuItem):
 
         # TODO: For accessibility it would be nice to add mnemonics or some
         # other key shortcut thing to the RatingMenu, e.g. "+" and "-"
+
     def factory(self, menu, parent, context):
         # don't show rating widget for computed track selections (see #340)
         if context.get('needs-computing'):
             return
         item = rating.RatingMenuItem()
         item.connect('show', self.on_show, menu, parent, context)
-        self._rating_changed_id = item.connect('rating-changed',
-                                               self.on_rating_changed, menu, parent, context)
+        self._rating_changed_id = item.connect(
+            'rating-changed', self.on_rating_changed, menu, parent, context
+        )
 
         return item
 
-    #@common.threaded
+    # @common.threaded
     # TODO: ASYNC
     # most of this function isn't safe to use from a (interacts with UI elements)
     def on_show(self, widget, menu, parent, context):
@@ -90,8 +92,9 @@ class RatingMenuItem(menu.MenuItem):
         rating = trax.util.get_rating_from_tracks(tracks)
         widget.disconnect(self._rating_changed_id)
         widget.props.rating = rating
-        self._rating_changed_id = widget.connect('rating-changed',
-                                                 self.on_rating_changed, menu, parent, context)
+        self._rating_changed_id = widget.connect(
+            'rating-changed', self.on_rating_changed, menu, parent, context
+        )
 
     def on_rating_changed(self, widget, rating, menu, parent, context):
         """
@@ -108,14 +111,22 @@ def _enqueue_cb(widget, name, parent, context, get_tracks_func):
 
 
 def EnqueueMenuItem(name, after, get_tracks_func=generic_get_tracks_func):
-    return menu.simple_menu_item(name, after, _("En_queue"), 'list-add',
-                                 _enqueue_cb, callback_args=[get_tracks_func])
+    return menu.simple_menu_item(
+        name,
+        after,
+        _("En_queue"),
+        'list-add',
+        _enqueue_cb,
+        callback_args=[get_tracks_func],
+    )
+
 
 # TODO: move logic into (GUI?) playlist
 
 
 def _append_cb(widget, name, parent, context, get_tracks_func, replace=False):
     from xlgui import main
+
     page = main.get_selected_playlist()
     if not page:
         return
@@ -126,7 +137,7 @@ def _append_cb(widget, name, parent, context, get_tracks_func, replace=False):
     tracks = get_tracks_func(parent, context)
     # This is well-intentioned, but it leads to odd effects (see #147)
     # -> this is more proof that the playlist needs to handle this logic
-    #sort_by, reverse = page.view.get_sort_by()
+    # sort_by, reverse = page.view.get_sort_by()
     # tracks = trax.sort_tracks(sort_by, tracks, reverse=reverse,
     #    artist_compilations=True)
     pl.extend(tracks)
@@ -136,13 +147,25 @@ def _append_cb(widget, name, parent, context, get_tracks_func, replace=False):
 
 
 def ReplaceCurrentMenuItem(name, after, get_tracks_func=generic_get_tracks_func):
-    return menu.simple_menu_item(name, after, _("_Replace Current"), None,
-                                 _append_cb, callback_args=[get_tracks_func, True])
+    return menu.simple_menu_item(
+        name,
+        after,
+        _("_Replace Current"),
+        None,
+        _append_cb,
+        callback_args=[get_tracks_func, True],
+    )
 
 
 def AppendMenuItem(name, after, get_tracks_func=generic_get_tracks_func):
-    return menu.simple_menu_item(name, after, _("_Append to Current"),
-                                 'list-add', _append_cb, callback_args=[get_tracks_func])
+    return menu.simple_menu_item(
+        name,
+        after,
+        _("_Append to Current"),
+        'list-add',
+        _append_cb,
+        callback_args=[get_tracks_func],
+    )
 
 
 def _properties_cb(widget, name, parent, context, get_tracks_func, dialog_parent):
@@ -151,11 +174,17 @@ def _properties_cb(widget, name, parent, context, get_tracks_func, dialog_parent
         properties.TrackPropertiesDialog(dialog_parent, tracks)
 
 
-def PropertiesMenuItem(name, after, get_tracks_func=generic_get_tracks_func,
-                       dialog_parent=None):
-    return menu.simple_menu_item(name, after, _("_Track Properties"),
-                                 'document-properties', _properties_cb,
-                                 callback_args=[get_tracks_func, dialog_parent])
+def PropertiesMenuItem(
+    name, after, get_tracks_func=generic_get_tracks_func, dialog_parent=None
+):
+    return menu.simple_menu_item(
+        name,
+        after,
+        _("_Track Properties"),
+        'document-properties',
+        _properties_cb,
+        callback_args=[get_tracks_func, dialog_parent],
+    )
 
 
 def _open_directory_cb(widget, name, parent, context, get_tracks_func):
@@ -167,8 +196,14 @@ def _open_directory_cb(widget, name, parent, context, get_tracks_func):
 
 
 def OpenDirectoryMenuItem(name, after, get_tracks_func=generic_get_tracks_func):
-    return menu.simple_menu_item(name, after, _("_Open Directory"),
-                                 'folder-open', _open_directory_cb, callback_args=[get_tracks_func])
+    return menu.simple_menu_item(
+        name,
+        after,
+        _("_Open Directory"),
+        'folder-open',
+        _open_directory_cb,
+        callback_args=[get_tracks_func],
+    )
 
 
 def generic_trash_tracks_func(parent, context, tracks):
@@ -183,22 +218,38 @@ def generic_delete_tracks_func(parent, context, tracks):
         gfile.delete()
 
 
-def _on_trash_tracks(widget, name, parent, context,
-                     get_tracks_func, trash_tracks_func, delete_tracks_func):
+def _on_trash_tracks(
+    widget,
+    name,
+    parent,
+    context,
+    get_tracks_func,
+    trash_tracks_func,
+    delete_tracks_func,
+):
 
     tracks = get_tracks_func(parent, context)
 
     try:
         trash_tracks_func(parent, context, tracks)
     except GLib.GError:
-        dialog = Gtk.MessageDialog(parent=parent.parent,
-                                   message_type=Gtk.MessageType.WARNING,
-                                   text=_('The files cannot be moved to the Trash. '
-                                          'Delete them permanently from the disk?'))
+        dialog = Gtk.MessageDialog(
+            parent=parent.parent,
+            message_type=Gtk.MessageType.WARNING,
+            text=_(
+                'The files cannot be moved to the Trash. '
+                'Delete them permanently from the disk?'
+            ),
+        )
         dialog.add_buttons(
-            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-            Gtk.STOCK_DELETE, Gtk.ResponseType.OK)
-        dialog.set_alternative_button_order_from_array((Gtk.ResponseType.OK, Gtk.ResponseType.CANCEL))
+            Gtk.STOCK_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_DELETE,
+            Gtk.ResponseType.OK,
+        )
+        dialog.set_alternative_button_order_from_array(
+            (Gtk.ResponseType.OK, Gtk.ResponseType.CANCEL)
+        )
 
         if dialog.run() == Gtk.ResponseType.OK:
             delete_tracks_func(parent, context, tracks)
@@ -206,12 +257,22 @@ def _on_trash_tracks(widget, name, parent, context,
         dialog.destroy()
 
 
-def TrashMenuItem(name, after, get_tracks_func=generic_get_tracks_func,
-                  trash_tracks_func=generic_trash_tracks_func,
-                  delete_tracks_func=generic_delete_tracks_func):
-    return menu.simple_menu_item(name, after, _('_Move to Trash'), 'user-trash',
-                                 _on_trash_tracks, callback_args=[get_tracks_func,
-                                                                  trash_tracks_func, delete_tracks_func])
+def TrashMenuItem(
+    name,
+    after,
+    get_tracks_func=generic_get_tracks_func,
+    trash_tracks_func=generic_trash_tracks_func,
+    delete_tracks_func=generic_delete_tracks_func,
+):
+    return menu.simple_menu_item(
+        name,
+        after,
+        _('_Move to Trash'),
+        'user-trash',
+        _on_trash_tracks,
+        callback_args=[get_tracks_func, trash_tracks_func, delete_tracks_func],
+    )
+
 
 ### END TRACKS ITEMS ###
 
@@ -222,30 +283,59 @@ def TrashMenuItem(name, after, get_tracks_func=generic_get_tracks_func,
 
 
 def RenamePlaylistMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('_Rename'), 'accessories-text-editor',
-                                 lambda w, n, o, c: o.rename_playlist(get_pl_func(o, c)),
-                                 condition_fn=lambda n, p, c: not isinstance(c['selected-playlist'], playlist.SmartPlaylist))
+    return menu.simple_menu_item(
+        name,
+        after,
+        _('_Rename'),
+        'accessories-text-editor',
+        lambda w, n, o, c: o.rename_playlist(get_pl_func(o, c)),
+        condition_fn=lambda n, p, c: not isinstance(
+            c['selected-playlist'], playlist.SmartPlaylist
+        ),
+    )
 
 
 def EditPlaylistMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('_Edit'), 'accessories-text-editor',
-                                 lambda w, n, o, c: o.edit_smart_playlist(get_pl_func(o, c)),
-                                 condition_fn=lambda n, p, c: isinstance(c['selected-playlist'], playlist.SmartPlaylist))
+    return menu.simple_menu_item(
+        name,
+        after,
+        _('_Edit'),
+        'accessories-text-editor',
+        lambda w, n, o, c: o.edit_smart_playlist(get_pl_func(o, c)),
+        condition_fn=lambda n, p, c: isinstance(
+            c['selected-playlist'], playlist.SmartPlaylist
+        ),
+    )
 
 
 def ExportPlaylistMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('E_xport Playlist'), 'document-save-as',
-                                 lambda w, n, o, c: dialogs.export_playlist_dialog(get_pl_func(o, c)))
+    return menu.simple_menu_item(
+        name,
+        after,
+        _('E_xport Playlist'),
+        'document-save-as',
+        lambda w, n, o, c: dialogs.export_playlist_dialog(get_pl_func(o, c)),
+    )
 
 
 def ExportPlaylistFilesMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('Export _Files'), 'document-save-as',
-                                 lambda w, n, o, c: dialogs.export_playlist_files(get_pl_func(o, c)))
+    return menu.simple_menu_item(
+        name,
+        after,
+        _('Export _Files'),
+        'document-save-as',
+        lambda w, n, o, c: dialogs.export_playlist_files(get_pl_func(o, c)),
+    )
 
 
 def DeletePlaylistMenuItem(name, after, get_pl_func=generic_get_playlist_func):
-    return menu.simple_menu_item(name, after, _('_Delete Playlist'), 'edit-delete',
-                                 lambda w, n, o, c: o.remove_playlist(get_pl_func(o, c)))
+    return menu.simple_menu_item(
+        name,
+        after,
+        _('_Delete Playlist'),
+        'edit-delete',
+        lambda w, n, o, c: o.remove_playlist(get_pl_func(o, c)),
+    )
 
 
 ### END PLAYLIST ITEMS ###

--- a/xlgui/widgets/notebook.py
+++ b/xlgui/widgets/notebook.py
@@ -40,36 +40,40 @@ if (Gtk.MAJOR_VERSION, Gtk.MINOR_VERSION) >= (3, 20):
     TAB_CSS.load_from_data(
         # Work around weird Close button position on panel.
         # Need to find out why the button is not centered.
-        'notebook.vertical tab { ' +
-        'padding-left: 6px; ' +
-        'padding-right: 3px; ' +
-        '} ' +
-
+        'notebook.vertical tab { '
+        + 'padding-left: 6px; '
+        + 'padding-right: 3px; '
+        + '} '
+        +
         # Remove gap between tabs
-        'header.top tab, header.bottom tab { ' +
-        'margin-left: -1px; ' +
-        'margin-right: -1px; ' +
-        '} ' +
-        'header.left tab, header.right tab { ' +
-        'margin-top: -1px; ' +
-        'margin-bottom: -1px; ' +
-        '}')
+        'header.top tab, header.bottom tab { '
+        + 'margin-left: -1px; '
+        + 'margin-right: -1px; '
+        + '} '
+        + 'header.left tab, header.right tab { '
+        + 'margin-top: -1px; '
+        + 'margin-bottom: -1px; '
+        + '}'
+    )
 else:
     TAB_CSS.load_from_data(
-        '.notebook { ' +
+        '.notebook { '
+        +
         # Remove gap before first tab
-        '-GtkNotebook-initial-gap: 0; ' +
+        '-GtkNotebook-initial-gap: 0; '
+        +
         # Remove gap between tabs
-        '-GtkNotebook-tab-overlap: 1; ' +
-        '} ' +
-        '.notebook tab { ' +
+        '-GtkNotebook-tab-overlap: 1; '
+        + '} '
+        + '.notebook tab { '
+        +
         # Make tabs smaller (or bigger on some other themes, unfortunately)
-        'padding: 6px; ' +
-        '}')
+        'padding: 6px; '
+        + '}'
+    )
 
 
 class SmartNotebook(Gtk.Notebook):
-
     def __init__(self, vertical=False):
         Gtk.Notebook.__init__(self)
         self.set_scrollable(True)
@@ -151,14 +155,16 @@ class SmartNotebook(Gtk.Notebook):
         self._add_tab_on_empty = add_tab_on_empty
 
     def on_button_press(self, widget, event):
-        if event.type == Gdk.EventType.BUTTON_PRESS and event.button == Gdk.BUTTON_MIDDLE:
+        if (
+            event.type == Gdk.EventType.BUTTON_PRESS
+            and event.button == Gdk.BUTTON_MIDDLE
+        ):
             self.add_default_tab()
 
     def on_popup_menu(self, widget):
         page = self.get_current_tab()
         tab_label = self.get_tab_label(self.get_current_tab())
-        page.tab_menu.popup(None, None, guiutil.position_menu, tab_label,
-                            0, 0)
+        page.tab_menu.popup(None, None, guiutil.position_menu, tab_label, 0, 0)
         return True
 
     def __on_notify_tab_pos(self, _widget, _param):
@@ -175,6 +181,7 @@ class NotebookTab(Gtk.EventBox):
     """
         Class to represent a generic tab in a Gtk.Notebook.
     """
+
     reorderable = True
 
     def __init__(self, notebook, page, vertical=False):
@@ -298,13 +305,15 @@ class NotebookTab(Gtk.EventBox):
 
             Typically triggers renaming, closing and menu.
         """
-        if event.button == Gdk.BUTTON_PRIMARY and event.type == Gdk.EventType._2BUTTON_PRESS:
+        if (
+            event.button == Gdk.BUTTON_PRIMARY
+            and event.type == Gdk.EventType._2BUTTON_PRESS
+        ):
             self.start_rename()
         elif event.button == Gdk.BUTTON_MIDDLE:
             self.close()
         elif event.triggers_context_menu():
-            self.page.tab_menu.popup(None, None, None, None,
-                                     event.button, event.time)
+            self.page.tab_menu.popup(None, None, None, None, event.button, event.time)
             return True
 
     def on_entry_activate(self, entry):
@@ -375,19 +384,12 @@ class NotebookPage(Gtk.Box):
     """
         Base class representing a page. Should never be used directly.
     """
+
     menu_provider_name = 'tab-context'  # override this in subclasses
     reorderable = True
     __gsignals__ = {
-        'name-changed': (
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            ()
-        ),
-        'closing': (
-            GObject.SignalFlags.RUN_LAST,
-            GObject.TYPE_BOOLEAN,
-            ()
-        )
+        'name-changed': (GObject.SignalFlags.RUN_LAST, None, ()),
+        'closing': (GObject.SignalFlags.RUN_LAST, GObject.TYPE_BOOLEAN, ()),
     }
 
     def __init__(self, child=None, page_name=None, menu_provider_name=None):
@@ -446,6 +448,7 @@ class NotebookAction(object):
     """
         A custom action to be placed to the left or right of tabs in a notebook
     """
+
     name = None
     position = Gtk.PackType.END
 

--- a/xlgui/widgets/playback.py
+++ b/xlgui/widgets/playback.py
@@ -1385,10 +1385,10 @@ class VolumeControl(Gtk.Box):
 
     __gtype_name__ = 'VolumeControl'
 
-    button,             \
+    (button,             \
         slider,             \
         button_image,       \
-        slider_adjustment = GtkTemplate.Child.widgets(4)
+        slider_adjustment) = GtkTemplate.Child.widgets(4)
 
     def __init__(self, player):
         Gtk.Box.__init__(self)

--- a/xlgui/widgets/playback.py
+++ b/xlgui/widgets/playback.py
@@ -31,13 +31,7 @@ from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Pango
 
-from xl import (
-    event,
-    formatter,
-    player,
-    providers,
-    settings,
-)
+from xl import event, formatter, player, providers, settings
 from xl.common import clamp
 from xl.nls import gettext as _
 from xlgui.widgets import menu
@@ -45,6 +39,7 @@ from xlgui.widgets import menu
 from xlgui.guiutil import GtkTemplate
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -56,8 +51,7 @@ class ProgressBarFormatter(formatter.ProgressTextFormatter):
     def __init__(self, player):
         formatter.ProgressTextFormatter.__init__(self, '', player)
 
-        self.on_option_set('gui_option_set', settings,
-                           'gui/progress_bar_text_format')
+        self.on_option_set('gui_option_set', settings, 'gui/progress_bar_text_format')
         event.add_ui_callback(self.on_option_set, 'gui_option_set')
 
     def on_option_set(self, event, settings, option):
@@ -66,8 +60,8 @@ class ProgressBarFormatter(formatter.ProgressTextFormatter):
         """
         if option == 'gui/progress_bar_text_format':
             self.props.format = settings.get_option(
-                'gui/progress_bar_text_format',
-                '$current_time / $remaining_time')
+                'gui/progress_bar_text_format', '$current_time / $remaining_time'
+            )
 
 
 class PlaybackProgressBar(Gtk.ProgressBar):
@@ -91,8 +85,12 @@ class PlaybackProgressBar(Gtk.ProgressBar):
 
         self.formatter = ProgressBarFormatter(player)
         self.__timer_id = None
-        self.__events = ('playback_track_start', 'playback_player_end',
-                         'playback_toggle_pause', 'playback_error')
+        self.__events = (
+            'playback_track_start',
+            'playback_player_end',
+            'playback_toggle_pause',
+            'playback_error',
+        )
 
         for e in self.__events:
             event.add_ui_callback(getattr(self, 'on_%s' % e), e, self.__player)
@@ -121,11 +119,9 @@ class PlaybackProgressBar(Gtk.ProgressBar):
         interval = settings.get_option('gui/progress_update_millisecs', 1000)
 
         if interval % 1000 == 0:
-            self.__timer_id = GLib.timeout_add_seconds(
-                interval / 1000, self.on_timer)
+            self.__timer_id = GLib.timeout_add_seconds(interval / 1000, self.on_timer)
         else:
-            self.__timer_id = GLib.timeout_add(
-                interval, self.on_timer)
+            self.__timer_id = GLib.timeout_add(interval, self.on_timer)
 
         self.on_timer()
 
@@ -185,7 +181,10 @@ class PlaybackProgressBar(Gtk.ProgressBar):
 class Anchor(int):
     __gtype__ = GObject.TYPE_INT
 
-for i, a in enumerate('CENTER NORTH NORTH_WEST NORTH_EAST SOUTH SOUTH_WEST SOUTH_EAST WEST EAST'.split()):
+
+for i, a in enumerate(
+    'CENTER NORTH NORTH_WEST NORTH_EAST SOUTH SOUTH_WEST SOUTH_EAST WEST EAST'.split()
+):
     setattr(Anchor, a, Anchor(i))
 
 
@@ -193,49 +192,48 @@ class Marker(GObject.GObject):
     """
         A marker pointing to a playback position
     """
+
     __gproperties__ = {
         'anchor': (
             Anchor,
             'anchor position',
             'The position the marker will be anchored',
-            Anchor.CENTER, Anchor.EAST, Anchor.SOUTH,
-            GObject.PARAM_READWRITE
+            Anchor.CENTER,
+            Anchor.EAST,
+            Anchor.SOUTH,
+            GObject.PARAM_READWRITE,
         ),
         'color': (
             Gdk.RGBA,
             'marker color',
             'Override color of the marker',
-            GObject.PARAM_READWRITE
+            GObject.PARAM_READWRITE,
         ),
         'label': (
             GObject.TYPE_STRING,
             'marker label',
             'Textual description of the marker',
             None,
-            GObject.PARAM_READWRITE
+            GObject.PARAM_READWRITE,
         ),
         'position': (
             GObject.TYPE_FLOAT,
             'marker position',
             'Relative position of the marker',
-            0, 1, 0,
-            GObject.PARAM_READWRITE
+            0,
+            1,
+            0,
+            GObject.PARAM_READWRITE,
         ),
         'state': (
             Gtk.StateType,
             'marker state',
             'The state of the marker',
             Gtk.StateType.NORMAL,
-            GObject.PARAM_READWRITE
-        )
+            GObject.PARAM_READWRITE,
+        ),
     }
-    __gsignals__ = {
-        'reached': (
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            ()
-        )
-    }
+    __gsignals__ = {'reached': (GObject.SignalFlags.RUN_LAST, None, ())}
 
     def __init__(self, position=0):
         GObject.GObject.__init__(self)
@@ -245,7 +243,7 @@ class Marker(GObject.GObject):
             'color': None,
             'label': None,
             'position': 0,
-            'state': Gtk.StateType.NORMAL
+            'state': Gtk.StateType.NORMAL,
         }
 
         self.props.position = position
@@ -401,13 +399,17 @@ class MarkerManager(providers.ProviderHandler):
             return True
 
         playback_time = player.get_time()
-        reached_markers = (m for m in providers.get('playback-markers')
-                           if int(m.props.position * track_length) == playback_time)
+        reached_markers = (
+            m
+            for m in providers.get('playback-markers')
+            if int(m.props.position * track_length) == playback_time
+        )
 
         for marker in reached_markers:
             marker.emit('reached')
 
         return True
+
 
 __MARKERMANAGER = MarkerManager()
 add_marker = __MARKERMANAGER.add_marker
@@ -417,9 +419,7 @@ get_markers_at = __MARKERMANAGER.get_markers_at
 
 class _SeekInternalProgressBar(PlaybackProgressBar):
 
-    __gsignals__ = {
-        'draw': 'override',
-    }
+    __gsignals__ = {'draw': 'override'}
 
     def __init__(self, player, points, marker_scale):
         PlaybackProgressBar.__init__(self, player)
@@ -457,10 +457,10 @@ class _SeekInternalProgressBar(PlaybackProgressBar):
                     base = style.get_color(marker.props.state)
 
                 context.set_source_rgba(
-                    base.red / 256.0**2,
-                    base.green / 256.0**2,
-                    base.blue / 256.0**2,
-                    0.7
+                    base.red / 256.0 ** 2,
+                    base.green / 256.0 ** 2,
+                    base.blue / 256.0 ** 2,
+                    0.7,
                 )
             context.fill_preserve()
 
@@ -470,10 +470,10 @@ class _SeekInternalProgressBar(PlaybackProgressBar):
             else:
                 foreground = style.get_color(marker.props.state)
                 context.set_source_rgba(
-                    foreground.red / 256.0**2,
-                    foreground.green / 256.0**2,
-                    foreground.blue / 256.0**2,
-                    0.7
+                    foreground.red / 256.0 ** 2,
+                    foreground.green / 256.0 ** 2,
+                    foreground.blue / 256.0 ** 2,
+                    0.7,
                 )
             context.stroke()
 
@@ -492,13 +492,16 @@ class SeekProgressBar(Gtk.EventBox, providers.ProviderHandler):
         Playback progress bar which allows for seeking
         and setting positional markers
     """
+
     __gproperties__ = {
         'marker-scale': (
             GObject.TYPE_FLOAT,
             'marker scale',
             'Scaling of markers',
-            0, 1, 0.7,
-            GObject.PARAM_READWRITE
+            0,
+            1,
+            0.7,
+            GObject.PARAM_READWRITE,
         )
     }
     __gsignals__ = {
@@ -513,8 +516,8 @@ class SeekProgressBar(Gtk.EventBox, providers.ProviderHandler):
             GObject.SignalFlags.RUN_LAST,
             GObject.TYPE_BOOLEAN,
             (Marker,),
-            GObject.signal_accumulator_true_handled
-        )
+            GObject.signal_accumulator_true_handled,
+        ),
     }
 
     def __init__(self, player, use_markers=True):
@@ -531,29 +534,30 @@ class SeekProgressBar(Gtk.EventBox, providers.ProviderHandler):
         self.__values = {'marker-scale': 0.7}
         self._points = points
 
-        self.__progressbar = _SeekInternalProgressBar(player, points,
-                                                      self.__values['marker-scale'])
+        self.__progressbar = _SeekInternalProgressBar(
+            player, points, self.__values['marker-scale']
+        )
         self._progressbar_menu = None
 
         if use_markers:
             self._progressbar_menu = ProgressBarContextMenu(self)
 
             self._marker_menu = MarkerContextMenu(self)
-            self._marker_menu.connect('deactivate',
-                                      self.on_marker_menu_deactivate)
+            self._marker_menu.connect('deactivate', self.on_marker_menu_deactivate)
 
             providers.ProviderHandler.__init__(self, 'playback-markers')
 
-        self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK |
-                        Gdk.EventMask.BUTTON_RELEASE_MASK |
-                        Gdk.EventMask.POINTER_MOTION_MASK |
-                        Gdk.EventMask.LEAVE_NOTIFY_MASK |
-                        Gdk.EventMask.SCROLL_MASK)
+        self.add_events(
+            Gdk.EventMask.BUTTON_PRESS_MASK
+            | Gdk.EventMask.BUTTON_RELEASE_MASK
+            | Gdk.EventMask.POINTER_MOTION_MASK
+            | Gdk.EventMask.LEAVE_NOTIFY_MASK
+            | Gdk.EventMask.SCROLL_MASK
+        )
 
         self.set_can_focus(True)
 
-        self.connect('hierarchy-changed',
-                     self.on_hierarchy_changed)
+        self.connect('hierarchy-changed', self.on_hierarchy_changed)
         self.connect('scroll-event', self.on_scroll_event)
 
         self.add(self.__progressbar)
@@ -586,7 +590,7 @@ class SeekProgressBar(Gtk.EventBox, providers.ProviderHandler):
             if marker.props.label:
                 markup = '<b>%s</b> (%d%%)' % (
                     marker.props.label,
-                    int(marker.props.position * 100)
+                    int(marker.props.position * 100),
                 )
             else:
                 markup = '%d%%' % int(marker.props.position * 100)
@@ -647,56 +651,56 @@ class SeekProgressBar(Gtk.EventBox, providers.ProviderHandler):
             points = (
                 (position - offset, offset),
                 (position + marker_scale * 0.75 - offset, offset),
-                (position - offset, marker_scale * 0.75 + offset)
+                (position - offset, marker_scale * 0.75 + offset),
             )
         elif marker.props.anchor == Anchor.NORTH:
             points = (
                 (position - offset, marker_scale / 2 + offset),
                 (position + marker_scale / 2 - offset, offset),
-                (position - marker_scale / 2 - offset, offset)
+                (position - marker_scale / 2 - offset, offset),
             )
         elif marker.props.anchor == Anchor.NORTH_EAST:
             points = (
                 (position - marker_scale * 0.75 - offset, offset),
                 (position - offset, offset),
-                (position - offset, marker_scale * 0.75 + offset)
+                (position - offset, marker_scale * 0.75 + offset),
             )
         elif marker.props.anchor == Anchor.EAST:
             points = (
                 (position - marker_scale / 2 - offset, height / 2 + offset),
                 (position - offset, height / 2 - marker_scale / 2 + offset),
-                (position - offset, height / 2 + marker_scale / 2 + offset)
+                (position - offset, height / 2 + marker_scale / 2 + offset),
             )
         elif marker.props.anchor == Anchor.SOUTH_EAST:
             points = (
                 (position - offset, height - offset),
                 (position - offset, height - marker_scale * 0.75 - offset),
-                (position - marker_scale * 0.75 - offset, height - offset)
+                (position - marker_scale * 0.75 - offset, height - offset),
             )
         elif marker.props.anchor == Anchor.SOUTH:
             points = (
                 (position - offset, height - marker_scale / 2 - offset),
                 (position + marker_scale / 2 - offset, height - offset),
-                (position - marker_scale / 2 - offset, height - offset)
+                (position - marker_scale / 2 - offset, height - offset),
             )
         elif marker.props.anchor == Anchor.SOUTH_WEST:
             points = (
                 (position - offset, height - offset),
                 (position + marker_scale * 0.75 - offset, height - offset),
-                (position - offset, height - marker_scale * 0.75 - offset)
+                (position - offset, height - marker_scale * 0.75 - offset),
             )
         elif marker.props.anchor == Anchor.WEST:
             points = (
                 (position + marker_scale / 2 - offset, height / 2 + offset),
                 (position - offset, height / 2 - marker_scale / 2 + offset),
-                (position - offset, height / 2 + marker_scale / 2 + offset)
+                (position - offset, height / 2 + marker_scale / 2 + offset),
             )
         elif marker.props.anchor == Anchor.CENTER:
             points = (
                 (position - offset, height / 2 - marker_scale / 2 + offset),
                 (position + marker_scale / 2 - offset, height / 2 + offset),
                 (position - offset, height / 2 + marker_scale / 2 + offset),
-                (position - marker_scale / 2 - offset, height / 2 + offset)
+                (position - marker_scale / 2 - offset, height / 2 + offset),
             )
 
         return points
@@ -738,8 +742,9 @@ class SeekProgressBar(Gtk.EventBox, providers.ProviderHandler):
             if length is not None:
                 position = float(self.__player.get_time()) / length
                 self.__progressbar.set_fraction(position)
-                self.__progressbar.set_text(self.__progressbar.formatter.format(
-                    current_time=length * position))
+                self.__progressbar.set_text(
+                    self.__progressbar.formatter.format(current_time=length * position)
+                )
 
     def do_get_property(self, gproperty):
         """
@@ -790,8 +795,7 @@ class SeekProgressBar(Gtk.EventBox, providers.ProviderHandler):
 
         for marker in self._points:
             if self._is_marker_hit(marker, event.x, event.y):
-                if marker.props.state in (Gtk.StateType.NORMAL,
-                                          Gtk.StateType.PRELIGHT):
+                if marker.props.state in (Gtk.StateType.NORMAL, Gtk.StateType.PRELIGHT):
                     marker.props.state = Gtk.StateType.ACTIVE
                     hit_markers += [marker]
 
@@ -815,8 +819,11 @@ class SeekProgressBar(Gtk.EventBox, providers.ProviderHandler):
 
                 self.__progressbar.set_fraction(fraction)
                 self.__progressbar.set_text(
-                    _('Seeking: %s') % self.__progressbar.formatter.format(
-                        current_time=length * fraction))
+                    _('Seeking: %s')
+                    % self.__progressbar.formatter.format(
+                        current_time=length * fraction
+                    )
+                )
                 self.__progressbar._seeking = True
         elif event.triggers_context_menu():
             if len(hit_markers) > 0:
@@ -948,25 +955,29 @@ class SeekProgressBar(Gtk.EventBox, providers.ProviderHandler):
         progress_delta = 0.05  # 5% of track length
         progress_delta_small = 0.005  # 0.5% of track length
 
-        if event.direction == Gdk.ScrollDirection.DOWN or \
-                event.direction == Gdk.ScrollDirection.LEFT:
+        if (
+            event.direction == Gdk.ScrollDirection.DOWN
+            or event.direction == Gdk.ScrollDirection.LEFT
+        ):
             if event.get_state() & Gdk.ModifierType.SHIFT_MASK:
                 new_progress = progress - progress_delta_small
             else:
                 new_progress = progress - progress_delta
-        elif event.direction == Gdk.ScrollDirection.UP or \
-                event.direction == Gdk.ScrollDirection.RIGHT:
+        elif (
+            event.direction == Gdk.ScrollDirection.UP
+            or event.direction == Gdk.ScrollDirection.RIGHT
+        ):
             if event.get_state() & Gdk.ModifierType.SHIFT_MASK:
                 new_progress = progress + progress_delta_small
             else:
                 new_progress = progress + progress_delta
         elif event.direction == Gdk.ScrollDirection.SMOOTH:
             if event.get_state() & Gdk.ModifierType.SHIFT_MASK:
-                new_progress = progress \
-                    + progress_delta_small * (event.deltax + event.deltay)
+                new_progress = progress + progress_delta_small * (
+                    event.deltax + event.deltay
+                )
             else:
-                new_progress = progress \
-                    + progress_delta * (event.deltax + event.deltay)
+                new_progress = progress + progress_delta * (event.deltax + event.deltay)
 
         self.__player.set_progress(clamp(new_progress, 0, 1))
         self.update_progress()
@@ -987,8 +998,9 @@ class SeekProgressBar(Gtk.EventBox, providers.ProviderHandler):
         # actual toplevel window.
         toplevel = self.get_toplevel()
         if toplevel.is_toplevel():
-            conn = toplevel.connect('focus-out-event',
-                                    lambda w, e: self.emit('focus-out-event', e.copy()))
+            conn = toplevel.connect(
+                'focus-out-event', lambda w, e: self.emit('focus-out-event', e.copy())
+            )
             self.__prev_focus_out_conn = (toplevel, conn)
 
     def on_marker_menu_deactivate(self, menu):
@@ -1065,8 +1077,7 @@ class ProgressBarContextMenu(menu.ProviderMenu):
             :param progressbar: the progress bar
             :type progressbar: :class:`PlaybackProgressBar`
         """
-        menu.ProviderMenu.__init__(self,
-                                   'progressbar-context-menu', progressbar)
+        menu.ProviderMenu.__init__(self, 'progressbar-context-menu', progressbar)
 
         self._position = -1
 
@@ -1100,8 +1111,7 @@ class MarkerContextMenu(menu.ProviderMenu):
             :param markerbar: the marker capable progress bar
             :type markerbar: :class:`SeekProgressBar`
         """
-        menu.ProviderMenu.__init__(self,
-                                   'playback-marker-context-menu', markerbar)
+        menu.ProviderMenu.__init__(self, 'playback-marker-context-menu', markerbar)
 
         self._markers = ()
         self._position = -1
@@ -1131,7 +1141,7 @@ class MarkerContextMenu(menu.ProviderMenu):
             context = {
                 'current-marker': marker,
                 'selected-markers': self._markers,
-                'current-position': self._position
+                'current-position': self._position,
             }
 
             for item in self._items:
@@ -1160,8 +1170,7 @@ class MoveMarkerMenuItem(menu.MenuItem):
         Menu item allowing for movement of markers
     """
 
-    def __init__(self, name, after, display_name=_('Move'),
-                 icon_name=None):
+    def __init__(self, name, after, display_name=_('Move'), icon_name=None):
         menu.MenuItem.__init__(self, name, None, after)
 
         self._parent = None
@@ -1179,17 +1188,15 @@ class MoveMarkerMenuItem(menu.MenuItem):
         item = Gtk.ImageMenuItem.new_with_mnemonic(self._display_name)
 
         if self._icon_name is not None:
-            item.set_image(Gtk.Image.new_from_icon_name(
-                self._icon_name, Gtk.IconSize.MENU))
+            item.set_image(
+                Gtk.Image.new_from_icon_name(self._icon_name, Gtk.IconSize.MENU)
+            )
 
         item.connect('activate', self.on_activate, parent, context)
 
-        parent.connect('button-press-event',
-                       self.on_parent_button_press_event)
-        parent.connect('motion-notify-event',
-                       self.on_parent_motion_notify_event)
-        parent.connect('focus-out-event',
-                       self.on_parent_focus_out_event)
+        parent.connect('button-press-event', self.on_parent_button_press_event)
+        parent.connect('motion-notify-event', self.on_parent_motion_notify_event)
+        parent.connect('focus-out-event', self.on_parent_focus_out_event)
 
         return item
 
@@ -1209,7 +1216,8 @@ class MoveMarkerMenuItem(menu.MenuItem):
             self._marker.props.state = Gtk.StateType.ACTIVE
             self._reset_position = marker.props.position
             self._parent.props.window.set_cursor(
-                Gdk.Cursor.new(Gdk.CursorType.SB_H_DOUBLE_ARROW))
+                Gdk.Cursor.new(Gdk.CursorType.SB_H_DOUBLE_ARROW)
+            )
 
             return True
 
@@ -1307,8 +1315,7 @@ class NewMarkerMenuItem(MoveMarkerMenuItem):
     """
 
     def __init__(self, name, after):
-        MoveMarkerMenuItem.__init__(self, name, after,
-                                    _('New Marker'), 'list-add')
+        MoveMarkerMenuItem.__init__(self, name, after, _('New Marker'), 'list-add')
 
     def move_cancel(self):
         """
@@ -1336,6 +1343,7 @@ class NewMarkerMenuItem(MoveMarkerMenuItem):
         context['current-marker'] = add_marker(context['current-position'])
         MoveMarkerMenuItem.on_activate(self, widget, parent, context)
 
+
 # XXX: Example implementation only
 # Bookmarks: "Add bookmark" (1 new marker)
 # A-B-Repeat: "Repeat" (2 new marker, NW, NE)
@@ -1348,6 +1356,8 @@ def __create_progressbar_context_menu():
 
     for item in items:
         providers.register('progressbar-context-menu', item)
+
+
 __create_progressbar_context_menu()
 
 
@@ -1362,16 +1372,26 @@ def __create_marker_context_menu():
     def on_remove_item_activate(widget, name, parent, context):
         providers.unregister('playback-markers', context['current-marker'])
 
-    items.append(menu.simple_menu_item('jumpto-marker',
-                                       [], _("_Jump to"), 'go-jump', on_jumpto_item_activate))
-    items.append(MoveMarkerMenuItem('move-marker',
-                                    [items[-1].name]))
-    items.append(menu.simple_menu_item('remove-marker',
-                                       [items[-1].name], _("_Remove Marker"), 'list-remove',
-                                       on_remove_item_activate))
+    items.append(
+        menu.simple_menu_item(
+            'jumpto-marker', [], _("_Jump to"), 'go-jump', on_jumpto_item_activate
+        )
+    )
+    items.append(MoveMarkerMenuItem('move-marker', [items[-1].name]))
+    items.append(
+        menu.simple_menu_item(
+            'remove-marker',
+            [items[-1].name],
+            _("_Remove Marker"),
+            'list-remove',
+            on_remove_item_activate,
+        )
+    )
 
     for item in items:
         providers.register('playback-marker-context-menu', item)
+
+
 __create_marker_context_menu()
 
 
@@ -1385,10 +1405,7 @@ class VolumeControl(Gtk.Box):
 
     __gtype_name__ = 'VolumeControl'
 
-    (button,             \
-        slider,             \
-        button_image,       \
-        slider_adjustment) = GtkTemplate.Child.widgets(4)
+    (button, slider, button_image, slider_adjustment) = GtkTemplate.Child.widgets(4)
 
     def __init__(self, player):
         Gtk.Box.__init__(self)
@@ -1519,6 +1536,7 @@ def playpause(player):
         player.toggle_pause()
     else:
         from xlgui import main
+
         page = main.get_selected_playlist()
         if page:
             pl = page.playlist
@@ -1541,21 +1559,38 @@ def PlayPauseMenuItem(name, player, after):
         else:
             icon_name = 'media-playback-start'
             label = _("P_lay")
-        return menu.simple_menu_item(name, after, label, icon_name,
-                                     callback=lambda *args: playpause(player))
+        return menu.simple_menu_item(
+            name, after, label, icon_name, callback=lambda *args: playpause(player)
+        )
+
     return factory(name, after, player)
 
 
 def NextMenuItem(name, player, after):
-    return menu.simple_menu_item(name, after, _("_Next Track"), 'media-skip-forward',
-                                 callback=lambda *args: player.queue.next())
+    return menu.simple_menu_item(
+        name,
+        after,
+        _("_Next Track"),
+        'media-skip-forward',
+        callback=lambda *args: player.queue.next(),
+    )
 
 
 def PrevMenuItem(name, player, after):
-    return menu.simple_menu_item(name, after, _("_Previous Track"), 'media-skip-backward',
-                                 callback=lambda *args: player.queue.prev())
+    return menu.simple_menu_item(
+        name,
+        after,
+        _("_Previous Track"),
+        'media-skip-backward',
+        callback=lambda *args: player.queue.prev(),
+    )
 
 
 def StopMenuItem(name, player, after):
-    return menu.simple_menu_item(name, after, _("_Stop"), 'media-playback-stop',
-                                 callback=lambda *args: player.stop())
+    return menu.simple_menu_item(
+        name,
+        after,
+        _("_Stop"),
+        'media-playback-stop',
+        callback=lambda *args: player.stop(),
+    )

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -223,7 +223,7 @@ def __create_playlist_tab_context_menu():
 
     items.append(smi('save', ['new-tab-sep'], _("_Save"), 'document-save',
                      callback=lambda w, n, p, c: p.on_save(),
-                     condition_fn=lambda n, p, c: p.can_save() and main.exaile().playlists.has_playlist_name(p.playlist.name)))
+                     condition_fn=lambda n, p, c: (p.can_save() and main.exaile().playlists.has_playlist_name(p.playlist.name))))
     items.append(smi('saveas', ['save'], _("Save _As"), 'document-save-as',
                      callback=lambda w, n, p, c: p.on_saveas(),
                      condition_fn=lambda n, p, c: p.can_saveas()))

--- a/xlgui/widgets/playlist_columns.py
+++ b/xlgui/widgets/playlist_columns.py
@@ -32,13 +32,7 @@ from gi.repository import Pango
 import logging
 import time
 
-from xl import (
-    common,
-    event,
-    player,
-    settings,
-    providers
-)
+from xl import common, event, player, settings, providers
 from xl.common import classproperty
 from xl.formatter import TrackFormatter
 from xl.nls import gettext as _
@@ -64,22 +58,23 @@ class Column(Gtk.TreeViewColumn):
 
     def __init__(self, container, player, font, size_ratio):
         if self.__class__ == Column:
-            raise NotImplementedError("Can't instantiate "
-                                      "abstract class %s" % repr(self.__class__))
-        
+            raise NotImplementedError(
+                "Can't instantiate " "abstract class %s" % repr(self.__class__)
+            )
+
         self._size_ratio = size_ratio
         self.container = container
         self.player = player
         self.settings_width_name = "gui/col_width_%s" % self.name
         self.cellrenderer = self.renderer()
         self.destroyed = False
-        
+
         super(Column, self).__init__(self.display)
         self.props.min_width = 3
-        
+
         self.pack_start(self.cellrenderer, True)
         self.set_cell_data_func(self.cellrenderer, self.data_func)
-        
+
         try:
             self.cellrenderer.set_property('font-desc', font)
         except TypeError:
@@ -92,7 +87,7 @@ class Column(Gtk.TreeViewColumn):
 
         for name, val in self.cellproperties.iteritems():
             self.cellrenderer.set_property(name, val)
-        
+
         self.set_reorderable(True)
         self.set_clickable(True)
         self.set_sizing(Gtk.TreeViewColumnSizing.FIXED)  # needed for fixed-height mode
@@ -106,8 +101,9 @@ class Column(Gtk.TreeViewColumn):
         self._width_notify = self.connect('notify::width', self.on_width_changed)
         self._setup_sizing()
 
-        event.add_ui_callback(self.on_option_set, "gui_option_set",
-                              destroy_with=container)
+        event.add_ui_callback(
+            self.on_option_set, "gui_option_set", destroy_with=container
+        )
 
     def on_option_set(self, typ, obj, data):
         if data in ("gui/resizable_cols", self.settings_width_name):
@@ -116,8 +112,9 @@ class Column(Gtk.TreeViewColumn):
     @common.glib_wait(100)
     def on_width_changed(self, column, wid):
         width = self.get_width()
-        if not self.destroyed and \
-           width != settings.get_option(self.settings_width_name, -1):
+        if not self.destroyed and width != settings.get_option(
+            self.settings_width_name, -1
+        ):
             settings.set_option(self.settings_width_name, width)
 
     def _setup_sizing(self):
@@ -125,8 +122,7 @@ class Column(Gtk.TreeViewColumn):
             if settings.get_option('gui/resizable_cols', False):
                 self.set_resizable(True)
                 self.set_expand(False)
-                width = settings.get_option(self.settings_width_name,
-                                            self.size)
+                width = settings.get_option(self.settings_width_name, self.size)
                 self.set_fixed_width(width)
             else:
                 self.set_resizable(False)
@@ -147,20 +143,24 @@ class Column(Gtk.TreeViewColumn):
     def data_func(self, col, cell, model, iter, user_data):
         # warning: this function gets called from the render function, so do as
         #          little work as possible!
-        
+
         cache = model.get_value(iter, 1)
-        
+
         text = cache.get(self.name)
         if text is None:
             track = model.get_value(iter, 0)
             text = self.formatter.format(track)
             cache[self.name] = text
-        
+
         cell.props.text = text
-        
+
     def __repr__(self):
-        return '%s(%r, %r, %r)' % (self.__class__.__name__,
-                                   self.name, self.display, self.size)
+        return '%s(%r, %r, %r)' % (
+            self.__class__.__name__,
+            self.name,
+            self.display,
+            self.size,
+        )
 
 
 class TrackNumberColumn(Column):
@@ -170,6 +170,8 @@ class TrackNumberColumn(Column):
     menu_title = _('Track Number')
     size = 30
     cellproperties = {'xalign': 1.0, 'width-chars': 4}
+
+
 providers.register('playlist-columns', TrackNumberColumn)
 
 
@@ -178,6 +180,8 @@ class TitleColumn(Column):
     display = _('Title')
     size = 200
     autoexpand = True
+
+
 providers.register('playlist-columns', TitleColumn)
 
 
@@ -186,6 +190,8 @@ class ArtistColumn(Column):
     display = _('Artist')
     size = 150
     autoexpand = True
+
+
 providers.register('playlist-columns', ArtistColumn)
 
 
@@ -194,6 +200,8 @@ class ComposerColumn(Column):
     display = _('Composer')
     size = 150
     autoexpand = True
+
+
 providers.register('playlist-columns', ComposerColumn)
 
 
@@ -202,6 +210,8 @@ class AlbumColumn(Column):
     display = _('Album')
     size = 150
     autoexpand = True
+
+
 providers.register('playlist-columns', AlbumColumn)
 
 
@@ -210,6 +220,8 @@ class LengthColumn(Column):
     display = _('Length')
     size = 50
     cellproperties = {'xalign': 1.0}
+
+
 providers.register('playlist-columns', LengthColumn)
 
 
@@ -219,6 +231,8 @@ class DiscNumberColumn(Column):
     menu_title = _('Disc Number')
     size = 40
     cellproperties = {'xalign': 1.0, 'width-chars': 2}
+
+
 providers.register('playlist-columns', DiscNumberColumn)
 
 
@@ -264,6 +278,8 @@ class RatingColumn(Column):
 
         rating = track.set_rating(rating)
         event.log_event('rating_changed', self, rating)
+
+
 providers.register('playlist-columns', RatingColumn)
 
 
@@ -271,6 +287,8 @@ class DateColumn(Column):
     name = 'date'
     display = _('Date')
     size = 50
+
+
 providers.register('playlist-columns', DateColumn)
 
 
@@ -278,6 +296,8 @@ class YearColumn(Column):
     name = 'year'
     display = _('Year')
     size = 45
+
+
 providers.register('playlist-columns', YearColumn)
 
 
@@ -286,6 +306,8 @@ class GenreColumn(Column):
     display = _('Genre')
     size = 100
     autoexpand = True
+
+
 providers.register('playlist-columns', GenreColumn)
 
 
@@ -294,6 +316,8 @@ class BitrateColumn(Column):
     display = _('Bitrate')
     size = 45
     cellproperties = {'xalign': 1.0}
+
+
 providers.register('playlist-columns', BitrateColumn)
 
 
@@ -302,6 +326,8 @@ class IoLocColumn(Column):
     display = _('Location')
     size = 200
     autoexpand = True
+
+
 providers.register('playlist-columns', IoLocColumn)
 
 
@@ -310,6 +336,8 @@ class FilenameColumn(Column):
     display = _('Filename')
     size = 200
     autoexpand = True
+
+
 providers.register('playlist-columns', FilenameColumn)
 
 
@@ -318,6 +346,8 @@ class PlayCountColumn(Column):
     display = _('Playcount')
     size = 50
     cellproperties = {'xalign': 1.0}
+
+
 providers.register('playlist-columns', PlayCountColumn)
 
 
@@ -326,6 +356,8 @@ class BPMColumn(Column):
     display = _('BPM')
     size = 50
     cellproperties = {'xalign': 1.0}
+
+
 providers.register('playlist-columns', BPMColumn)
 
 
@@ -334,6 +366,8 @@ class LanguageColumn(Column):
     display = _('Language')
     size = 100
     autoexpand = True
+
+
 providers.register('playlist-columns', LanguageColumn)
 
 
@@ -341,6 +375,8 @@ class LastPlayedColumn(Column):
     name = '__last_played'
     display = _('Last played')
     size = 80
+
+
 providers.register('playlist-columns', LastPlayedColumn)
 
 
@@ -348,6 +384,8 @@ class DateAddedColumn(Column):
     name = '__date_added'
     display = _('Date added')
     size = 80
+
+
 providers.register('playlist-columns', DateAddedColumn)
 
 
@@ -360,12 +398,17 @@ class ScheduleTimeColumn(Column):
         Column.__init__(self, *args)
         self.timeout_id = None
 
-        event.add_ui_callback(self.on_queue_current_playlist_changed,
-                              'queue_current_playlist_changed', player.QUEUE)
-        event.add_ui_callback(self.on_playback_player_start,
-                              'playback_player_start', player.PLAYER)
-        event.add_ui_callback(self.on_playback_player_end,
-                              'playback_player_end', player.PLAYER)
+        event.add_ui_callback(
+            self.on_queue_current_playlist_changed,
+            'queue_current_playlist_changed',
+            player.QUEUE,
+        )
+        event.add_ui_callback(
+            self.on_playback_player_start, 'playback_player_start', player.PLAYER
+        )
+        event.add_ui_callback(
+            self.on_playback_player_end, 'playback_player_end', player.PLAYER
+        )
 
     def data_func(self, col, cell, model, iter, user_data):
         """
@@ -379,10 +422,12 @@ class ScheduleTimeColumn(Column):
         # 2) this playlist is currently played
         # 3) playback is not in shuffle mode
         # 4) the current track is not repeated
-        if not self.player.is_stopped() and \
-           playlist is self.player.queue.current_playlist and \
-           playlist.shuffle_mode == 'disabled' and \
-           playlist.repeat_mode != 'track':
+        if (
+            not self.player.is_stopped()
+            and playlist is self.player.queue.current_playlist
+            and playlist.shuffle_mode == 'disabled'
+            and playlist.repeat_mode != 'track'
+        ):
             track = model.get_value(iter, 0)
             position = playlist.index(track)
             current_position = playlist.current_position
@@ -392,8 +437,10 @@ class ScheduleTimeColumn(Column):
                 # The delay is the accumulated length of all tracks
                 # between the currently playing and this one
                 try:
-                    delay = sum(t.get_tag_raw('__length')
-                                for t in playlist[current_position:position])
+                    delay = sum(
+                        t.get_tag_raw('__length')
+                        for t in playlist[current_position:position]
+                    )
                 except TypeError:
                     # on tracks with length == None, we cannot determine
                     # when later tracks will play
@@ -470,6 +517,8 @@ class ScheduleTimeColumn(Column):
             Disables realtime updates for all playlists
         """
         self.stop_timer()
+
+
 providers.register('playlist-columns', ScheduleTimeColumn)
 
 
@@ -480,6 +529,8 @@ class CommentColumn(Column):
     autoexpand = True
     # Remove the newlines to fit into the vertical space of rows
     formatter = TrackFormatter('${comment:newlines=strip}')
+
+
 providers.register('playlist-columns', CommentColumn)
 
 
@@ -488,6 +539,8 @@ class GroupingColumn(Column):
     display = _('Grouping')
     size = 200
     autoexpand = True
+
+
 providers.register('playlist-columns', GroupingColumn)
 
 
@@ -496,6 +549,8 @@ class StartOffsetColumn(Column):
     display = _('Start Offset')
     size = 50
     cellproperties = {'xalign': 1.0}
+
+
 providers.register('playlist-columns', StartOffsetColumn)
 
 
@@ -504,6 +559,8 @@ class StopOffsetColumn(Column):
     display = _('Stop Offset')
     size = 50
     cellproperties = {'xalign': 1.0}
+
+
 providers.register('playlist-columns', StopOffsetColumn)
 
 
@@ -512,6 +569,8 @@ class WebsiteColumn(Column):
     display = _('Website')
     size = 200
     autoexpand = True
+
+
 providers.register('playlist-columns', WebsiteColumn)
 
 
@@ -541,8 +600,7 @@ class ColumnMenuItem(menu.MenuItem):
         item = Gtk.CheckMenuItem.new_with_label(self.title)
         active = self.is_selected(self.name, parent, context)
         item.set_active(active)
-        item.connect('activate', self.on_item_activate,
-                     self.name, parent, context)
+        item.connect('activate', self.on_item_activate, self.name, parent, context)
 
         return item
 
@@ -572,6 +630,7 @@ def __register_playlist_columns_menuitems():
     """
         Registers standard menu items for playlist columns
     """
+
     def is_column_selected(name, parent, context):
         """
             Returns whether a menu item should be checked
@@ -611,8 +670,16 @@ def __register_playlist_columns_menuitems():
         elif name == 'autosize':
             settings.set_option('gui/resizable_cols', False)
 
-    columns = ['tracknumber', 'title', 'artist', 'album',
-               '__length', 'genre', '__rating', 'date']
+    columns = [
+        'tracknumber',
+        'title',
+        'artist',
+        'album',
+        '__length',
+        'genre',
+        '__rating',
+        'date',
+    ]
 
     for provider in providers.get('playlist-columns'):
         if provider.name not in columns:
@@ -631,15 +698,29 @@ def __register_playlist_columns_menuitems():
     menu_items += [separator_item]
     after = [separator_item.name]
 
-    sizing_item = menu.radio_menu_item('resizable', after, _('_Resizable'),
-                                       'column-sizing', is_resizable, on_sizing_item_activate)
+    sizing_item = menu.radio_menu_item(
+        'resizable',
+        after,
+        _('_Resizable'),
+        'column-sizing',
+        is_resizable,
+        on_sizing_item_activate,
+    )
     menu_items += [sizing_item]
     after = [sizing_item.name]
 
-    sizing_item = menu.radio_menu_item('autosize', after, _('_Autosize'),
-                                       'column-sizing', is_resizable, on_sizing_item_activate)
+    sizing_item = menu.radio_menu_item(
+        'autosize',
+        after,
+        _('_Autosize'),
+        'column-sizing',
+        is_resizable,
+        on_sizing_item_activate,
+    )
     menu_items += [sizing_item]
 
     for menu_item in menu_items:
         providers.register('playlist-columns-menu', menu_item)
+
+
 __register_playlist_columns_menuitems()

--- a/xlgui/widgets/queue.py
+++ b/xlgui/widgets/queue.py
@@ -34,7 +34,6 @@ from xlgui.widgets.playlist import PlaylistPageBase, PlaylistView
 
 
 class QueuePage(PlaylistPageBase):
-
     def __init__(self, container, player):
         PlaylistPageBase.__init__(self)
         self.plcontainer = container
@@ -49,9 +48,17 @@ class QueuePage(PlaylistPageBase):
         self.view.dragdrop_copyonly = True
         self.swindow.add(self.view)
 
-        event.add_ui_callback(self.on_length_changed, 'playlist_current_position_changed', self.player.queue)
-        event.add_ui_callback(self.on_length_changed, "playlist_tracks_added", self.player.queue)
-        event.add_ui_callback(self.on_length_changed, "playlist_tracks_removed", self.player.queue)
+        event.add_ui_callback(
+            self.on_length_changed,
+            'playlist_current_position_changed',
+            self.player.queue,
+        )
+        event.add_ui_callback(
+            self.on_length_changed, "playlist_tracks_added", self.player.queue
+        )
+        event.add_ui_callback(
+            self.on_length_changed, "playlist_tracks_removed", self.player.queue
+        )
 
         self.show_all()
 
@@ -89,8 +96,7 @@ class QueuePage(PlaylistPageBase):
 
     def on_saveas(self):
         exaile = main.exaile()
-        name = dialogs.ask_for_playlist_name(
-            exaile.gui.main.window, exaile.playlists)
+        name = dialogs.ask_for_playlist_name(exaile.gui.main.window, exaile.playlists)
         if name is not None:
             pl = playlist.Playlist(name, self.playlist[:])
             exaile.playlists.save_playlist(pl)

--- a/xlgui/widgets/rating.py
+++ b/xlgui/widgets/rating.py
@@ -40,6 +40,7 @@ class RatingWidget(Gtk.EventBox):
         A rating widget which displays a row of
         images and allows for selecting the rating
     """
+
     __gproperties__ = {
         'rating': (
             GObject.TYPE_INT,
@@ -48,15 +49,11 @@ class RatingWidget(Gtk.EventBox):
             0,  # Minimum
             65535,  # Maximum
             0,  # Default
-            GObject.PARAM_READWRITE
+            GObject.PARAM_READWRITE,
         )
     }
     __gsignals__ = {
-        'rating-changed': (
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            (GObject.TYPE_INT,)
-        )
+        'rating-changed': (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_INT,))
     }
 
     def __init__(self, rating=0, player=None):
@@ -83,8 +80,12 @@ class RatingWidget(Gtk.EventBox):
 
         if self._player is not None:
 
-            event.add_ui_callback(self.on_rating_update, 'playback_track_start', self._player)
-            event.add_ui_callback(self.on_rating_update, 'playback_track_end', self._player)
+            event.add_ui_callback(
+                self.on_rating_update, 'playback_track_start', self._player
+            )
+            event.add_ui_callback(
+                self.on_rating_update, 'playback_track_end', self._player
+            )
             event.add_ui_callback(self.on_rating_update, 'rating_changed')
 
             self.on_rating_update('rating_changed', None, None)
@@ -94,8 +95,12 @@ class RatingWidget(Gtk.EventBox):
             Cleanups
         """
         if self._player is not None:
-            event.remove_callback(self.on_rating_update, 'playback_track_start', self._player)
-            event.remove_callback(self.on_rating_update, 'playback_track_end', self._player)
+            event.remove_callback(
+                self.on_rating_update, 'playback_track_start', self._player
+            )
+            event.remove_callback(
+                self.on_rating_update, 'playback_track_end', self._player
+            )
             event.remove_callback(self.on_rating_update, 'rating_changed')
 
     def do_get_property(self, property):
@@ -118,8 +123,7 @@ class RatingWidget(Gtk.EventBox):
                 value = clamp(value, 0, settings.get_option('rating/maximum', 5))
 
             self._rating = value
-            self._image.set_from_pixbuf(
-                icons.MANAGER.pixbuf_from_rating(value).pixbuf)
+            self._image.set_from_pixbuf(icons.MANAGER.pixbuf_from_rating(value).pixbuf)
 
             self.emit('rating-changed', value)
         else:
@@ -139,7 +143,7 @@ class RatingWidget(Gtk.EventBox):
                 x=event.area.x,
                 y=event.area.y,
                 width=event.area.width,
-                height=event.area.height
+                height=event.area.height,
             )
 
         Gtk.EventBox.do_expose_event(self, event)
@@ -159,8 +163,7 @@ class RatingWidget(Gtk.EventBox):
         position = (event.x + threshold) / allocation.width
         rating = int(position * maximum)
 
-        self._image.set_from_pixbuf(
-            icons.MANAGER.pixbuf_from_rating(rating).pixbuf)
+        self._image.set_from_pixbuf(icons.MANAGER.pixbuf_from_rating(rating).pixbuf)
 
     def do_leave_notify_event(self, event):
         """
@@ -170,7 +173,8 @@ class RatingWidget(Gtk.EventBox):
             return
 
         self._image.set_from_pixbuf(
-            icons.MANAGER.pixbuf_from_rating(self._rating).pixbuf)
+            icons.MANAGER.pixbuf_from_rating(self._rating).pixbuf
+        )
 
     def do_button_release_event(self, event):
         """
@@ -221,7 +225,8 @@ class RatingWidget(Gtk.EventBox):
         if self._player.current is not None:
             self._rating = self._player.current.get_rating()
             self._image.set_from_pixbuf(
-                icons.MANAGER.pixbuf_from_rating(self._rating).pixbuf)
+                icons.MANAGER.pixbuf_from_rating(self._rating).pixbuf
+            )
             self.set_sensitive(True)
         else:
             self.set_sensitive(False)
@@ -231,6 +236,7 @@ class RatingMenuItem(Gtk.MenuItem):
     """
         A menuitem containing a rating widget
     """
+
     __gproperties__ = {
         'rating': (
             GObject.TYPE_INT,
@@ -239,15 +245,11 @@ class RatingMenuItem(Gtk.MenuItem):
             0,  # Minimum
             65535,  # Maximum
             0,  # Default
-            GObject.PARAM_READWRITE
+            GObject.PARAM_READWRITE,
         )
     }
     __gsignals__ = {
-        'rating-changed': (
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            (GObject.TYPE_INT,)
-        )
+        'rating-changed': (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_INT,))
     }
 
     def __init__(self, rating=0, player=None):
@@ -267,8 +269,7 @@ class RatingMenuItem(Gtk.MenuItem):
 
         self.add(box)
 
-        self.rating_widget.connect('rating-changed',
-                                   self.on_rating_changed)
+        self.rating_widget.connect('rating-changed', self.on_rating_changed)
 
     def do_get_property(self, property):
         """
@@ -295,8 +296,9 @@ class RatingMenuItem(Gtk.MenuItem):
         allocation = self.rating_widget.get_allocation()
 
         if allocation.x < event.x < allocation.x + allocation.width:
-            x, y = self.translate_coordinates(self.rating_widget,
-                                              int(event.x), int(event.y))
+            x, y = self.translate_coordinates(
+                self.rating_widget, int(event.x), int(event.y)
+            )
             event.x, event.y = float(x), float(y)
             self.rating_widget.emit('motion-notify-event', event.copy())
 
@@ -313,8 +315,9 @@ class RatingMenuItem(Gtk.MenuItem):
         allocation = self.rating_widget.get_allocation()
 
         if allocation.x < event.x < allocation.x + allocation.width:
-            x, y = self.translate_coordinates(self.rating_widget,
-                                              int(event.x), int(event.y))
+            x, y = self.translate_coordinates(
+                self.rating_widget, int(event.x), int(event.y)
+            )
             event.x, event.y = float(x), float(y)
             self.rating_widget.emit('button-release-event', event.copy())
 
@@ -330,6 +333,7 @@ class RatingCellRenderer(Gtk.CellRendererPixbuf):
         A cell renderer drawing rating images
         and allowing for selection of ratings
     """
+
     __gproperties__ = {
         'rating': (
             GObject.TYPE_INT,
@@ -338,14 +342,14 @@ class RatingCellRenderer(Gtk.CellRendererPixbuf):
             0,  # Minimum
             65535,  # Maximum
             0,  # Default
-            GObject.PARAM_READWRITE
+            GObject.PARAM_READWRITE,
         )
     }
     __gsignals__ = {
         'rating-changed': (
             GObject.SignalFlags.RUN_LAST,
             None,
-            (GObject.TYPE_PYOBJECT, GObject.TYPE_INT)
+            (GObject.TYPE_PYOBJECT, GObject.TYPE_INT),
         )
     }
 
@@ -372,12 +376,13 @@ class RatingCellRenderer(Gtk.CellRendererPixbuf):
         """
         if property.name == 'rating':
             self.rating = value
-            self.props.pixbuf = icons.MANAGER.pixbuf_from_rating(self.rating, self.size_ratio).pixbuf
+            self.props.pixbuf = icons.MANAGER.pixbuf_from_rating(
+                self.rating, self.size_ratio
+            ).pixbuf
         else:
             raise AttributeError('unknown property %s' % property.name)
 
-    def do_activate(self, event, widget, path,
-                    background_area, cell_area, flags):
+    def do_activate(self, event, widget, path, background_area, cell_area, flags):
         """
             Checks if a button press event did occur
             within the clickable rating image area
@@ -390,19 +395,20 @@ class RatingCellRenderer(Gtk.CellRendererPixbuf):
             x=0,
             y=self.props.ypad,
             width=self.props.pixbuf.get_width(),
-            height=self.props.pixbuf.get_height()
+            height=self.props.pixbuf.get_height(),
         )
 
         # Move event location relative to zero
         event.x -= cell_area.x + click_area.x
         event.y -= cell_area.y + click_area.y
 
-        if 0 <= event.x <= click_area.width and \
-           0 <= event.y <= click_area.height:
+        if 0 <= event.x <= click_area.width and 0 <= event.y <= click_area.height:
             fraction = event.x / click_area.width
             maximum = settings.get_option('rating/maximum', 5)
             rating = fraction * maximum + 1
             self.emit('rating-changed', (int(path),), rating)
+
+
 '''
     No longer needed in GTK3?
 

--- a/xlgui/widgets/smart_playlist_editor.py
+++ b/xlgui/widgets/smart_playlist_editor.py
@@ -118,6 +118,7 @@ class SpinNothing(SpinLabelField):
 # _NMAP, and will be really translated by filtergui; no need to clutter the
 # code here.
 _criteria_types = {
+    # fmt: off
 
     # TODO
     'bitrate': [
@@ -189,6 +190,8 @@ _criteria_types = {
         ('at least', SpinRating),
         ('at most', SpinRating),
     ],
+    
+    # fmt: on
 }
 
 # aliases

--- a/xlgui/widgets/smart_playlist_editor.py
+++ b/xlgui/widgets/smart_playlist_editor.py
@@ -26,11 +26,7 @@
 
 from gi.repository import Gtk
 
-from xl import (
-    main,
-    playlist,
-    settings
-)
+from xl import main, playlist, settings
 
 from xl.nls import gettext as _
 
@@ -47,6 +43,7 @@ from .filter import (
 )
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -55,26 +52,22 @@ def N_(x):
 
 
 class EntrySecondsField(MultiEntryField):
-
     def __init__(self):
         MultiEntryField.__init__(self, (50, _('seconds')))
 
 
 class EntryAndEntryField(MultiEntryField):
-
     def __init__(self):
         # TRANSLATORS: Logical AND used for smart playlists
         MultiEntryField.__init__(self, (50, _('and'), 50))
 
 
 class EntryDaysField(MultiEntryField):
-
     def __init__(self):
         MultiEntryField.__init__(self, (50, _('days')))
 
 
 class PlaylistField(ComboEntryField):
-
     def __init__(self):
         playlists = []
         playlists.extend(main.exaile().smart_playlists.list_playlists())
@@ -82,33 +75,29 @@ class PlaylistField(ComboEntryField):
         playlists.sort()
         ComboEntryField.__init__(self, playlists)
 
-DATE_FIELDS = [
-    N_('seconds'), N_('minutes'), N_('hours'), N_('days'), N_('weeks')]
+
+DATE_FIELDS = [N_('seconds'), N_('minutes'), N_('hours'), N_('days'), N_('weeks')]
 
 
 class SpinDateField(SpinButtonAndComboField):
-
     def __init__(self):
         SpinButtonAndComboField.__init__(self, DATE_FIELDS)
 
 
 class SpinSecondsField(SpinLabelField):
-
     def __init__(self):
         SpinLabelField.__init__(self, _('seconds'))
 
 
 class SpinRating(SpinLabelField):
-
     def __init__(self):
-        SpinLabelField.__init__(self, '',
-                                settings.get_option("rating/maximum", 5), 0)
+        SpinLabelField.__init__(self, '', settings.get_option("rating/maximum", 5), 0)
 
 
 class SpinNothing(SpinLabelField):
-
     def __init__(self):
         SpinLabelField.__init__(self, '')
+
 
 # This sets up the CRITERIA for all the available types of tags
 # that exaile supports. The actual CRITERIA dict is populated
@@ -190,7 +179,6 @@ _criteria_types = {
         ('at least', SpinRating),
         ('at most', SpinRating),
     ],
-    
     # fmt: on
 }
 
@@ -294,11 +282,11 @@ def __update_maps():
             raise ValueError("_REV_NMAP Internal error: '%s', '%s'" % (k, v))
         _REV_NMAP[v] = k
 
+
 __update_maps()
 
 
 class SmartPlaylistEditor(object):
-
     @classmethod
     def create(cls, collection, smart_manager, parent=None):
         """
@@ -370,15 +358,12 @@ class SmartPlaylistEditor(object):
 
         cls._attach_sort_widgets(dialog, *pl.get_sort_tags())
 
-        return cls._run_edit_dialog(dialog, collection, smart_manager, parent,
-                                    orig_pl=pl)
+        return cls._run_edit_dialog(
+            dialog, collection, smart_manager, parent, orig_pl=pl
+        )
 
     @classmethod
-    def _run_edit_dialog(cls, dialog,
-                         collection,
-                         smart_manager,
-                         parent,
-                         orig_pl=None):
+    def _run_edit_dialog(cls, dialog, collection, smart_manager, parent, orig_pl=None):
         '''internal helper function'''
 
         while True:
@@ -396,15 +381,17 @@ class SmartPlaylistEditor(object):
             sort_tags = cls._get_sort_tags(dialog)
 
             if not name:
-                dialogs.error(parent, _("You did "
-                                        "not enter a name for your playlist"))
+                dialogs.error(
+                    parent, _("You did " "not enter a name for your playlist")
+                )
                 continue
 
             if not orig_pl or name != orig_pl.name:
                 try:
                     pl = smart_manager.get_playlist(name)
-                    dialogs.error(parent, _("The "
-                                            "playlist name you entered is already in use."))
+                    dialogs.error(
+                        parent, _("The " "playlist name you entered is already in use.")
+                    )
                     continue
                 except ValueError:
                     pass  # playlist didn't exist
@@ -432,6 +419,7 @@ class SmartPlaylistEditor(object):
         from xl.metadata.tags import tag_data
 
         dialog.sort_enable = sort_enable = Gtk.CheckButton.new_with_label(_('Sort by:'))
+
         def _on_sort_enable_changed(ck):
             sort_tags.set_sensitive(ck.get_active())
             sort_order.set_sensitive(ck.get_active())


### PR DESCRIPTION
I'm not necessarily advocating that we have to continue on this path, but I'm opening this PR to start the conversation about whether we should do this or not. It is nice to not have to worry about style. From my initial look at this, for the most part it seems to generate better looking code with only a few exceptions (and in those places I've added `# fmt: on/off` directives to disable it). I also modified the travis configuration to enforce usage of the formatter.

I ran black like so:

```
black -S *.py plugins/ xl/ xlgui/ tests/
```

One thing it does reformat is our custom of doing imports like so:

```
from xl import (
  common
  nls
)
```

to 

```
from xl import common, nls
```

... honestly, I don't really care much about that particular style point anyways, so seems fine to me.

One thing I do care about is single vs double quoted strings. I used the `-S` option of black to tell it to not force everything to double quotes.

Thoughts?