### PR TITLE
Editable comment playlist column

### DIFF
--- a/xl/formatter.py
+++ b/xl/formatter.py
@@ -850,7 +850,7 @@ class CommentTagFormatter(TagFormatter):
             :returns: the formatted value
             :rtype: string
         """
-        value = track.get_tag_disk(self.name)
+        value = track.get_tag_raw(self.name)
 
         if not value:
             return ''

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -1320,6 +1320,7 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
                 e.button == Gdk.BUTTON_PRIMARY
                 and not e.state & Gtk.accelerator_get_default_mod_mask()
                 and selection.path_is_selected(path)
+                and selection.count_selected_rows() > 1
             ):
                 selection.set_select_function(lambda *args: False, None)
                 self.pending_event = (path, col)

--- a/xlgui/widgets/playlist_columns.py
+++ b/xlgui/widgets/playlist_columns.py
@@ -543,6 +543,18 @@ class CommentColumn(Column):
     autoexpand = True
     # Remove the newlines to fit into the vertical space of rows
     formatter = TrackFormatter('${comment:newlines=strip}')
+    cellproperties = {'editable': True}
+
+    def __init__(self, *args):
+        Column.__init__(self, *args)
+        self.cellrenderer.connect('edited', self.on_edited)
+
+    def on_edited(self, cellrenderer, path, new_text):
+        model = self.get_tree_view().get_model()
+        iter = model.get_iter(path)
+        track = model.get_value(iter, 0)
+
+        track.set_tag_raw("comment", new_text)
 
 
 providers.register('playlist-columns', CommentColumn)

--- a/xlgui/widgets/playlist_columns.py
+++ b/xlgui/widgets/playlist_columns.py
@@ -548,13 +548,33 @@ class CommentColumn(Column):
     def __init__(self, *args):
         Column.__init__(self, *args)
         self.cellrenderer.connect('edited', self.on_edited)
+        self.cellrenderer.connect('editing-started', self.on_editing_started)
 
     def on_edited(self, cellrenderer, path, new_text):
+        # Undo newline escaping
+        new_text = new_text.decode('unicode-escape')
+
+        # Set comment
         model = self.get_tree_view().get_model()
         iter = model.get_iter(path)
         track = model.get_value(iter, 0)
 
         track.set_tag_raw("comment", new_text)
+
+    def on_editing_started(self, cellrenderer, editable, path):
+        # Retrieve comment in original form
+        model = self.get_tree_view().get_model()
+
+        iter = model.get_iter(path)
+        track = model.get_value(iter, 0)
+
+        comment = TrackFormatter('$comment').format(track)
+
+        # Escape newlines
+        comment = comment.encode('unicode-escape')
+
+        # Set text
+        editable.set_text(comment)
 
 
 providers.register('playlist-columns', CommentColumn)


### PR DESCRIPTION
This PR implements editable comment playlist column (enhancement #579).

The first commit makes ```CommentTagFormatter``` use ```get_tag_raw()``` instead of ```get_tag_disk()``` to retrieve the comment. Without this change, the comment column always displays the comment stored in the music file, and fails to reflect the changes made to the comment via Exaile's Track properties dialog.

The second commit addresses interference with selection of an editable column, which turns out to be caused by code-path that aims to preserve multiple-item selection for DnD. Since the latter is relevant only for multiple-item selection, it should be activated only when multiple items are actually selected.

The third commit marks the comment column as editable and implements storage of the edited value.

The fourth commit expands the preceding one by adding support for newlines; when the column is edited, we now display newlines '\n' instead of stripping them, which allows both addition of new lines directly in the column's edit entry, and prevents the loss of existing newlines in the comment.

Closes #579.