### PR TITLE
docs: add mingw-w64-i686-python2-bsddb3 to list of Windows dependencies

### DIFF
--- a/doc/dev/getting_started.rst
+++ b/doc/dev/getting_started.rst
@@ -62,6 +62,7 @@ awhile):
     mingw-w64-i686-python2-gobject \
     mingw-w64-i686-python2-cairo \
     mingw-w64-i686-python2-pip \
+    mingw-w64-i686-python2-bsddb3 \
     mingw-w64-i686-gtk3 \
     mingw-w64-i686-gdk-pixbuf2 \
     mingw-w64-i686-gstreamer \


### PR DESCRIPTION
Without it, exaile appears to be mysteriously stuck after "Mutagen works" message, because we get an exception that does not seem to be displayed on stdout (flushing issue?)...