### PR TITLE
Playlist rating fix

### DIFF
--- a/xlgui/widgets/rating.py
+++ b/xlgui/widgets/rating.py
@@ -391,12 +391,11 @@ class RatingCellRenderer(Gtk.CellRendererPixbuf):
             return
 
         # Locate click area at zero
-        click_area = Gdk.Rectangle(
-            x=0,
-            y=self.props.ypad,
-            width=self.props.pixbuf.get_width(),
-            height=self.props.pixbuf.get_height(),
-        )
+        click_area = Gdk.Rectangle()
+        click_area.x = 0
+        click_area.y = self.props.ypad
+        click_area.width = self.props.pixbuf.get_width()
+        click_area.height = self.props.pixbuf.get_height()
 
         # Move event location relative to zero
         event.x -= cell_area.x + click_area.x

--- a/xlgui/widgets/rating.py
+++ b/xlgui/widgets/rating.py
@@ -401,7 +401,7 @@ class RatingCellRenderer(Gtk.CellRendererPixbuf):
         event.x -= cell_area.x + click_area.x
         event.y -= cell_area.y + click_area.y
 
-        if 0 <= event.x <= click_area.width and 0 <= event.y <= click_area.height:
+        if 0 <= event.x <= click_area.width:
             fraction = event.x / click_area.width
             maximum = settings.get_option('rating/maximum', 5)
             rating = fraction * maximum + 1


### PR DESCRIPTION
This PR should address #551, which is caused by click_area being effectively (0, 0, 0, 0) due to its members not being initialized from the values passed the constructor. The second commit allows user to set the rating even if clicked above or below the stars in the corresponding cell.