### PR TITLE
Playlist columns: filter out activation events for non-active size items

### DIFF
--- a/xlgui/widgets/playlist_columns.py
+++ b/xlgui/widgets/playlist_columns.py
@@ -675,6 +675,11 @@ def __register_playlist_columns_menuitems():
         """
             Updates column sizing setting
         """
+
+        # Ignore the activation if the menu item is not actually active
+        if not menu_item.get_active():
+            return
+
         if name == 'resizable':
             settings.set_option('gui/resizable_cols', True)
         elif name == 'autosize':


### PR DESCRIPTION
In certain scenarios (e.g., during menu (re)population), we may
receive an "activate" event for a radio menu item that is not
active anymore. Therefore, on_sizing_item_activate() needs to
verify the menu_item's actual state before taking action.

Fixes #586, where such spurious activation is emitted for the
first radio item ("Resizable"), and thus we always end up marking
it as selected.