### PR TITLE
Drop hal and UDisks(1) support

### DIFF
--- a/plugins/cd/PLUGININFO
+++ b/plugins/cd/PLUGININFO
@@ -1,7 +1,7 @@
 Version='4.0.0'
 Authors=['Aren Olson <reacocard@gmail.com>']
 Name=_('CD Playback')
-Description=_('Adds support for playing audio CDs.\n\nRequires HAL, UDisks or UDisks2 to autodetect CDs\nRequires cddb-py (%s) to look up tags.') % 'http://cddb-py.sourceforge.net/'
+Description=_('Adds support for playing audio CDs.\n\nRequires UDisks2 to autodetect CDs\nRequires cddb-py (%s) to look up tags.') % 'http://cddb-py.sourceforge.net/'
 Category=_('Devices')
 Platforms=['linux']
 RequiredModules=['dbus']

--- a/xl/main.py
+++ b/xl/main.py
@@ -729,8 +729,6 @@ class Exaile(object):
         # -> if initialized and connected, then the object is not None
 
         self.udisks2 = None
-        self.udisks = None
-        self.hal = None
 
         if self.options.Hal:
             from xl import hal
@@ -738,15 +736,6 @@ class Exaile(object):
             udisks2 = hal.UDisks2(self.devices)
             if udisks2.connect():
                 self.udisks2 = udisks2
-            else:
-                udisks = hal.UDisks(self.devices)
-                if udisks.connect():
-                    self.udisks = udisks
-                else:
-                    self.hal = hal.HAL(self.devices)
-                    self.hal.connect()
-        else:
-            self.hal = None
 
         # Radio Manager
         from xl import radio


### PR DESCRIPTION
HAL has been deprecated for years and has been removed from most Linux distributions . Even its successor, UDisks version 1 has been superseded by UDisks2 about 4 years ago.

FreeBSD has its own implementation of UDisks2: https://svnweb.freebsd.org/ports/head/sysutils/bsdisks/
@rokm: Do I remember correctly that you are using FreeBSD? If yes, can you please check whether this works for you too?

The massstorage plugin is still broken, see #610 for that.