### PR TITLE
Installer: Fix crash when running executables in SDK if MSYS has been updated locally

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,8 @@ image: Visual Studio 2015
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: "true"
   build_dir: C:\msys64\home\appveyor
-  build_root: exaile/tools/installer/_build_root
+  build_root: exaile\tools\installer\_build_root
+  build_root_slash: exaile/tools/installer/_build_root
   sdk_name: exaile-sdk-win
   sdk_ver: 14
   sdk_url: https://github.com/exaile/$(sdk_name)/releases/download/$(sdk_name)-$(sdk_ver)/$(sdk_name)-$(sdk_ver).tar.xz
@@ -21,7 +22,8 @@ cache:
 init:
   - cmd: |
       REM Update PATH for Bash
-      set PATH=C:\msys64\usr\bin;%PATH%
+      set hostbash=C:\msys64\usr\bin\bash.exe
+      set sdkbash=%build_dir%\%build_root%\usr\bin\bash.exe
       set GTK_SDK_VERBOSE=1
       set MAKEFLAGS=-j2
       IF "%APPVEYOR_REPO_TAG%" == "true"  (set DIST_VERSION=%APPVEYOR_REPO_TAG_NAME%)
@@ -37,17 +39,17 @@ install:
   - cmd: |
       cd %build_dir%
       git clone --depth=1 https://github.com/exaile/python-gtk3-gst-sdk.git
-      bash -lc "[[ -f $sdk_name-$sdk_ver.tar.xz ]] || time curl -qfLo $sdk_name-$sdk_ver.tar.xz $sdk_url"
-      bash -lc "time pacman --noconfirm --noprogressbar -Syuu"
+      %hostbash% -lc "[ -f $sdk_name-$sdk_ver.tar.xz ] || time curl -qfLo $sdk_name-$sdk_ver.tar.xz $sdk_url"
 
 before_build:
   - cmd: |
-      bash -lc "mkdir $build_root"
-      bash -lc "time tar -xf $sdk_name-$sdk_ver.tar.xz -C $build_root"
+      mkdir %build_root%
+      %hostbash% -lc "time tar -xf $sdk_name-$sdk_ver.tar.xz -C $build_root_slash"
+      %sdkbash% -lc exit
 
 build_script:
   - cmd: |
-      bash -lc "cd exaile/tools/installer && time ../../../python-gtk3-gst-sdk/win_installer/build_win32_installer.sh"
+      %sdkbash% -lc "cd ""$build_dir/exaile/tools/installer"" && time ../../../python-gtk3-gst-sdk/win_installer/build_win32_installer.sh"
 
 after_build:
   - cmd: |

--- a/tools/installer/project.config
+++ b/tools/installer/project.config
@@ -1,8 +1,20 @@
+# Our SDK tool is designed for local use, where you'd run build_win32_sdk.sh
+# and build_win32_installer.sh in succession, so both the SDK and the host MSYS
+# environments depend on the same MSYS runtime version.
 #
-# Packages to download
+# This is not possible in our CI setup, where the SDK can be built a long time
+# before the installer. If you try to mix two MSYS environments that have
+# significantly diverged, things will crash.
 #
-TARGET_DOWNLOAD_PKGS="\
-make \
-git \
-tar \
-mingw-w64-i686-python2-bsddb3"
+# So for CI we include the following packages in the SDK (see the SDK's
+# appveyor.yml) and avoid the need for the host MSYS during installer creation.
+
+# Only define TARGET_DOWNLOAD_PKGS on local build or when building the SDK
+if [ -z "$CI" -o "$APPVEYOR_PROJECT_NAME" == "exaile-win-sdk" ]; then
+  TARGET_DOWNLOAD_PKGS="
+    git
+    make
+    tar
+    mingw-w64-i686-python2-bsddb3
+  "
+fi


### PR DESCRIPTION
Currently the installer breaks if the build host's MSYS runtime is newer than the SDK's.