### PR TITLE
widgets: SpinButtonAndComboField: fix state restore in non-C locale

### DIFF
--- a/xlgui/widgets/filter.py
+++ b/xlgui/widgets/filter.py
@@ -516,7 +516,7 @@ class SpinButtonAndComboField(Gtk.Box):
             self.entry.set_value(int(state[0]))
         except ValueError:
             pass
-        combo_state = _(state[1])
+        combo_state = state[1]
         try:
             index = self.items.index(combo_state)
         except ValueError:


### PR DESCRIPTION
When running localized version of Exaile, the combo boxes in
SpinDateField (e.g., for "Last played") keep resetting to seconds
every time the dialog is re-run.

The issue is that set_state() translates the input unit string
before trying to look it up in internal list of (non-translated)
strings.