### PR TITLE
Improve parsing of tags from remote streams

### DIFF
--- a/xl/player/gst/gst_utils.py
+++ b/xl/player/gst/gst_utils.py
@@ -194,6 +194,7 @@ def parse_stream_tags(track, tag_list):
     keep = ['bitrate',
             'duration',
             'track-number',
+            'track-count',
             'album',
             'artist',
             'genre',
@@ -229,7 +230,11 @@ def parse_stream_tags(track, tag_list):
 
     v = tags.get('track-number')
     if v:
-        etags['tracknumber'] = v
+        c = tags.get('track-count')
+        if c:
+            etags['tracknumber'] = u'%d/%d' % (v[0], c[0])
+        else:
+            etags['tracknumber'] = u'%d' % (v[0])
 
     v = tags.get('album')
     if v:

--- a/xl/player/gst/gst_utils.py
+++ b/xl/player/gst/gst_utils.py
@@ -195,6 +195,8 @@ def parse_stream_tags(track, tag_list):
             'duration',
             'track-number',
             'track-count',
+            'album-disc-number',
+            'album-disc-count',
             'album',
             'artist',
             'genre',
@@ -235,6 +237,14 @@ def parse_stream_tags(track, tag_list):
             etags['tracknumber'] = u'%d/%d' % (v[0], c[0])
         else:
             etags['tracknumber'] = u'%d' % (v[0])
+
+    v = tags.get('album-disc-number')
+    if v:
+        c = tags.get('album-disc-count')
+        if c:
+            etags['discnumber'] = u'%d/%d' % (v[0], c[0])
+        else:
+            etags['discnumber'] = u'%d' % (v[0])
 
     v = tags.get('album')
     if v:


### PR DESCRIPTION
This PR addresses an issue with displaying properties of a track from a DAAP share. When a track is added to a playlist, it is possible to show its properties by right clicking on it and selecting "Track properties". But, once the track has been played, the same action results in the following error:
```
Traceback (most recent call last):
  File "/usr/share/exaile/xlgui/widgets/playlist.py", line 361, in <lambda>
    'document-properties', lambda w, n, o, c: o.show_properties_dialog()))
  File "/usr/share/exaile/xlgui/widgets/playlist.py", line 1508, in show_properties_dialog
    current_position, with_extras)
  File "/usr/share/exaile/xlgui/properties.py", line 130, in __init__
    self.trackdata = self._tags_copy(tracks)
  File "/usr/share/exaile/xlgui/properties.py", line 191, in _tags_copy
    if len(entry.split('/')) < 2:
AttributeError: 'int' object has no attribute 'split'
```
This is because playback updates the track metadata with tags from the received stream, and ```tracknumber``` is stored as integer whereas the rest of code expects it to be a string.

The first commit fixes this issue, and also adds parsing of track-count, if available. The second commit implements parsing of album-disc-number and album-disc-count fields to construct the ```discnumber``` tag.