### PR TITLE
Add option to use a 'dark theme' if available

### DIFF
--- a/data/ui/preferences/appearance.ui
+++ b/data/ui/preferences/appearance.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkImage" id="image1">
@@ -203,7 +203,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">6</property>
+        <property name="top_attach">7</property>
       </packing>
     </child>
     <child>
@@ -215,7 +215,7 @@
       </object>
       <packing>
         <property name="left_attach">1</property>
-        <property name="top_attach">6</property>
+        <property name="top_attach">7</property>
       </packing>
     </child>
     <child>
@@ -229,7 +229,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">10</property>
+        <property name="top_attach">11</property>
         <property name="width">2</property>
       </packing>
     </child>
@@ -243,7 +243,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">11</property>
+        <property name="top_attach">12</property>
         <property name="width">2</property>
       </packing>
     </child>
@@ -257,7 +257,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">12</property>
+        <property name="top_attach">13</property>
         <property name="width">2</property>
       </packing>
     </child>
@@ -273,7 +273,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">7</property>
+        <property name="top_attach">8</property>
         <property name="width">2</property>
       </packing>
     </child>
@@ -288,7 +288,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">8</property>
+        <property name="top_attach">9</property>
         <property name="width">2</property>
       </packing>
     </child>
@@ -322,7 +322,22 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">9</property>
+        <property name="top_attach">10</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="gui/gtk_dark_hint">
+        <property name="label" translatable="yes">Prefer dark theme</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="draw_indicator">True</property>
+        <property name="tooltip_text" translatable="yes">If not checked, will not specify a preference to GTK. May not work on some platforms.</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">6</property>
         <property name="width">2</property>
       </packing>
     </child>

--- a/xlgui/preferences/appearance.py
+++ b/xlgui/preferences/appearance.py
@@ -71,6 +71,10 @@ class PlaylistFontResetButtonPreference(widgets.FontResetButtonPreference):
     condition_preference_name = 'gui/playlist_font'
 
 
+class GtkDarkThemePreference(widgets.CheckPreference):
+    default = False
+    name = 'gui/gtk_dark_hint'
+
 class UseAlphaTransparencyPreference(widgets.CheckPreference):
     default = False
     name = 'gui/use_alpha'


### PR DESCRIPTION
Tried this on Windows 7... it doesn't look that terrible. I suspect it would look better on Windows 10 if you were using a dark Windows theme already, but I don't have such a system available to me.

On Linux it doesn't seem that I can specify the non-dark theme anymore... and when I pick a theme that doesn't have a corresponding dark theme, this doesn't seem to do anything.