### PR TITLE
Windows installer: Don't package fonts

### DIFF
--- a/tools/installer/exaile_installer.nsi
+++ b/tools/installer/exaile_installer.nsi
@@ -143,7 +143,7 @@ Section "-Exaile" SecExaile
 
     SetOutPath "$INSTDIR"
 
-    File /r "_dist\exaile\*.*"
+    File /r /x "fonts" /x "fontconfig" "_dist\exaile\*.*"
 
     ;Store installation folder
     WriteRegStr SHCTX "${INSTDIR_KEY}" "${INSTDIR_SUBKEY}" $INSTDIR


### PR DESCRIPTION
Before this path: 48.9MB (installer) / 163MB (installed)
After this patch: 45.1MB (installer) / 150 MB (installed)

I don't see any troubles without fonts directory.