### PR TITLE
playlist widget: don't always grab focus in button_press_event

### DIFF
--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -1290,7 +1290,6 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
             * thunar_details_view_button_press_event() of thunar-details-view.c
             * MultiDragTreeView.__button_press/__button.release of quodlibet/qltk/views.py
         """
-        self.grab_focus()
 
         # need this to workaround bug in GTK+ on OSX when dragging/dropping
         # -> https://bugzilla.gnome.org/show_bug.cgi?id=722815


### PR DESCRIPTION
Original comment was:

>  Grab focus upon click in playlist views (fixes a bug where opening the track properties dialog fails to open due to wrong selection)

I can't seem to duplicate that condition, and I know we've fixed a lot of things related to playlists and selection since then, so I'm guessing it's not needed anymore.

Related to #633 