### PR TITLE
Playlist: _search_playlist: fixed detection of timestamp-based fields

### DIFF
--- a/xl/playlist.py
+++ b/xl/playlist.py
@@ -1952,6 +1952,9 @@ class SmartPlaylist(object):
                 params += [param]
                 continue
             (field, op, value) = param
+            fieldtype = tag_data.get(field)
+            if fieldtype is not None:
+                fieldtype = fieldtype.type
 
             s = ""
 
@@ -1975,7 +1978,7 @@ class SmartPlaylist(object):
                 else:
                     matchers.append(trax.TracksNotInList(pl))
                 continue
-            elif tag_data.get(field) == 'timestamp':
+            elif fieldtype == 'timestamp':
                 duration, unit = value
                 delta = durations[unit](duration)
                 point = datetime.now() - delta


### PR DESCRIPTION
Due to incorrect comparison of "timestamp" string against _TD object
returned by tag_data.get(field), we failed to detect timestamp-based
fields, which in turn broke the search/filtering. The comparison
should be done against "type" member of the _TD object.

Should fix #19 (which was reopened for 4.0.0).