### PR TITLE
Fix unicode handling in playlist names

### DIFF
--- a/xlgui/playlist_container.py
+++ b/xlgui/playlist_container.py
@@ -203,7 +203,7 @@ class PlaylistNotebook(SmartNotebook):
 
         for n in range(self.get_n_pages()):
             page = self.get_nth_page(n)
-            name = page.get_page_name().decode('utf-8', errors='replace')
+            name = page.get_page_name()
             name_parts = [
                 # 'Playlist 99' => 'Playlist '
                 name[0 : len(default_name_parts[0])],

--- a/xlgui/widgets/notebook.py
+++ b/xlgui/widgets/notebook.py
@@ -377,6 +377,9 @@ class NotebookTab(Gtk.EventBox):
         """
         name = self.entry.get_text()
 
+        if not isinstance(name, unicode):
+            name = name.decode('utf-8', errors='replace')
+
         if name.strip() != "" and not self.entry.props.editing_canceled:
             self.page.set_page_name(name)
             self.label.set_text(name)


### PR DESCRIPTION
A fix for issues with non-ASCII characters in playlist name (#643 ).

The original issue is caused by the decode() call on page name, which is already a unicode object. 

(Unless I am mistaken, the decode() call would make sense if the name was a str object containing UTF-8 characters. To get from unicode back to str, encode() should be used instead. But since default_playlist_name and consequently default_name_parts are also unicode objects, no conversion is actually required).

The second issue (error upon closing exaile) is fixed by ensuring that the name which we pass to encode_filename is a unicode object instead of str.