### PR TITLE
Explicit python2 in all shebangs

### DIFF
--- a/plugins/lastfmlove/cellrenderertoggleimage.py
+++ b/plugins/lastfmlove/cellrenderertoggleimage.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from gi.repository import GdkPixbuf, GObject, Gtk, Gdk

--- a/tools/.bpythonrc
+++ b/tools/.bpythonrc
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import sys
 sys.path.insert(0, '.')
 

--- a/tools/ipcli
+++ b/tools/ipcli
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2008-2010 Adam Olsen
 #

--- a/tools/ipshell
+++ b/tools/ipshell
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 sys.path.insert(0, ".")


### PR DESCRIPTION
I'm packaging Exaile 4.0.0.rc4 for Arch Linux, and I see `namcap` complains about the built package:
```
$ namcap exaile-4.0.0.rc4-1-any.pkg.tar.xz
exaile E: Dependency python detected and not included (programs ['python'] needed in scripts ['usr/share/exaile/plugins/lastfmlove/cellrenderertoggleimage.py'])
```
It is because `namcap` thinks Python 3 is required (due to Arch's default), but it is not the case.

I prefer to set an explicit Python version to avoid this.