### PR TITLE
Show GTK+ theme name in About dialog

### DIFF
--- a/xlgui/__init__.py
+++ b/xlgui/__init__.py
@@ -44,6 +44,7 @@ from xlgui import guiutil
 version.register(
     "GTK+", "%s.%s.%s" % (Gtk.MAJOR_VERSION, Gtk.MINOR_VERSION, Gtk.MICRO_VERSION)
 )
+version.register("GTK+ theme", Gtk.Settings.get_default().props.gtk_theme_name)
 
 
 def get_controller():

--- a/xlgui/widgets/dialogs.py
+++ b/xlgui/widgets/dialogs.py
@@ -132,6 +132,10 @@ class AboutDialog(Gtk.AboutDialog):
 
         self.set_version(xl.version.__version__)
 
+        # The user may have changed the theme since startup.
+        theme = Gtk.Settings.get_default().props.gtk_theme_name
+        xl.version.__external_versions__["GTK+ theme"] = theme
+
         comments = []
         for name, version in sorted(xl.version.__external_versions__.iteritems()):
             comments.append('%s: %s' % (name, version))


### PR DESCRIPTION
For when we get theme-specific bugs.