### PR TITLE
Get current git revision only if .git directory exists

### DIFF
--- a/xl/version.py
+++ b/xl/version.py
@@ -53,7 +53,7 @@ def get_current_revision(directory):
         return None
 
 
-if xdg.local_hack:
+if os.path.isdir(os.path.join(xdg.exaile_dir, ".git")):
     revision = get_current_revision(xdg.exaile_dir)
     if revision is not None:
         extra += "+" + revision


### PR DESCRIPTION
Related to #588.

> Maybe we should just check for the .git directory.

So that's what I did.