### PR TITLE
xl/logger_setup.py: Add leading zeros to milliseconds

### DIFF
--- a/xl/logger_setup.py
+++ b/xl/logger_setup.py
@@ -131,7 +131,7 @@ def start_logging(debug, quiet, debugthreads, module_filter, level_filter):
     if debug:
         file_loglevel = logging.DEBUG
         console_loglevel = logging.DEBUG
-        console_format = "%(asctime)s,%(msecs)3d:" + console_format
+        console_format = "%(asctime)s,%(msecs)03d:" + console_format
         console_format += " (%(name)s)"  # add module name
     elif quiet:
         console_loglevel = logging.WARNING


### PR DESCRIPTION
See Python's documentation on [String Formatting Operations](https://docs.python.org/2.7/library/stdtypes.html?highlight=sprintf#string-formatting-operations).