### PR TITLE
Fix columns being shrunk to 0 size on older GTK+

### DIFF
--- a/xl/common.py
+++ b/xl/common.py
@@ -280,20 +280,14 @@ def glib_wait(timeout):
         called once, then again half a second later, it would run
         only once, 1.5 seconds after the first call to it.
 
-        Arguments are supported, but which call's set of arguments
-        is used is undefined, so this is not useful for much beyond
-        passing in unchanging arguments like 'self' or 'cls'.
+        If arguments are given to the function, only the last call's set
+        of arguments will be used.
 
         If the function returns a value that evaluates to True, it
         will be called again under the same timeout rules.
         
         .. warning:: Can only be used with instance methods
     """
-    # 'undefined' is a bit of a white lie - it's always the most
-    # recent call's args. However, I'm reserving the right to change
-    # the implementation later for the moment, and really I don't
-    # think it makes sense to use functions that have changing args
-    # with this decorator.
     return _glib_wait_inner(timeout, GLib.timeout_add)
 
 

--- a/xlgui/widgets/playlist_columns.py
+++ b/xlgui/widgets/playlist_columns.py
@@ -109,9 +109,13 @@ class Column(Gtk.TreeViewColumn):
         if data in ("gui/resizable_cols", self.settings_width_name):
             self._setup_sizing()
 
-    @common.glib_wait(100)
     def on_width_changed(self, column, wid):
-        width = self.get_width()
+        # Don't call get_width in the delayed function; it can be incorrect.
+        # See https://github.com/exaile/exaile/issues/580
+        self._delayed_width_changed(self.get_width())
+
+    @common.glib_wait(100)
+    def _delayed_width_changed(self, width):
         if not self.destroyed and width != settings.get_option(
             self.settings_width_name, -1
         ):


### PR DESCRIPTION
We need to call `get_width` directly in the `notify::width` signal handler. We can't call it inside a `common.glib_wait`ed function because the width may be wrong there.

This merge request also includes documentation change to `common.glib_wait`. Previously, if there are multiple calls batched into one, the set of arguments being used is undefined. Now we specify that the last set always wins (the code already does this but it was considered implementation detail).

Fixes #580