### PR TITLE
playlistanalyzer: Fix wrong setting name

### DIFF
--- a/plugins/playlistanalyzer/analyzer_dialog.py
+++ b/plugins/playlistanalyzer/analyzer_dialog.py
@@ -342,7 +342,7 @@ class AnalyzerDialog(object):
         output_uri = dialogs.save(
             self.window,
             output_fname,
-            'plugin/playlist_analyzer/dlg_location',
+            'plugin/playlistanalyzer/dlg_location',
             None,
             _("Save analysis"),
         )


### PR DESCRIPTION
All the other settings use "playlistanalyzer" (as is the plugin name) while this one used "playlist_analyzer". This bothers my sensibilities.

For reference, the setting stores the last save location so the user doesn't have to re-choose it each time they run the analyzer. This commit loses the existing value and leaves the incorrect entry in `settings.ini`, but actual user impact should be negligible.