### PR TITLE
Add AppVeyor file to build Windows installer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,14 @@ cache:
   - '%build_dir%\%sdk_name%-%sdk_ver%.tar.xz'
 
 init:
-  - set PATH=C:\msys64\usr\bin;%PATH%
-  - set GTK_SDK_VERBOSE=1
+  - cmd: |
+      REM Update PATH for Bash
+      set PATH=C:\msys64\usr\bin;%PATH%
+      set GTK_SDK_VERBOSE=1
+
+      REM Show detailed package statistics on pacman -S
+      echo [options]>> C:\msys64\etc\pacman.conf
+      echo VerbosePkgLists>> C:\msys64\etc\pacman.conf
 
 install:
   - cmd: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,65 @@
+branches:
+  only:
+    - master
+
+skip_non_tags: true
+
+version: "{branch}-{build}"
+
+image: Visual Studio 2015
+
+environment:
+  APPVEYOR_SAVE_CACHE_ON_ERROR: "true"
+  GTK_SDK_VERBOSE: 1
+  BUILD_DIR: C:\msys64\home\appveyor
+  BUILD_ROOT: exaile/tools/installer/_build_root
+  SDK_NAME: exaile-binenv-win
+  SDK_VER: 1
+  SDK_URL: https://github.com/exaile/exaile-binenv-win-appveyor/releases/download/$(SDK_NAME)-$(SDK_VER)/$(SDK_NAME)-$(SDK_VER).tar.xz
+  dist_name: $(APPVEYOR_PROJECT_NAME)-$(APPVEYOR_REPO_TAG_NAME)
+
+clone_folder: $(BUILD_DIR)\$(APPVEYOR_PROJECT_NAME)
+
+clone_depth: 1
+
+cache:
+  - C:\msys64\var\cache\pacman\pkg
+  - '%BUILD_DIR%\%SDK_NAME%-%SDK_VER%.tar.xz'
+
+init:
+  - set PATH=C:\msys64\usr\bin;%PATH%
+
+install:
+  - cmd: |
+      cd %BUILD_DIR%
+      git clone --depth=1 https://github.com/exaile/python-gtk3-gst-sdk.git
+      bash -lc "[[ -f $SDK_NAME-$SDK_VER.tar.xz ]] || time wget -O $SDK_NAME-$SDK_VER.tar.xz $SDK_URL"
+      bash -lc "time pacman --noconfirm --noprogressbar -Syuu"
+
+before_build:
+  - cmd: |
+      bash -lc "mkdir $BUILD_ROOT"
+      bash -lc "time tar -xf $SDK_NAME-$SDK_VER.tar.xz -C $BUILD_ROOT"
+
+build_script:
+  - cmd: |
+      bash -lc "cd exaile/tools/installer && time ../../../python-gtk3-gst-sdk/win_installer/build_win32_installer.sh"
+
+after_build:
+  - cmd: |
+      move "exaile\tools\installer\exaile-LATEST.exe" "%APPVEYOR_BUILD_FOLDER%\%dist_name%.exe"
+
+artifacts:
+  - path: $(dist_name).exe
+    name: dist
+
+deploy:
+  provider: GitHub
+  release: $(APPVEYOR_REPO_TAG_NAME)
+  description: ""
+  auth_token:
+    secure: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+  artifact: dist
+  on:
+    branch: master
+    APPVEYOR_REPO_TAG: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: "true"
   build_dir: C:\msys64\home\appveyor
   build_root: exaile/tools/installer/_build_root
-  sdk_name: $(APPVEYOR_PROJECT_NAME)
+  sdk_name: exaile-sdk-win
   sdk_ver: 6
   sdk_url: https://github.com/exaile/$(sdk_name)/releases/download/$(sdk_name)-$(sdk_ver)/$(sdk_name)-$(sdk_ver).tar.xz
   dist_name: $(APPVEYOR_PROJECT_NAME)-$(APPVEYOR_REPO_TAG_NAME)
