### PR TITLE
Temporarily disable main window's accelerators in search entry widgets

### DIFF
--- a/xlgui/accelerators.py
+++ b/xlgui/accelerators.py
@@ -44,10 +44,30 @@ class AcceleratorManager(providers.ProviderHandler):
         self.accelgroup = accelgroup
         providers.ProviderHandler.__init__(self, providername, simple_init=True)
 
+        self.accelerators = {}
+
     def on_provider_added(self, provider):
         self.accelgroup.connect(
             provider.key, provider.mods, Gtk.AccelFlags.VISIBLE, provider.callback
         )
 
+        # Add accelerator to internal list, so we can enable and disable
+        # them via enable_accelerators() and disable_accelerators()
+        self.accelerators[(provider.key, provider.mods)] = provider
+
     def on_provider_removed(self, provider):
         self.accelgroup.disconnect_key(provider.key, provider.mods)
+
+        # Remove accelerator from our internal list
+        del self.accelerators[(provider.key, provider.mods)]
+
+    ## Global accelerator enable/disable
+    def disable_accelerators(self):
+        for provider in self.accelerators.values():
+            self.accelgroup.disconnect_key(provider.key, provider.mods)
+
+    def enable_accelerators(self):
+        for provider in self.accelerators.values():
+            self.accelgroup.connect(
+                provider.key, provider.mods, Gtk.AccelFlags.VISIBLE, provider.callback
+            )

--- a/xlgui/guiutil.py
+++ b/xlgui/guiutil.py
@@ -37,6 +37,9 @@ from gi.repository import Pango
 
 from xl import settings, xdg
 
+# Required for xlgui.get_controller()
+import xlgui
+
 # Import from external namespace
 from xl.externals.gi_composites import GtkTemplate as _GtkTemplate
 
@@ -309,6 +312,17 @@ class SearchEntry(object):
         entry.connect('changed', self.on_entry_changed)
         entry.connect('icon-press', self.on_entry_icon_press)
         entry.connect('activate', self.on_entry_activated)
+
+        # Disable global accelerators while editing, re-enable when
+        # done
+        entry.connect(
+            'focus-in-event',
+            lambda w, e: xlgui.get_controller().main.accel_manager.disable_accelerators(),
+        )
+        entry.connect(
+            'focus-out-event',
+            lambda w, e: xlgui.get_controller().main.accel_manager.enable_accelerators(),
+        )
 
     def on_entry_changed(self, entry):
         """


### PR DESCRIPTION
This PR is an attempt to address #568. The issue is that the accelerators installed to main window are triggered even when editing a text entry. As far as I am aware, the only way around this is to temporarily remove the accelerators when text entry gains keyboard focus, and reinstall them once the focus is lost.

To do so, the first commit extends AcceleratorManager with two new methods that allow enabling/disabling all registered accelerators (in addition to keeping track of registered/unregistered providers/accelerators).

The second commit adds support for disabling and re-enabling accelerators when guiutil.SearchEntry gains and loses keyboard focus, respectively. This allows skipping between the words with ctrl+arrow not only in Playlist's Search entry (#568), but also in all other search entries that use this utility class (for example, the search entry in Collection panel).