### PR TITLE
Exclude WASAPI plugin from installer

### DIFF
--- a/tools/installer/exaile.spec
+++ b/tools/installer/exaile.spec
@@ -49,6 +49,7 @@ def assemble_hook(analysis):
       'gstschro',
       'gstvideo',
       'gstvpx',
+      'gstwasapi',  # Generally buggy, e.g. https://github.com/exaile/exaile/issues/532
       'gstwebp',
       'gstwebrtc',
       'gstx264',


### PR DESCRIPTION
Haven't tested this (I don't have the setup to build the installer), hopefully it's correct.

Fixes https://github.com/exaile/exaile/issues/532

Fixes https://github.com/exaile/exaile/issues/534

Fixes https://github.com/exaile/exaile/issues/538