### PR TITLE
playback: remove draw override for compat with pygobject 3.30

### DIFF
--- a/xlgui/widgets/playback.py
+++ b/xlgui/widgets/playback.py
@@ -418,9 +418,6 @@ get_markers_at = __MARKERMANAGER.get_markers_at
 
 
 class _SeekInternalProgressBar(PlaybackProgressBar):
-
-    __gsignals__ = {'draw': 'override'}
-
     def __init__(self, player, points, marker_scale):
         PlaybackProgressBar.__init__(self, player)
         self._points = points


### PR DESCRIPTION
- Fixes #544

Tested on OSX and this does the trick. We should probably clean house at some point with the various gsignal things we have, but this is fine for now I think?