@@ -30,6 +30,7 @@ init:
       REM Update PATH for Bash
       set PATH=C:\msys64\usr\bin;%PATH%
       set GTK_SDK_VERBOSE=1
+      set MAKEFLAGS=-j2
 
       REM Show detailed package statistics on pacman -S
       echo [options]>> C:\msys64\etc\pacman.conf

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,3 @@
-branches:
-  only:
-    - master
-
-skip_non_tags: true
-
 version: "{branch}-{build}"
 
 image: Visual Studio 2015
@@ -62,7 +56,7 @@ artifacts:
 
 deploy:
   provider: GitHub
-  release: $(APPVEYOR_REPO_TAG_NAME)
+  tag: $(APPVEYOR_REPO_TAG_NAME)
   description: ""
   draft: true
   auth_token:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ environment:
   sdk_name: exaile-sdk-win
   sdk_ver: 6
   sdk_url: https://github.com/exaile/$(sdk_name)/releases/download/$(sdk_name)-$(sdk_ver)/$(sdk_name)-$(sdk_ver).tar.xz
-  dist_name: $(APPVEYOR_PROJECT_NAME)-$(APPVEYOR_REPO_TAG_NAME)
 
 clone_folder: $(build_dir)\$(APPVEYOR_PROJECT_NAME)
 
@@ -25,6 +24,8 @@ init:
       set PATH=C:\msys64\usr\bin;%PATH%
       set GTK_SDK_VERBOSE=1
       set MAKEFLAGS=-j2
+      IF "%APPVEYOR_REPO_TAG%" == "true"  (set dist_name="%APPVEYOR_PROJECT_NAME%-%APPVEYOR_REPO_TAG_NAME%")
+      IF "%APPVEYOR_REPO_TAG%" == "false" (set dist_name="%APPVEYOR_PROJECT_NAME%-%APPVEYOR_BUILD_NUMBER%")
 
       REM Show detailed package statistics on pacman -S
       echo [options]>> C:\msys64\etc\pacman.conf

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ deploy:
   description: ""
   draft: true
   auth_token:
-    secure: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    secure: vvfih0eox0HI74Oo9hdPhgi5yoXjcGS4YhSkDAM9mLTqxam8+F5iro4/QppvmD9M # sjohannes's access token
   artifact: dist
   on:
     branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,9 @@ init:
       set PATH=C:\msys64\usr\bin;%PATH%
       set GTK_SDK_VERBOSE=1
       set MAKEFLAGS=-j2
-      IF "%APPVEYOR_REPO_TAG%" == "true"  (set dist_name="%APPVEYOR_PROJECT_NAME%-%APPVEYOR_REPO_TAG_NAME%")
-      IF "%APPVEYOR_REPO_TAG%" == "false" (set dist_name="%APPVEYOR_PROJECT_NAME%-%APPVEYOR_BUILD_NUMBER%")
+      IF "%APPVEYOR_REPO_TAG%" == "true"  (set dist_name=%APPVEYOR_PROJECT_NAME%-%APPVEYOR_REPO_TAG_NAME%)
+      IF "%APPVEYOR_REPO_TAG%" == "false" (set dist_name=%APPVEYOR_PROJECT_NAME%-%APPVEYOR_BUILD_NUMBER%)
+      echo Using dist_name %dist_name%
 
       REM Show detailed package statistics on pacman -S
       echo [options]>> C:\msys64\etc\pacman.conf

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,36 +10,36 @@ image: Visual Studio 2015
 
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: "true"
-  GTK_SDK_VERBOSE: 1
-  BUILD_DIR: C:\msys64\home\appveyor
-  BUILD_ROOT: exaile/tools/installer/_build_root
-  SDK_NAME: exaile-binenv-win
-  SDK_VER: 1
-  SDK_URL: https://github.com/exaile/exaile-binenv-win-appveyor/releases/download/$(SDK_NAME)-$(SDK_VER)/$(SDK_NAME)-$(SDK_VER).tar.xz
+  build_dir: C:\msys64\home\appveyor
+  build_root: exaile/tools/installer/_build_root
+  sdk_name: exaile-binenv-win
+  sdk_ver: 1
+  sdk_url: https://github.com/exaile/exaile-binenv-win-appveyor/releases/download/$(sdk_name)-$(sdk_ver)/$(sdk_name)-$(sdk_ver).tar.xz
   dist_name: $(APPVEYOR_PROJECT_NAME)-$(APPVEYOR_REPO_TAG_NAME)
 
