### PR TITLE
Change volume up accellerator from Ctrl++ to Ctrl+=.

### DIFF
--- a/xlgui/main.py
+++ b/xlgui/main.py
@@ -185,7 +185,7 @@ class MainWindow(GObject.GObject):
                 lambda *_e: self._on_seek_key(False),
             ),
             (
-                '<Primary>plus',
+                '<Primary>equal',
                 _('Increase the volume'),
                 lambda *_e: self._on_volume_key(True),
             ),


### PR DESCRIPTION
Ctrl+= makes more sense than Ctrl++ on QWERTY, but are there layouts where it's bad? If this is an issue on other layouts we can always allow both (like Firefox does).