### PR TITLE
playlist_columns: Fix columns getting 0 width on older GTK+

### DIFF
--- a/xlgui/widgets/playlist_columns.py
+++ b/xlgui/widgets/playlist_columns.py
@@ -112,6 +112,10 @@ class Column(Gtk.TreeViewColumn):
     @common.glib_wait(100)
     def on_width_changed(self, column, wid):
         width = self.get_width()
+        if width == 0:
+            # Some older GTK+ versions (possibly <3.20) trigger this
+            # with 0 width on startup.
+            return
         if not self.destroyed and width != settings.get_option(
             self.settings_width_name, -1
         ):


### PR DESCRIPTION
On some older GTK+ versions (e.g. on Linux Mint 18.3 with GTK+ 3.18.9), on startup GTK+ emits the `notify::width` signal on every column while the column width is 0. (Or maybe this is timing-related instead of version-related? I'm not entirely sure.)

This causes us to save the value 0 to our settings, and then that gets applied, causing [#580](https://github.com/exaile/exaile/issues/580).

This patch ignores any `notify::width` events with width==0. This assumes that it doesn't make sense for the user to shrink columns until they're invisible.