-clone_folder: $(BUILD_DIR)\$(APPVEYOR_PROJECT_NAME)
+clone_folder: $(build_dir)\$(APPVEYOR_PROJECT_NAME)
 
 clone_depth: 1
 
 cache:
   - C:\msys64\var\cache\pacman\pkg
-  - '%BUILD_DIR%\%SDK_NAME%-%SDK_VER%.tar.xz'
+  - '%build_dir%\%sdk_name%-%sdk_ver%.tar.xz'
 
 init:
   - set PATH=C:\msys64\usr\bin;%PATH%
+  - set GTK_SDK_VERBOSE=1
 
 install:
   - cmd: |
-      cd %BUILD_DIR%
+      cd %build_dir%
       git clone --depth=1 https://github.com/exaile/python-gtk3-gst-sdk.git
-      bash -lc "[[ -f $SDK_NAME-$SDK_VER.tar.xz ]] || time wget -O $SDK_NAME-$SDK_VER.tar.xz $SDK_URL"
+      bash -lc "[[ -f $sdk_name-$sdk_ver.tar.xz ]] || time wget -O $sdk_name-$sdk_ver.tar.xz $sdk_url"
       bash -lc "time pacman --noconfirm --noprogressbar -Syuu"
 
 before_build:
   - cmd: |
-      bash -lc "mkdir $BUILD_ROOT"
-      bash -lc "time tar -xf $SDK_NAME-$SDK_VER.tar.xz -C $BUILD_ROOT"
+      bash -lc "mkdir $build_root"
+      bash -lc "time tar -xf $sdk_name-$sdk_ver.tar.xz -C $build_root"
 
 build_script:
   - cmd: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,9 @@ environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: "true"
   build_dir: C:\msys64\home\appveyor
   build_root: exaile/tools/installer/_build_root
-  sdk_name: exaile-binenv-win
-  sdk_ver: 1
-  sdk_url: https://github.com/exaile/exaile-binenv-win-appveyor/releases/download/$(sdk_name)-$(sdk_ver)/$(sdk_name)-$(sdk_ver).tar.xz
+  sdk_name: $(APPVEYOR_PROJECT_NAME)
+  sdk_ver: 6
+  sdk_url: https://github.com/exaile/$(sdk_name)/releases/download/$(sdk_name)-$(sdk_ver)/$(sdk_name)-$(sdk_ver).tar.xz
   dist_name: $(APPVEYOR_PROJECT_NAME)-$(APPVEYOR_REPO_TAG_NAME)
 
 clone_folder: $(build_dir)\$(APPVEYOR_PROJECT_NAME)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,6 +63,7 @@ deploy:
   provider: GitHub
   release: $(APPVEYOR_REPO_TAG_NAME)
   description: ""
+  draft: true
   auth_token:
     secure: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
   artifact: dist


### PR DESCRIPTION
I think we are OK about #584.

Things to do **before** accepting this PR (in this order):
- [x] Merge [sjohannes' PyInstaller (`sdk` branch)](https://github.com/sjohannes/pyinstaller/tree/sdk) into [exaile's PyInstaller](https://github.com/exaile/pyinstaller/tree/sdk)
- [x] Create exaile/exaile-binenv-win-appveyor repo from https://github.com/sjohannes/exaile-binenv-win-appveyor
- [x] Setup AppVeyor for Exaile

This `appveyor.yml` file builds and deploys Exaile Windows installer to each new tag.