### PR TITLE
daapclient: explicitly convert panel's name to string

### DIFF
--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -629,7 +629,7 @@ class NetworkPanel(CollectionPanel):
             Expects a parent Gtk.Window, and a daap connection.
         """
 
-        self.name = library.daap_share.name
+        self.name = str(library.daap_share.name)
         self.daap_share = library.daap_share
         self.net_collection = collection.Collection(self.name)
         self.net_collection.add_library(library)


### PR DESCRIPTION
Otherwise, it will be stored to the list of opened panels as
dbus.String() type, causing the following error:
NameError: name 'dbus' is not defined
when restoring the GUI on the next program start.