### PR TITLE
Fix wrong gettext call on shortcut keys

### DIFF
--- a/xlgui/main.py
+++ b/xlgui/main.py
@@ -238,7 +238,7 @@ class MainWindow(GObject.GObject):
         )
 
         for keys, helptext, function in hotkeys:
-            accelerator = Accelerator(_(keys), helptext, function)
+            accelerator = Accelerator(keys, helptext, function)
             providers.register('mainwindow-accelerators', accelerator)
 
     def _setup_widgets(self):


### PR DESCRIPTION
I don't think the key definitions (e.g. `<Primary>F`) are meant to be translated here. Anyway the `_(keys)` call is definitely wrong because the keys themselves are not currently marked for translation.