### PR TITLE
Improve metadata retrieval for remote tracks (DAAP)

### DIFF
--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -537,6 +537,7 @@ class DaapConnection(object):
             'artist': 'asar',
             'album': 'asal',
             'tracknumber': 'astn',
+            'date': 'asyr',
         }
         #            'genre':'asgn','enc':'asfm','bitrate':'asbr'}
 

--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -538,6 +538,7 @@ class DaapConnection(object):
             'album': 'asal',
             'tracknumber': 'astn',
             'date': 'asyr',
+            'discnumber': 'asdn',
         }
         #            'genre':'asgn','enc':'asfm','bitrate':'asbr'}
 

--- a/plugins/daapclient/client.py
+++ b/plugins/daapclient/client.py
@@ -188,7 +188,7 @@ class DAAPSession(object):
 # the atoms we want. Making this list smaller reduces memory footprint,
 # and speeds up reading large libraries. It also reduces the metainformation
 # available to the client.
-daap_atoms = "dmap.itemid,dmap.itemname,daap.songalbum,daap.songartist," "daap.songformat,daap.songtime,daap.songsize,daap.songgenre," "daap.songyear,daap.songtracknumber"
+daap_atoms = "dmap.itemid,dmap.itemname,daap.songalbum,daap.songartist,daap.songformat,daap.songtime,daap.songsize,daap.songgenre,daap.songyear,daap.songtracknumber"
 
 
 class DAAPDatabase(object):

--- a/plugins/daapclient/client.py
+++ b/plugins/daapclient/client.py
@@ -188,7 +188,7 @@ class DAAPSession(object):
 # the atoms we want. Making this list smaller reduces memory footprint,
 # and speeds up reading large libraries. It also reduces the metainformation
 # available to the client.
-daap_atoms = "dmap.itemid,dmap.itemname,daap.songalbum,daap.songartist,daap.songformat,daap.songtime,daap.songsize,daap.songgenre,daap.songyear,daap.songtracknumber"
+daap_atoms = "dmap.itemid,dmap.itemname,daap.songalbum,daap.songartist,daap.songformat,daap.songtime,daap.songsize,daap.songgenre,daap.songyear,daap.songtracknumber,daap.songdiscnumber"
 
 
 class DAAPDatabase(object):

--- a/xl/player/gst/gst_utils.py
+++ b/xl/player/gst/gst_utils.py
@@ -208,6 +208,7 @@ def parse_stream_tags(track, tag_list):
         'genre',
         'comment',
         'title',
+        'datetime',
     ]
 
     # Build a dictionary first
@@ -266,6 +267,11 @@ def parse_stream_tags(track, tag_list):
     v = tags.get('genre')
     if v:
         etags['genre'] = v
+
+    v = tags.get('datetime')
+    if v:
+        # v[0] is a Gst.DateTime object
+        etags['date'] = v[0].to_iso8601_string()
 
     # if there's a comment, but no album, set album to the comment
     v = tags.get('comment')


### PR DESCRIPTION
This PR improves the metadata retrieval for tracks in remote locations, with the main aim of enhancing the collection views for remote (DAAP) shares.

The first commit adds parsing of track year/date from the remote stream's metadata when the track is played. Like all metadata set at the playback time, this information serves as a fall-back for the case when it is not retrieved otherwise (e.g., at the moment, daapclient plugin does not retrieve track year).

The second commit modifies daapclient plugin to parse track year (which is already in the list of retrieved DAAP atoms), with the goal of enabling "Date - Artist", "Date - Album", and "Artist - (Date - Album)" views in collection pane.

The third commit similarly adds retrieval of disc number, which improves track sorting within collection views (and playlists) for multi-disc albums.

As noted in the source code, retrieving more metadata means greater communication overhead; however I would argue that we should be retrieving all metadata that we use for filtering and sorting. Otherwise, this functionality becomes fully available only after all tracks are played at least once (and metadata is retrieved from the stream itself), which is very impractical.