### PR TITLE
README: Point to exaile.org instead of readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ tagging, last.fm scrobbling, support for portable media players, podcasts,
 internet radio such as icecast and Soma.FM, ReplayGain, output via a secondary
 output device (great for DJs!), and much more.
 
-For more information see https://exaile.readthedocs.io/
+For more information see https://exaile.org/


### PR DESCRIPTION
Potential users often expect all the info about a project in the GitHub readme. We're not doing this, but we should at least point them to our website, which has more info (e.g. screenshots).