### PR TITLE
plugins: Use pkgutil.find_loader when checking is_potentially_broken.

### DIFF
--- a/xl/plugins.py
+++ b/xl/plugins.py
@@ -235,6 +235,7 @@ class PluginsManager(object):
 
             :param info: The data returned from get_plugin_info()
         '''
+        import pkgutil
         from gi.repository import GIRepository
 
         gir = GIRepository.Repository.get_default()
@@ -249,11 +250,7 @@ class PluginsManager(object):
                     if not gir.enumerate_versions(module):
                         return True
             else:
-                try:
-                    mdata = imp.find_module(module)
-                    if mdata[0] is not None:
-                        mdata[0].close()
-                except Exception:
+                if not pkgutil.find_loader(module):
                     return True
 
         return False


### PR DESCRIPTION
On our official Windows builds, some of the plugins are mistakenly marked as potentially broken (⚠️). This is because the RequiredModules field in PLUGININFO files are checked using `imp.find_module`, which doesn't work with whatever magic PyInstaller uses to package modules. This changes the check to use `pkgutil.find_loader` instead, which works correctly for this.

Fixes: https://github.com/exaile/exaile/issues/629