### PR TITLE
common: GioFileOutputStream: handle unicode strings in write()

### DIFF
--- a/xl/common.py
+++ b/xl/common.py
@@ -1037,6 +1037,8 @@ class GioFileOutputStream(_GioFileStream):
         self.stream.flush()
 
     def write(self, s):
+        if isinstance(s, unicode):
+            s = s.encode('utf-8')
         return self.stream.write(s)
 
 


### PR DESCRIPTION
Unicode strings need to be converted to byte strings before
they are passed to underlying stream.write().

Fixes #560.