### PR TITLE
Replace cddb by libdiscid

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -42,7 +42,7 @@ Device detection:
 
 CD info:
 
-* python-libdiscid (optional)
+* python-libdiscid or python-discid (optional on linux, required to use musicbrainz)
 * python-musicbrainzngs (optional)
 
 DAAP plugins (daapserver and daapclient):

--- a/DEPS
+++ b/DEPS
@@ -42,7 +42,8 @@ Device detection:
 
 CD info:
 
-* cddb (python2), from http://cddb-py.sourceforge.net/
+* python-libdiscid (optional)
+* python-musicbrainzngs (optional)
 
 DAAP plugins (daapserver and daapclient):
 

--- a/plugins/cd/PLUGININFO
+++ b/plugins/cd/PLUGININFO
@@ -1,7 +1,7 @@
 Version='4.0.0'
 Authors=['Aren Olson <reacocard@gmail.com>']
 Name=_('CD Playback')
-Description=_('Adds support for playing audio CDs.\n\nRequires UDisks2 to autodetect CDs\nRequires cddb-py (%s) to look up tags.') % 'http://cddb-py.sourceforge.net/'
+Description=_('Adds support for playing audio CDs.\n\nRequires UDisks2 to autodetect CDs\nRequires python-libdiscid (%s) and python-musicbrainzngs (%s) to look up tags.') % ('https://pypi.org/project/python-libdiscid/', 'https://pypi.org/project/musicbrainzngs/')
 Category=_('Devices')
 Platforms=['linux']
 RequiredModules=['dbus']

--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -146,7 +146,8 @@ class CDPlaylist(playlist.Playlist):
         elif toc_entries is not None:
             tracks = linux_cd_parser.parse_tracks(toc_entries, mcn, self.__device)
         else:
-            logger.err('Could not read disc index')
+            logger.error('Could not read disc index')
+            tracks = None
         if tracks is not None:
             logger.debug('Read disc with tracks %s', tracks)
             self.extend(tracks)

--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -35,7 +35,7 @@ from xl.nls import gettext as _
 from xl import providers, event, main
 from xl.hal import Handler, UDisksProvider
 from xl.devices import Device, KeyedDevice
-from xl import playlist, trax, common
+from xl import playlist, trax, common, settings
 from xl.trax import Track
 
 import cdprefs
@@ -128,8 +128,10 @@ class CDPlaylist(playlist.Playlist):
         if disc_id is None:
             return
 
-        logger.info('Starting to get disc metadata')
-        self.__read_disc_metadata_internal(disc_id, tracks, self.__device)
+        allow_internet = settings.get_option('cd_metadata/fetch_from_internet', True)
+        if allow_internet:
+            logger.info('Starting to get disc metadata')
+            self.__read_disc_metadata_internal(disc_id, tracks, self.__device)
 
     @staticmethod
     def __read_disc_index_internal(device):
@@ -174,8 +176,6 @@ class CDPlaylist(playlist.Playlist):
         # * http://ftp.freedb.org/pub/freedb/latest/DBFORMAT
         # * http://ftp.freedb.org/pub/freedb/latest/CDDBPROTO
         # * Servers: http://freedb.freedb.org/,
-
-        # TODO: add setting to let user choose whether he wants internet connections
         if MUSICBRAINZNGS_AVAILABLE:
             musicbrainzngs_parser.fetch_with_disc_id(
                 disc_id, tracks, self.__metadata_parsed_callback

--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -138,7 +138,7 @@ class CDPlaylist(playlist.Playlist):
             tracks = discid_parser.parse_disc(disc_id, self.__device)
             if tracks is not None:
                 allow_internet = settings.get_option(
-                    'cd_metadata/fetch_from_internet', True
+                    'plugin/cd/fetch_metadata_from_internet', True
                 )
                 if allow_internet:
                     logger.info('Starting to get disc metadata')

--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -207,7 +207,7 @@ class CDPlaylist(playlist.Playlist):
             )
 
         self.name = title[1].decode('iso-8859-15', 'replace')
-        event.log_event('cddb_info_retrieved', self, True)
+        event.log_event('cd_info_retrieved', self, True)
 
 
 class CDDevice(KeyedDevice):

--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -49,21 +49,14 @@ if sys.platform.startswith('linux'):
     import linux_cd_parser
 
 try:
-    try:  # allow both python-discid and python-libdiscid
-        from libdiscid.compat import discid
-    except ImportError:
-        import discid
     import discid_parser
-
     DISCID_AVAILABLE = True
 except ImportError:
     logger.warn('Cannot import dependency for plugin cd.', exc_info=True)
     DISCID_AVAILABLE = False
 
 try:
-    import musicbrainzngs
     import musicbrainzngs_parser
-
     MUSICBRAINZNGS_AVAILABLE = True
 except ImportError:
     logger.warn('Cannot import dependency for plugin cd.', exc_info=True)

--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -39,6 +39,7 @@ from xl import playlist, trax, common, settings
 from xl.trax import Track
 
 import cdprefs
+import _cdguipanel
 
 
 logger = logging.getLogger(__name__)
@@ -185,19 +186,7 @@ class CDDevice(KeyedDevice):
         self.name = _("Audio Disc")
         self.dev = dev
 
-    def _get_panel_type(self):
-        import imp
-
-        try:
-            _cdguipanel = imp.load_source(
-                "_cdguipanel", os.path.join(os.path.dirname(__file__), "_cdguipanel.py")
-            )
-            return _cdguipanel.CDPanel
-        except Exception:
-            logger.exception("Could not import cd gui panel")
-            return 'flatplaylist'
-
-    panel_type = property(_get_panel_type)
+    panel_type = _cdguipanel.CDPanel
 
     def __on_cd_info_retrieved(self, _event_type, cd_playlist, _disc_title):
         self.playlists.append(cd_playlist)

--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -51,6 +51,7 @@ try:
     except ImportError:
         import discid
     import discid_parser
+
     DISCID_AVAILABLE = True
 except ImportError:
     logger.warn('Cannot import dependency for plugin cd.', exc_info=True)
@@ -59,6 +60,7 @@ except ImportError:
 try:
     import musicbrainzngs
     import musicbrainzngs_parser
+
     MUSICBRAINZNGS_AVAILABLE = True
 except ImportError:
     logger.warn('Cannot import dependency for plugin cd.', exc_info=True)
@@ -126,7 +128,7 @@ class CDPlaylist(playlist.Playlist):
         # * even older python code: http://cddb-py.sourceforge.net/
         # * http://ftp.freedb.org/pub/freedb/latest/DBFORMAT
         # * http://ftp.freedb.org/pub/freedb/latest/CDDBPROTO
-        # * Servers: http://freedb.freedb.org/, 
+        # * Servers: http://freedb.freedb.org/,
 
         if DISCID_AVAILABLE:
             try:
@@ -137,30 +139,38 @@ class CDPlaylist(playlist.Playlist):
                 
                 if MUSICBRAINZNGS_AVAILABLE: # TODO: add setting to let user choose whether he wants internet connections
                     try:
-                        result = musicbrainzngs_parser.fetch_with_disc_id(disc_id, device)
+                        result = musicbrainzngs_parser.fetch_with_disc_id(
+                            disc_id, device
+                        )
                         if result is not None:
                             (tracks, title) = result
                             self.extend(tracks)
                             print(title)  # TODO: set as playlist title, panel title?
                             return
-                    except musicbrainzngs.WebServiceError as web_error:
+                    except musicbrainzngs.WebServiceError:
                         # This is expected to fail if user is offline or behind an
                         # aggressive firewall.
-                        logger.info('Failed to fetch data from musicbrainz database.', exc_info=True)
-                    except:
-                        logger.warn('Failed to parse data from musicbrainz database.', exc_info=True)
-                
+                        logger.info(
+                            'Failed to fetch data from musicbrainz database.',
+                            exc_info=True,
+                        )
+                    except Exception:
+                        logger.warn(
+                            'Failed to parse data from musicbrainz database.',
+                            exc_info=True,
+                        )
+
                 tracks = discid_parser.parse_disc(disc_id, device)
                 self.extend(tracks)
-                return # TODO commented out for debugging purposes
-            except:
+                return
+            except Exception:
                 logger.warn('Failed to fetch data from cd using discid.', exc_info=True)
-        
+
         if sys.platform.startswith('linux'):
             try:
                 tracks = linux_cd_parser.read_cd_index(device)
                 self.extend(tracks)
-            except:
+            except Exception:
                 logger.warn('Failed to read metadata from CD.', exc_info=True)
 
 

--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -50,6 +50,7 @@ if sys.platform.startswith('linux'):
 
 try:
     import discid_parser
+
     DISCID_AVAILABLE = True
 except ImportError:
     logger.warn('Cannot import dependency for plugin cd.', exc_info=True)
@@ -57,6 +58,7 @@ except ImportError:
 
 try:
     import musicbrainzngs_parser
+
     MUSICBRAINZNGS_AVAILABLE = True
 except ImportError:
     logger.warn('Cannot import dependency for plugin cd.', exc_info=True)
@@ -108,9 +110,12 @@ class CDPlaylist(playlist.Playlist):
         if DISCID_AVAILABLE:
             try:
                 disc_id = discid_parser.read_disc_id(device)
-                logger.debug('Successfully read CD using discid with %i tracks. '
-                             'Musicbrainz id: %s',
-                             len(disc_id.tracks), disc_id.id)
+                logger.debug(
+                    'Successfully read CD using discid with %i tracks. '
+                    'Musicbrainz id: %s',
+                    len(disc_id.tracks),
+                    disc_id.id,
+                )
                 GLib.idle_add(self.__apply_disc_index, disc_id, None, None)
                 return
             except Exception:
@@ -132,7 +137,9 @@ class CDPlaylist(playlist.Playlist):
         if disc_id is not None:
             tracks = discid_parser.parse_disc(disc_id, self.__device)
             if tracks is not None:
-                allow_internet = settings.get_option('cd_metadata/fetch_from_internet', True)
+                allow_internet = settings.get_option(
+                    'cd_metadata/fetch_from_internet', True
+                )
                 if allow_internet:
                     logger.info('Starting to get disc metadata')
                     self.__fetch_disc_metadata(disc_id, tracks)
@@ -162,7 +169,9 @@ class CDPlaylist(playlist.Playlist):
         # * Servers: http://freedb.freedb.org/,
         if MUSICBRAINZNGS_AVAILABLE:
             musicbrainz_data = musicbrainzngs_parser.fetch_with_disc_id(disc_id)
-            GLib.idle_add(self.__musicbrainz_metadata_fetched, musicbrainz_data, disc_id, tracks)
+            GLib.idle_add(
+                self.__musicbrainz_metadata_fetched, musicbrainz_data, disc_id, tracks
+            )
 
     def __musicbrainz_metadata_fetched(self, musicbrainz_data, disc_id, tracks):
         metadata = musicbrainzngs_parser.parse(musicbrainz_data, disc_id, tracks)

--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -135,14 +135,14 @@ class CDPlaylist(playlist.Playlist):
                              'Musicbrainz id: %s',
                              len(disc_id.tracks), disc_id.id)
                 
-                if MUSICBRAINZNGS_AVAILABLE: # TODO add setting to let user choose whether he wants internet connections
+                if MUSICBRAINZNGS_AVAILABLE: # TODO: add setting to let user choose whether he wants internet connections
                     try:
                         result = musicbrainzngs_parser.fetch_with_disc_id(disc_id, device)
                         if result is not None:
                             (tracks, title) = result
                             self.extend(tracks)
                             print(title)  # TODO: set as playlist title, panel title?
-                            return # TODO commented out for debugging purposes
+                            return
                     except musicbrainzngs.WebServiceError as web_error:
                         # This is expected to fail if user is offline or behind an
                         # aggressive firewall.

--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -135,7 +135,7 @@ class CDPlaylist(playlist.Playlist):
                              'Musicbrainz id: %s',
                              len(disc_id.tracks), disc_id.id)
                 
-                if MUSICBRAINZNGS_AVAILABLE:
+                if MUSICBRAINZNGS_AVAILABLE: # TODO add setting to let user choose whether he wants internet connections
                     try:
                         result = musicbrainzngs_parser.fetch_with_disc_id(disc_id, device)
                         if result is not None:

--- a/plugins/cd/_cdguipanel.py
+++ b/plugins/cd/_cdguipanel.py
@@ -78,7 +78,7 @@ class CDPanel(device.FlatPlaylistDevicePanel):
         device.FlatPlaylistDevicePanel.__init__(self, *args)
         self.__importing = False
 
-        event.add_ui_callback(self._tree_queue_draw, 'cddb_info_retrieved')
+        event.add_ui_callback(self._tree_queue_draw, 'cd_info_retrieved')
 
     def _tree_queue_draw(self, type, cdplaylist, object=None):
         if not hasattr(self.fppanel, 'tree'):

--- a/plugins/cd/_cdguipanel.py
+++ b/plugins/cd/_cdguipanel.py
@@ -39,6 +39,12 @@ import xlgui
 logger = logging.getLogger(__name__)
 
 
+# TODO: Improve progress update
+# TODO: Ask for folder where to put the disc instead of blindly copying it
+# TODO: add eject button
+# TODO: allow to directly play from panel
+
+
 class CDImportThread(common.ProgressThread):
     def __init__(self, cd_importer):
         common.ProgressThread.__init__(self)
@@ -80,7 +86,7 @@ class CDPanel(device.FlatPlaylistDevicePanel):
 
         event.add_ui_callback(self._tree_queue_draw, 'cd_info_retrieved')
 
-    def _tree_queue_draw(self, type, cdplaylist, disc_title=None):
+    def _tree_queue_draw(self, _event_type, cdplaylist, disc_title=None):
         if not hasattr(self.fppanel, 'tree'):
             return
 

--- a/plugins/cd/_cdguipanel.py
+++ b/plugins/cd/_cdguipanel.py
@@ -80,9 +80,17 @@ class CDPanel(device.FlatPlaylistDevicePanel):
 
         event.add_ui_callback(self._tree_queue_draw, 'cd_info_retrieved')
 
-    def _tree_queue_draw(self, type, cdplaylist, object=None):
+    def _tree_queue_draw(self, type, cdplaylist, disc_title=None):
         if not hasattr(self.fppanel, 'tree'):
             return
+
+        # TODO: set name to panel. This requires a GUI change in
+        # panel/flatplaylist/FlatPlaylistPanel respectively flatplaylist.ui
+        # Do not use self.name because it breaks the panel after switching to another CD
+        if disc_title is None:
+            self.panel_title = _('Unknown disc')
+        else:
+            self.panel_title = disc_title
 
         if cdplaylist in self.device.playlists:
             logger.info("Calling queue_draw for %s", str(cdplaylist))

--- a/plugins/cd/cdprefs.py
+++ b/plugins/cd/cdprefs.py
@@ -38,7 +38,6 @@ ui = os.path.join(basedir, "cdprefs_pane.ui")
 FORMAT_WIDGET = None
 
 
-
 class OutputFormatPreference(widgets.ComboPreference):
     name = 'cd_import/format'
 
@@ -65,10 +64,10 @@ class OutputQualityPreference(widgets.ComboPreference, widgets.Conditional):
             return False
 
         curiter = self.condition_widget.get_active_iter()
-        format = self.condition_widget.get_model().get_value(curiter, 0)
-        formatinfo = transcoder.FORMATS[format]
-        if self.format != format:
-            self.format = format
+        tc_format = self.condition_widget.get_model().get_value(curiter, 0)
+        formatinfo = transcoder.FORMATS[tc_format]
+        if self.format != tc_format:
+            self.format = tc_format
             default = formatinfo['default']
 
             if self.default != default:

--- a/plugins/cd/cdprefs.py
+++ b/plugins/cd/cdprefs.py
@@ -39,7 +39,7 @@ FORMAT_WIDGET = None
 
 
 class ImportMetadataPreference(widgets.CheckPreference):
-    name = 'cd_metadata/fetch_from_internet'
+    name = 'plugin/cd/fetch_metadata_from_internet'
     default = True
 
 

--- a/plugins/cd/cdprefs.py
+++ b/plugins/cd/cdprefs.py
@@ -37,7 +37,6 @@ ui = os.path.join(basedir, "cdprefs_pane.ui")
 
 FORMAT_WIDGET = None
 
-# TODO: allow setting cddb server?
 
 
 class OutputFormatPreference(widgets.ComboPreference):

--- a/plugins/cd/cdprefs.py
+++ b/plugins/cd/cdprefs.py
@@ -38,6 +38,11 @@ ui = os.path.join(basedir, "cdprefs_pane.ui")
 FORMAT_WIDGET = None
 
 
+class ImportMetadataPreference(widgets.CheckPreference):
+    name = 'cd_metadata/fetch_from_internet'
+    default = True
+
+
 class OutputFormatPreference(widgets.ComboPreference):
     name = 'cd_import/format'
 

--- a/plugins/cd/cdprefs_pane.ui
+++ b/plugins/cd/cdprefs_pane.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkListStore" id="format_model">
@@ -36,123 +36,193 @@
       <column type="gchararray"/>
     </columns>
   </object>
-  <object class="GtkGrid" id="preferences_pane">
+  <object class="GtkBox" id="preferences_pane">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="row_spacing">4</property>
-    <property name="column_spacing">2</property>
+    <property name="orientation">vertical</property>
     <child>
-      <object class="GtkLabel" id="label1">
+      <object class="GtkFrame" id="frame_metadata">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="halign">start</property>
-        <property name="label" translatable="yes">Import format: </property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">0</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkComboBox" id="cd_import/format">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="model">format_model</property>
-        <property name="active">0</property>
+        <property name="label_xalign">0</property>
+        <property name="shadow_type">none</property>
         <child>
-          <object class="GtkCellRendererText" id="renderer1"/>
-          <attributes>
-            <attribute name="text">0</attribute>
-          </attributes>
+          <object class="GtkAlignment">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="left_padding">12</property>
+            <child>
+              <object class="GtkCheckButton" id="cd_metadata/fetch_from_internet">
+                <property name="label" translatable="yes">Fetch metadata from internet servers</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="draw_indicator">True</property>
+              </object>
+            </child>
+          </object>
         </child>
-      </object>
-      <packing>
-        <property name="left_attach">1</property>
-        <property name="top_attach">0</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="label2">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="halign">start</property>
-        <property name="label" translatable="yes">Import quality: </property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkComboBox" id="cd_import/quality">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="model">quality_model</property>
-        <child>
-          <object class="GtkCellRendererText" id="renderer2"/>
-          <attributes>
-            <attribute name="text">1</attribute>
-          </attributes>
-        </child>
-      </object>
-      <packing>
-        <property name="left_attach">1</property>
-        <property name="top_attach">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="label3">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="halign">start</property>
-        <property name="label" translatable="yes">Import path: </property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">2</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkComboBox" id="cd_import/outpath">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="hexpand">True</property>
-        <property name="has_entry">True</property>
-        <child internal-child="entry">
-          <object class="GtkEntry" id="combobox-entry">
-            <property name="can_focus">True</property>
+        <child type="label">
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Disc metadata</property>
           </object>
         </child>
       </object>
       <packing>
-        <property name="left_attach">1</property>
-        <property name="top_attach">2</property>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
       </packing>
     </child>
     <child>
-      <object class="GtkImage" id="image1">
+      <object class="GtkFrame" id="frame_rip">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="icon_name">dialog-information</property>
-        <property name="icon_size">6</property>
+        <property name="label_xalign">0</property>
+        <property name="shadow_type">none</property>
+        <child>
+          <object class="GtkAlignment">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="left_padding">12</property>
+            <child>
+              <object class="GtkGrid" id="preferences_pane_1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="row_spacing">4</property>
+                <property name="column_spacing">2</property>
+                <child>
+                  <object class="GtkLabel" id="label1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Format: </property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBox" id="cd_import/format">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="model">format_model</property>
+                    <property name="active">0</property>
+                    <child>
+                      <object class="GtkCellRendererText" id="renderer1"/>
+                      <attributes>
+                        <attribute name="text">0</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Quality: </property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBox" id="cd_import/quality">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="model">quality_model</property>
+                    <child>
+                      <object class="GtkCellRendererText" id="renderer2"/>
+                      <attributes>
+                        <attribute name="text">1</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Path: </property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBox" id="cd_import/outpath">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="has_entry">True</property>
+                    <child internal-child="entry">
+                      <object class="GtkEntry">
+                        <property name="can_focus">True</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkImage" id="image1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">dialog-information</property>
+                    <property name="icon_size">6</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Every tag can be used with &lt;b&gt;$tag&lt;/b&gt; or &lt;b&gt;${tag}&lt;/b&gt;. Internal tags like &lt;b&gt;$__length&lt;/b&gt; need to be specified with two leading underscores.</property>
+                    <property name="use_markup">True</property>
+                    <property name="wrap">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="label">
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Import tracks to disk</property>
+          </object>
+        </child>
       </object>
       <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">3</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="label4">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="halign">start</property>
-        <property name="label" translatable="yes">Every tag can be used with &lt;b&gt;$tag&lt;/b&gt; or &lt;b&gt;${tag}&lt;/b&gt;. Internal tags like &lt;b&gt;$__length&lt;/b&gt; need to be specified with two leading underscores.</property>
-        <property name="use_markup">True</property>
-        <property name="wrap">True</property>
-      </object>
-      <packing>
-        <property name="left_attach">1</property>
-        <property name="top_attach">3</property>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
       </packing>
     </child>
   </object>

--- a/plugins/cd/cdprefs_pane.ui
+++ b/plugins/cd/cdprefs_pane.ui
@@ -52,7 +52,7 @@
             <property name="can_focus">False</property>
             <property name="left_padding">12</property>
             <child>
-              <object class="GtkCheckButton" id="cd_metadata/fetch_from_internet">
+              <object class="GtkCheckButton" id="plugin/cd/fetch_metadata_from_internet">
                 <property name="label" translatable="yes">Fetch metadata from internet servers</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>

--- a/plugins/cd/discid_parser.py
+++ b/plugins/cd/discid_parser.py
@@ -13,6 +13,10 @@ from xl.trax import Track
 
 
 def read_disc_id(device):
+    """
+        I/O operation to read an ID from the disc.
+        This must happen async because it may take quite some time.
+    """
     try:  # retry with reduced features if it fails
         # Note: reading additional features like isrc will take some time.
         disc_id = discid.read(device, features=discid.FEATURES)

--- a/plugins/cd/discid_parser.py
+++ b/plugins/cd/discid_parser.py
@@ -16,6 +16,9 @@ def read_disc_id(device):
     """
         I/O operation to read an ID from the disc.
         This must happen async because it may take quite some time.
+
+        @param device: Name of the CD device
+        @return: The disc ID as understood by musicbrainz and parse_disc()
     """
     try:  # retry with reduced features if it fails
         # Note: reading additional features like isrc will take some time.
@@ -27,9 +30,11 @@ def read_disc_id(device):
 
 def parse_disc(disc_id, device):
     """
-        Retrieves data from the disc using discid only.
-        As a result, the data will only contain track numbers and lengths.
+        Parses the given disc ID into tracks.
+        As a result, the data will only contain track numbers and lengths but
+        no sophisticated metadata.
 
+        @param disc_id: The disc ID from read_disc_id()
         @param device: Name of the CD device
         @return: An array of xl.trax.Track with minimal information
     """

--- a/plugins/cd/discid_parser.py
+++ b/plugins/cd/discid_parser.py
@@ -1,9 +1,7 @@
-'''
-Created on 03.05.2019
-
-@author: christian
-'''
-
+"""
+    This module is a parser for audio CDs based on discid.
+    It is compatible with both python-discid and python-libdiscid.
+"""
 
 
 try:  # allow both python-discid and python-libdiscid
@@ -14,18 +12,40 @@ except ImportError:
 from xl.trax import Track
 
 
+# TODO when reading isrc, it takes quite a while to read the disk!
+
 
 def parse_disc(device):
-    disc_id = discid.read(device)
+    """
+        Retrieves data from the disc using discid only.
+        As a result, the data will only contain track numbers and lengths.
+        
+        @param device: Name of the CD device
+        @return: An array of xl.trax.Track with minimal information
+    """
+    try:  # retry with reduced features if it fails
+        disc_id = discid.read(device, features=discid.FEATURES)
+    except discid.DiscError:
+        disc_id = discid.read(device)
     
     xl_tracks = []
     for discid_track in disc_id.tracks:
         track_uri = "cdda://%d/#%s" % (discid_track.number, device)
         track = Track(uri=track_uri, scan=False)
+        
+        track_number = '{0}/{1}'.format(discid_track.number, len(disc_id.tracks))
         track.set_tags(
             title="Track %d" % discid_track.number,
-            tracknumber=discid_track.number,
-            __length=discid_track.seconds
+            tracknumber=track_number,
+            __length=discid_track.seconds,
+            musicbrainz_disc_id=disc_id.id,
+            freedb_disc_id=disc_id.freedb_id,
         )
+        
+        if discid_track.isrc:
+            track.set_tags(isrc=discid_track.isrc)
+        
+        if disc_id.mcn and '0000000000000' not in disc_id.mcn:
+            track.set_tags(mcn=disc_id.mcn)
         xl_tracks.append(track)
     return xl_tracks

--- a/plugins/cd/discid_parser.py
+++ b/plugins/cd/discid_parser.py
@@ -54,7 +54,7 @@ def parse_disc(disc_id, device):
         track_tags['title'] = "Track %d" % discid_track.number
         track_tags['__length'] = discid_track.seconds
         if discid_track.isrc:
-            track_tags['__isrc'] = discid_track.isrc
+            track_tags['isrc'] = discid_track.isrc
 
         track_uri = "cdda://%d/#%s" % (discid_track.number, device)
         track = Track(uri=track_uri, scan=False)

--- a/plugins/cd/discid_parser.py
+++ b/plugins/cd/discid_parser.py
@@ -39,7 +39,9 @@ def parse_disc(disc_id, device):
 
     for discid_track in disc_id.tracks:
         track_tags = disc_tags.copy()
-        track_tags['tracknumber'] = '{0}/{1}'.format(discid_track.number, len(disc_id.tracks))
+        track_tags['tracknumber'] = '{0}/{1}'.format(
+            discid_track.number, len(disc_id.tracks)
+        )
         track_tags['title'] = "Track %d" % discid_track.number
         track_tags['__length'] = discid_track.seconds
         if discid_track.isrc:

--- a/plugins/cd/discid_parser.py
+++ b/plugins/cd/discid_parser.py
@@ -30,22 +30,21 @@ def parse_disc(disc_id, device):
     """
     xl_tracks = []
     for discid_track in disc_id.tracks:
-        track_uri = "cdda://%d/#%s" % (discid_track.number, device)
-        track = Track(uri=track_uri, scan=False)
         
-        track_number = '{0}/{1}'.format(discid_track.number, len(disc_id.tracks))
-        track.set_tags(
-            title="Track %d" % discid_track.number,
-            tracknumber=track_number,
-            __length=discid_track.seconds,
-            musicbrainz_disc_id=disc_id.id,
-            freedb_disc_id=disc_id.freedb_id,
-        )
+        tags = dict()
+        tags['tracknumber'] = '{0}/{1}'.format(discid_track.number, len(disc_id.tracks))
+        tags['title'] = "Track %d" % discid_track.number
+        tags['__length'] = discid_track.seconds
+        tags['__musicbrainz_disc_id'] = disc_id.id
+        tags['__freedb_disc_id'] = disc_id.freedb_id
 
         if discid_track.isrc:
-            track.set_tags(isrc=discid_track.isrc)
-
+            tags['__isrc'] = discid_track.isrc
         if disc_id.mcn and '0000000000000' not in disc_id.mcn:
-            track.set_tags(mcn=disc_id.mcn)
+            tags['__mcn'] = disc_id.mcn
+
+        track_uri = "cdda://%d/#%s" % (discid_track.number, device)
+        track = Track(uri=track_uri, scan=False)
+        track.set_tags(**tags)
         xl_tracks.append(track)
     return xl_tracks

--- a/plugins/cd/discid_parser.py
+++ b/plugins/cd/discid_parser.py
@@ -1,0 +1,31 @@
+'''
+Created on 03.05.2019
+
+@author: christian
+'''
+
+
+
+try:  # allow both python-discid and python-libdiscid
+    from libdiscid.compat import discid
+except ImportError:
+    import discid
+
+from xl.trax import Track
+
+
+
+def parse_disc(device):
+    disc_id = discid.read(device)
+    
+    xl_tracks = []
+    for discid_track in disc_id.tracks:
+        track_uri = "cdda://%d/#%s" % (discid_track.number, device)
+        track = Track(uri=track_uri, scan=False)
+        track.set_tags(
+            title="Track %d" % discid_track.number,
+            tracknumber=discid_track.number,
+            __length=discid_track.seconds
+        )
+        xl_tracks.append(track)
+    return xl_tracks

--- a/plugins/cd/discid_parser.py
+++ b/plugins/cd/discid_parser.py
@@ -20,31 +20,33 @@ def read_disc_id(device):
         disc_id = discid.read(device)
     return disc_id
 
+
 def parse_disc(disc_id, device):
     """
         Retrieves data from the disc using discid only.
         As a result, the data will only contain track numbers and lengths.
-        
+
         @param device: Name of the CD device
         @return: An array of xl.trax.Track with minimal information
     """
     xl_tracks = []
-    for discid_track in disc_id.tracks:
-        
-        tags = dict()
-        tags['tracknumber'] = '{0}/{1}'.format(discid_track.number, len(disc_id.tracks))
-        tags['title'] = "Track %d" % discid_track.number
-        tags['__length'] = discid_track.seconds
-        tags['__musicbrainz_disc_id'] = disc_id.id
-        tags['__freedb_disc_id'] = disc_id.freedb_id
+    disc_tags = dict()
+    # The tag name is chosen for compatibility with the cover manager!
+    disc_tags['musicbrainz_albumid'] = disc_id.id
+    disc_tags['__freedb_disc_id'] = disc_id.freedb_id
+    if disc_id.mcn and '0000000000000' not in disc_id.mcn:
+        disc_tags['__mcn'] = disc_id.mcn
 
+    for discid_track in disc_id.tracks:
+        track_tags = disc_tags.copy()
+        track_tags['tracknumber'] = '{0}/{1}'.format(discid_track.number, len(disc_id.tracks))
+        track_tags['title'] = "Track %d" % discid_track.number
+        track_tags['__length'] = discid_track.seconds
         if discid_track.isrc:
-            tags['__isrc'] = discid_track.isrc
-        if disc_id.mcn and '0000000000000' not in disc_id.mcn:
-            tags['__mcn'] = disc_id.mcn
+            track_tags['__isrc'] = discid_track.isrc
 
         track_uri = "cdda://%d/#%s" % (discid_track.number, device)
         track = Track(uri=track_uri, scan=False)
-        track.set_tags(**tags)
+        track.set_tags(**track_tags)
         xl_tracks.append(track)
     return xl_tracks

--- a/plugins/cd/discid_parser.py
+++ b/plugins/cd/discid_parser.py
@@ -12,10 +12,15 @@ except ImportError:
 from xl.trax import Track
 
 
-# TODO when reading isrc, it takes quite a while to read the disk!
+def read_disc_id(device):
+    try:  # retry with reduced features if it fails
+        # Note: reading additional features like isrc will take some time.
+        disc_id = discid.read(device, features=discid.FEATURES)
+    except discid.DiscError:
+        disc_id = discid.read(device)
+    return disc_id
 
-
-def parse_disc(device):
+def parse_disc(disc_id, device):
     """
         Retrieves data from the disc using discid only.
         As a result, the data will only contain track numbers and lengths.
@@ -23,11 +28,6 @@ def parse_disc(device):
         @param device: Name of the CD device
         @return: An array of xl.trax.Track with minimal information
     """
-    try:  # retry with reduced features if it fails
-        disc_id = discid.read(device, features=discid.FEATURES)
-    except discid.DiscError:
-        disc_id = discid.read(device)
-    
     xl_tracks = []
     for discid_track in disc_id.tracks:
         track_uri = "cdda://%d/#%s" % (discid_track.number, device)
@@ -41,10 +41,10 @@ def parse_disc(device):
             musicbrainz_disc_id=disc_id.id,
             freedb_disc_id=disc_id.freedb_id,
         )
-        
+
         if discid_track.isrc:
             track.set_tags(isrc=discid_track.isrc)
-        
+
         if disc_id.mcn and '0000000000000' not in disc_id.mcn:
             track.set_tags(mcn=disc_id.mcn)
         xl_tracks.append(track)

--- a/plugins/cd/linux_cd_parser.py
+++ b/plugins/cd/linux_cd_parser.py
@@ -1,0 +1,161 @@
+"""
+    This module is a low-level reader and parser for audio CDs.
+    It heavily relies on ioctls to the linux kernel.
+    
+    Original source for the code:
+    http://www.carey.geek.nz/code/python-cdrom/cdtoc.py
+    
+    Source for all the magical constants and more infos on the ioctls:
+    linux/include/uapi/linux/cdrom.h
+    https://github.com/torvalds/linux/blob/master/include/uapi/linux/cdrom.h
+"""
+
+
+from __future__ import division
+
+
+import fcntl
+import logging
+import os
+import struct
+
+from xl.main import common
+from xl.trax import Track
+
+
+logger = logging.getLogger(__name__)
+
+
+def read_cd_index(device):
+    """
+        Reads a CD's index and parses it to Exaile's trax.
+        
+        @param device: a path to a CD device
+        @return: an array of xl.trax.Track representing the disc's contents
+    """
+    toc_entries = __read_toc(device)
+    return __parse_tracks(toc_entries, device)
+
+
+def __read_toc(device):
+    """
+        Does all the I/O work on reading the disc table of contents (TOC)
+        
+        @param device: a path to a CD device
+        @return: Array of toc entries. The last one is a dummy.
+    """
+    toc_entries = []
+    fd = os.open(device, os.O_RDONLY)
+    try:
+        (start, end) = __read_toc_header(fd)
+
+        # index of the end, i.e. the last toc entry which is an empty dummy
+        CDROM_LEADOUT = 0xAA
+        for toc_entry_index in range(start, end + 1) + [CDROM_LEADOUT]:
+            toc_entry = __read_toc_entry(fd, toc_entry_index)
+            toc_entries.append(toc_entry)
+    finally:
+        os.close(fd)
+    return toc_entries
+
+
+def __read_toc_header(fd):
+    """ A wrapper for the `CDROMREADTOCHDR` ioctl """
+    
+    # struct cdrom_tochdr of 2 times u8
+    FORMAT_cdrom_tochdr = 'BB'
+    # u8 start: lowest track index (index of first track), probably always 1
+    # u8 end: highest track index (index of last track), = number of tracks
+    cdrom_tochdr = struct.pack(FORMAT_cdrom_tochdr, 0, 0)
+    
+    CDROMREADTOCHDR = 0x5305
+    cdrom_tochdr = fcntl.ioctl(fd, CDROMREADTOCHDR, cdrom_tochdr)
+    
+    start, end = struct.unpack(FORMAT_cdrom_tochdr, cdrom_tochdr)
+    
+    return (start, end)
+
+
+def __read_toc_entry(fd, toc_entry_num):
+    """ A wrapper for the `CDROMREADTOCENTRY` ioctl """
+    # value constant: Minute, Second, Frame: binary (not bcd here)
+    CDROM_MSF = 0x02
+    
+    # struct cdrom_tocentry of 3 times u8 followed by an int and another u8 
+    FORMAT_cdrom_tocentry = 'BBBiB'
+    # u8 cdte_track: Track number. Starts with 1, which is used for the TOC and contains data.
+    # u8 cdte_adr_ctrl: 4 high bits -> cdte_ctrl, 4 low bits -> cdte_adr
+    # u8 cdte_format: should be CDROM_MSF=0x02 as requested before
+    # int cdte_addr: see below
+    # u8 cdte_datamode: ??? (ignored)
+    cdrom_tocentry = struct.pack(FORMAT_cdrom_tocentry, toc_entry_num, 0, CDROM_MSF, 0, 0)
+    
+    CDROMREADTOCENTRY = 0x5306
+    cdrom_tocentry = fcntl.ioctl(fd, CDROMREADTOCENTRY, cdrom_tocentry)
+    
+    cdte_track, cdte_adr_ctrl, cdte_format, cdte_addr, cdte_datamode = \
+        struct.unpack(FORMAT_cdrom_tocentry, cdrom_tocentry)
+
+    if cdte_format is not CDROM_MSF:
+        raise OSError('Invalid syscall answer')
+
+    # unused:
+    # cdte_adr = cdte_adr_ctrl & 0x0f  # lower nibble
+    
+    cdte_ctrl = (cdte_adr_ctrl & 0xF0) >> 4  # higher nibble
+
+    CDROM_DATA_TRACK = 0x04
+    # data: `True` if this "track" contains data, `False` if it is audio
+    is_data_track = bool(cdte_ctrl & CDROM_DATA_TRACK)
+    
+    # union cdrom_addr of struct cdrom_msf0 and int
+    # struct cdrom_msf0 of 3 times u8 plus padding to match size of int
+    FORMAT_cdrom_addr = 'BBB' + 'x' * (struct.calcsize('i') - 3)
+    # u8 minute: Minutes from beginning of CD
+    # u8 second: Seconds after `minute`
+    # u8 frame: Frames after `frame`
+    minute, second, frame = struct.unpack(
+        FORMAT_cdrom_addr, struct.pack('i', cdte_addr))
+    
+    return (cdte_track, is_data_track, minute, second, frame)
+
+
+def __parse_tracks(toc_entries, device):
+    """ Parse the data from ioctl into xl.trax.Track """
+    real_track_count = len(toc_entries) - 1  # ignore the empty dummy track at the end
+    tracks = []
+    for toc_entry_index in range(0, real_track_count):
+        (track_index, is_data_track, _, _, _) = \
+            toc_entries[toc_entry_index]
+        if is_data_track:
+            continue
+        if track_index is not toc_entry_index + 1:
+            logger.warn('Unexpected index found. %ith toc entry claims to be track number %i',
+                        toc_entry_index, track_index)
+        
+        length = __calculate_track_length(toc_entries[toc_entry_index],
+                                          toc_entries[toc_entry_index + 1])
+        
+        track_uri = "cdda://%d/#%s" % (track_index, device)
+        track = Track(uri=track_uri, scan=False)
+        track.set_tags(
+            title="Track %d" % track_index,
+            tracknumber=track_index,
+            __length=length
+        )
+        
+        tracks.append(track)
+    return tracks
+
+
+def __calculate_track_length(current_track, next_track):
+    """ Calculate length of a single track from its data and the data of the following track """
+    (_, _, begin_minute, begin_second, begin_frame) = current_track
+    (_, _, end_minute, end_second, end_frame) = next_track
+    
+    length_minutes = end_minute - begin_minute
+    length_seconds = end_second - begin_second
+    length_frames = end_frame - begin_frame
+    # 75 frames per second, see CD_FRAMES in cdrom.h file
+    length = length_minutes * 60 + length_seconds + length_frames / 75
+    return length

--- a/plugins/cd/linux_cd_parser.py
+++ b/plugins/cd/linux_cd_parser.py
@@ -7,7 +7,7 @@
     
     Source for all the magical constants and more infos on the ioctls:
     linux/include/uapi/linux/cdrom.h
-    https://github.com/torvalds/linux/blob/master/include/uapi/linux/cdrom.h
+    https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/cdrom.h
 """
 
 
@@ -33,8 +33,8 @@ def read_cd_index(device):
         @param device: a path to a CD device
         @return: an array of xl.trax.Track representing the disc's contents
     """
-    toc_entries = __read_toc(device)
-    return __parse_tracks(toc_entries, device)
+    (toc_entries, mcn) = __read_toc(device)
+    return __parse_tracks(toc_entries, mcn, device)
 
 
 def __read_toc(device):
@@ -48,39 +48,57 @@ def __read_toc(device):
     fd = os.open(device, os.O_RDONLY)
     try:
         (start, end) = __read_toc_header(fd)
+        mcn = __read_disc_mcn(fd)
 
         # index of the end, i.e. the last toc entry which is an empty dummy
         CDROM_LEADOUT = 0xAA
         for toc_entry_index in range(start, end + 1) + [CDROM_LEADOUT]:
             toc_entry = __read_toc_entry(fd, toc_entry_index)
+            # XXX one could also reat+compute the `isrc` track id, see libdiscid
             toc_entries.append(toc_entry)
     finally:
         os.close(fd)
-    return toc_entries
+    return toc_entries, mcn
 
 
 def __read_toc_header(fd):
     """ A wrapper for the `CDROMREADTOCHDR` ioctl """
-    
     # struct cdrom_tochdr of 2 times u8
     FORMAT_cdrom_tochdr = 'BB'
     # u8 start: lowest track index (index of first track), probably always 1
     # u8 end: highest track index (index of last track), = number of tracks
     cdrom_tochdr = struct.pack(FORMAT_cdrom_tochdr, 0, 0)
-    
+
     CDROMREADTOCHDR = 0x5305
     cdrom_tochdr = fcntl.ioctl(fd, CDROMREADTOCHDR, cdrom_tochdr)
-    
+
     start, end = struct.unpack(FORMAT_cdrom_tochdr, cdrom_tochdr)
-    
+
     return (start, end)
+
+
+def __read_disc_mcn(fd):
+    """ A wrapper for the `CDROM_GET_MCN` ioctl """
+    # struct cdrom_mcn of 14 bytes, null-terminated
+    FORMAT_cdrom_mcn = '14s'
+    cdrom_mcn = struct.pack(FORMAT_cdrom_mcn, '\0')
+
+    CDROM_GET_MCN = 0x5311
+    cdrom_mcn = fcntl.ioctl(fd, CDROM_GET_MCN, cdrom_mcn)
+
+    raw_mcn = struct.unpack(FORMAT_cdrom_mcn, cdrom_mcn)
+    mcn = raw_mcn[0][0:13]
+    if '0000000000000' in mcn:
+        return None
+    else:
+        return mcn
 
 
 def __read_toc_entry(fd, toc_entry_num):
     """ A wrapper for the `CDROMREADTOCENTRY` ioctl """
     # value constant: Minute, Second, Frame: binary (not bcd here)
     CDROM_MSF = 0x02
-    
+
     # struct cdrom_tocentry of 3 times u8 followed by an int and another u8 
     FORMAT_cdrom_tocentry = 'BBBiB'
     # u8 cdte_track: Track number. Starts with 1, which is used for the TOC and contains data.
@@ -89,10 +107,10 @@ def __read_toc_entry(fd, toc_entry_num):
     # int cdte_addr: see below
     # u8 cdte_datamode: ??? (ignored)
     cdrom_tocentry = struct.pack(FORMAT_cdrom_tocentry, toc_entry_num, 0, CDROM_MSF, 0, 0)
-    
+
     CDROMREADTOCENTRY = 0x5306
     cdrom_tocentry = fcntl.ioctl(fd, CDROMREADTOCENTRY, cdrom_tocentry)
-    
+
     cdte_track, cdte_adr_ctrl, cdte_format, cdte_addr, cdte_datamode = \
         struct.unpack(FORMAT_cdrom_tocentry, cdrom_tocentry)
 
@@ -101,13 +119,13 @@ def __read_toc_entry(fd, toc_entry_num):
 
     # unused:
     # cdte_adr = cdte_adr_ctrl & 0x0f  # lower nibble
-    
+
     cdte_ctrl = (cdte_adr_ctrl & 0xF0) >> 4  # higher nibble
 
     CDROM_DATA_TRACK = 0x04
     # data: `True` if this "track" contains data, `False` if it is audio
     is_data_track = bool(cdte_ctrl & CDROM_DATA_TRACK)
-    
+
     # union cdrom_addr of struct cdrom_msf0 and int
     # struct cdrom_msf0 of 3 times u8 plus padding to match size of int
     FORMAT_cdrom_addr = 'BBB' + 'x' * (struct.calcsize('i') - 3)
@@ -116,11 +134,11 @@ def __read_toc_entry(fd, toc_entry_num):
     # u8 frame: Frames after `frame`
     minute, second, frame = struct.unpack(
         FORMAT_cdrom_addr, struct.pack('i', cdte_addr))
-    
+
     return (cdte_track, is_data_track, minute, second, frame)
 
 
-def __parse_tracks(toc_entries, device):
+def __parse_tracks(toc_entries, mcn, device):
     """ Parse the data from ioctl into xl.trax.Track """
     real_track_count = len(toc_entries) - 1  # ignore the empty dummy track at the end
     tracks = []
@@ -132,17 +150,22 @@ def __parse_tracks(toc_entries, device):
         if track_index is not toc_entry_index + 1:
             logger.warn('Unexpected index found. %ith toc entry claims to be track number %i',
                         toc_entry_index, track_index)
-        
+
         length = __calculate_track_length(toc_entries[toc_entry_index],
                                           toc_entries[toc_entry_index + 1])
-        
         track_uri = "cdda://%d/#%s" % (track_index, device)
+
         track = Track(uri=track_uri, scan=False)
+
+        track_number = '{0}/{1}'.format(track_index, real_track_count)
         track.set_tags(
             title="Track %d" % track_index,
-            tracknumber=track_index,
+            tracknumber=track_number,
             __length=length
         )
+
+        if mcn:
+            track.set_tags(mcn=mcn)
         
         tracks.append(track)
     return tracks
@@ -152,7 +175,7 @@ def __calculate_track_length(current_track, next_track):
     """ Calculate length of a single track from its data and the data of the following track """
     (_, _, begin_minute, begin_second, begin_frame) = current_track
     (_, _, end_minute, end_second, end_frame) = next_track
-    
+
     length_minutes = end_minute - begin_minute
     length_seconds = end_second - begin_second
     length_frames = end_frame - begin_frame

--- a/plugins/cd/linux_cd_parser.py
+++ b/plugins/cd/linux_cd_parser.py
@@ -34,6 +34,7 @@ def read_cd_index(device):
         @return: an array of xl.trax.Track representing the disc's contents
     """
     (toc_entries, mcn) = __read_toc(device)
+    logger.debug('Successfully read TOC of CD with MCN %s : %s', mcn, toc_entries)
     return __parse_tracks(toc_entries, mcn, device)
 
 

--- a/plugins/cd/linux_cd_parser.py
+++ b/plugins/cd/linux_cd_parser.py
@@ -106,13 +106,16 @@ def __read_toc_entry(fd, toc_entry_num):
     # u8 cdte_format: should be CDROM_MSF=0x02 as requested before
     # int cdte_addr: see below
     # u8 cdte_datamode: ??? (ignored)
-    cdrom_tocentry = struct.pack(FORMAT_cdrom_tocentry, toc_entry_num, 0, CDROM_MSF, 0, 0)
+    cdrom_tocentry = struct.pack(
+        FORMAT_cdrom_tocentry, toc_entry_num, 0, CDROM_MSF, 0, 0
+    )
 
     CDROMREADTOCENTRY = 0x5306
     cdrom_tocentry = fcntl.ioctl(fd, CDROMREADTOCENTRY, cdrom_tocentry)
 
-    cdte_track, cdte_adr_ctrl, cdte_format, cdte_addr, _cdte_datamode = \
-        struct.unpack(FORMAT_cdrom_tocentry, cdrom_tocentry)
+    cdte_track, cdte_adr_ctrl, cdte_format, cdte_addr, _cdte_datamode = struct.unpack(
+        FORMAT_cdrom_tocentry, cdrom_tocentry
+    )
 
     if cdte_format is not CDROM_MSF:
         raise OSError('Invalid syscall answer')
@@ -133,7 +136,8 @@ def __read_toc_entry(fd, toc_entry_num):
     # u8 second: Seconds after `minute`
     # u8 frame: Frames after `frame`
     minute, second, frame = struct.unpack(
-        FORMAT_cdrom_addr, struct.pack('i', cdte_addr))
+        FORMAT_cdrom_addr, struct.pack('i', cdte_addr)
+    )
 
     return (cdte_track, is_data_track, minute, second, frame)
 
@@ -143,25 +147,26 @@ def __parse_tracks(toc_entries, mcn, device):
     real_track_count = len(toc_entries) - 1  # ignore the empty dummy track at the end
     tracks = []
     for toc_entry_index in range(0, real_track_count):
-        (track_index, is_data_track, _, _, _) = \
-            toc_entries[toc_entry_index]
+        (track_index, is_data_track, _, _, _) = toc_entries[toc_entry_index]
         if is_data_track:
             continue
         if track_index is not toc_entry_index + 1:
-            logger.warn('Unexpected index found. %ith toc entry claims to be track number %i',
-                        toc_entry_index, track_index)
+            logger.warn(
+                'Unexpected index found. %ith toc entry claims to be track number %i',
+                toc_entry_index,
+                track_index,
+            )
 
-        length = __calculate_track_length(toc_entries[toc_entry_index],
-                                          toc_entries[toc_entry_index + 1])
+        length = __calculate_track_length(
+            toc_entries[toc_entry_index], toc_entries[toc_entry_index + 1]
+        )
         track_uri = "cdda://%d/#%s" % (track_index, device)
 
         track = Track(uri=track_uri, scan=False)
 
         track_number = '{0}/{1}'.format(track_index, real_track_count)
         track.set_tags(
-            title="Track %d" % track_index,
-            tracknumber=track_number,
-            __length=length
+            title="Track %d" % track_index, tracknumber=track_number, __length=length
         )
 
         if mcn:

--- a/plugins/cd/linux_cd_parser.py
+++ b/plugins/cd/linux_cd_parser.py
@@ -1,10 +1,10 @@
 """
     This module is a low-level reader and parser for audio CDs.
     It heavily relies on ioctls to the linux kernel.
-    
+
     Original source for the code:
     http://www.carey.geek.nz/code/python-cdrom/cdtoc.py
-    
+
     Source for all the magical constants and more infos on the ioctls:
     linux/include/uapi/linux/cdrom.h
     https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/cdrom.h
@@ -19,7 +19,6 @@ import logging
 import os
 import struct
 
-from xl.main import common
 from xl.trax import Track
 
 
@@ -29,7 +28,7 @@ logger = logging.getLogger(__name__)
 def read_cd_index(device):
     """
         Reads a CD's index and parses it to Exaile's trax.
-        
+
         @param device: a path to a CD device
         @return: an array of xl.trax.Track representing the disc's contents
     """
@@ -41,7 +40,7 @@ def read_cd_index(device):
 def __read_toc(device):
     """
         Does all the I/O work on reading the disc table of contents (TOC)
-        
+
         @param device: a path to a CD device
         @return: Array of toc entries. The last one is a dummy.
     """
@@ -100,7 +99,7 @@ def __read_toc_entry(fd, toc_entry_num):
     # value constant: Minute, Second, Frame: binary (not bcd here)
     CDROM_MSF = 0x02
 
-    # struct cdrom_tocentry of 3 times u8 followed by an int and another u8 
+    # struct cdrom_tocentry of 3 times u8 followed by an int and another u8
     FORMAT_cdrom_tocentry = 'BBBiB'
     # u8 cdte_track: Track number. Starts with 1, which is used for the TOC and contains data.
     # u8 cdte_adr_ctrl: 4 high bits -> cdte_ctrl, 4 low bits -> cdte_adr
@@ -112,7 +111,7 @@ def __read_toc_entry(fd, toc_entry_num):
     CDROMREADTOCENTRY = 0x5306
     cdrom_tocentry = fcntl.ioctl(fd, CDROMREADTOCENTRY, cdrom_tocentry)
 
-    cdte_track, cdte_adr_ctrl, cdte_format, cdte_addr, cdte_datamode = \
+    cdte_track, cdte_adr_ctrl, cdte_format, cdte_addr, _cdte_datamode = \
         struct.unpack(FORMAT_cdrom_tocentry, cdrom_tocentry)
 
     if cdte_format is not CDROM_MSF:
@@ -167,7 +166,7 @@ def __parse_tracks(toc_entries, mcn, device):
 
         if mcn:
             track.set_tags(mcn=mcn)
-        
+
         tracks.append(track)
     return tracks
 

--- a/plugins/cd/musicbrainzngs_parser.py
+++ b/plugins/cd/musicbrainzngs_parser.py
@@ -57,10 +57,7 @@ def fetch_with_disc_id(disc_id):
     except musicbrainzngs.WebServiceError:
         # This is expected to fail if user is offline or behind an
         # aggressive firewall.
-        logger.info(
-            'Failed to fetch data from musicbrainz database.',
-            exc_info=True,
-        )
+        logger.info('Failed to fetch data from musicbrainz database.', exc_info=True)
         musicbrainz_data = None
     return musicbrainz_data
 
@@ -89,7 +86,9 @@ def parse(musicbrainz_data, disc_id, tracks):
             if disc_tracks is not None:
                 logger.debug('Parsed disc data: %s', disc_tracks)
         if disc_tracks is None:
-            if musicbrainz_data.get('cdstub') is not None:  # bad quality, use as fallback
+            if (
+                musicbrainz_data.get('cdstub') is not None
+            ):  # bad quality, use as fallback
                 disc_tracks = __parse_musicbrainz_cdstub_data(
                     musicbrainz_data['cdstub'], tracks
                 )
@@ -98,10 +97,7 @@ def parse(musicbrainz_data, disc_id, tracks):
         if disc_tracks is None:
             logger.info('Musicbrainz returned no useful data: %s', musicbrainz_data)
     except Exception:
-        logger.warn(
-            'Failed to parse data from musicbrainz database.',
-            exc_info=True,
-        )
+        logger.warn('Failed to parse data from musicbrainz database.', exc_info=True)
     return disc_tracks
 
 

--- a/plugins/cd/musicbrainzngs_parser.py
+++ b/plugins/cd/musicbrainzngs_parser.py
@@ -4,43 +4,56 @@
     It uses the online database provided by musicbrainzngs.
     
     musicbrainz documentation:
+    * Wiki: https://wiki.musicbrainz.org/
     * Web API: https://musicbrainz.org/doc/Development/XML%20Web%20Service/Version%202
     * Web API format: https://github.com/metabrainz/mmd-schema/blob/master/schema/musicbrainz_mmd-2.0.rng
+    * Database schema: https://wiki.musicbrainz.org/MusicBrainz_Database/Schema
+    
+    musicbrainzngs documentation:
+    * https://python-musicbrainzngs.readthedocs.io/
     
     Note: All the "priority" values are arbitrary/random choices and may need improvement
+    
+    TODO: Room for improvement:
+    * fetch composers (especially interesting for classical music)
+    * test text-representation for non-latin languages
+    * get more data with secondary query, e.g. genre ("medium_tags") 
+        see https://wiki.musicbrainz.org/Genre
 """
 
 
 from __future__ import division
 
+import json
 import logging
+import urllib2
 
 import musicbrainzngs
 
 from xl import main
+from xl.metadata import CoverImage
 from xl.trax import Track
+
+from xl.covers import MANAGER as CoverManager
+
 from plugins.cd import discid_parser
 
 
 logger = logging.getLogger(__name__)
 
 
-MUSICBRAINZNGS_INITIALIZED = False
+def __init_musicbrainzngs():
+    version = main.exaile().get_user_agent_for_musicbrainz()
+    musicbrainzngs.set_useragent(*version)
 
-# TODO which fields are optional?
-# TODO test
-# TODO adapt log levels
+
+__init_musicbrainzngs()
 
 
 def fetch_with_disc_id(disc_id, device):
-    global MUSICBRAINZNGS_INITIALIZED
-    if not MUSICBRAINZNGS_INITIALIZED:
-        version = main.exaile().get_user_agent_for_musicbrainz()
-        musicbrainzngs.set_useragent(*version)
-        MUSICBRAINZNGS_INITIALIZED = True
-
     musicbrainz_data = musicbrainzngs.get_releases_by_discid(
-        disc_id.id, toc=disc_id.toc_string, includes=["artists", "recordings"])
+        disc_id.id, toc=disc_id.toc_string, includes=[
+            'artists', 'recordings', 'isrcs', 'artist-credits'])
     
     if musicbrainz_data.get('disc') is not None:  # preferred: good quality
         disc_tracks = __parse_musicbrainz_disc_data(musicbrainz_data['disc'], disc_id, device)
@@ -53,47 +66,57 @@ def fetch_with_disc_id(disc_id, device):
             return disc_tracks
     
     # no useful data returned
-    logger.info('Musicbrainz returned not useful data: %s', musicbrainz_data)
+    logger.info('Musicbrainz returned no useful data: %s', musicbrainz_data)
     return None
 
 
 def __parse_musicbrainz_cdstub_data(cdstub_data, disc_id, device):
-    # prepopulate from disc_id parser
+    """ Parses cdstub data into xl.trax.Track """
+    # populate from disc_id parser
     tracks = discid_parser.parse_disc(disc_id, device)
     
-    if cdstub_data['track-count']:
-        track_count = cdstub_data['track-count']
+    # See "def_cdstub"
+    # Unused: disambiguation, def_cdstub-attribute_extension, def_cdstub-element_extension
+    
+    track_count = cdstub_data.get('track-count')
+    if track_count is not None:
         if len(tracks) is not track_count:
-            logger.info('Track count mismatch: real disc has %i, musicbrainz says %i. Ignoring all data.',
+            logger.debug('Track count mismatch: real disc has %i, musicbrainz says %i. Ignoring all data.',
                   len(tracks), track_count)
             return None
     
+    album_tags = dict()
+    
+    if cdstub_data.get('id') is not None:
+        album_tags['__musicbrainz_cdstub_id'] = cdstub_data['id']
+    
     album_title = cdstub_data['title']
+    album_tags['album'] = album_title
     
     artist = cdstub_data.get('artist')
+    if artist is not None:
+        album_tags['albumartist'] = artist
+        album_tags['artist'] = artist
+    
     barcode = cdstub_data.get('barcode')
+    if barcode is not None:
+        album_tags['barcode'] = barcode
     
     track_list = cdstub_data.get('track-list')
     if track_list is not None:
         for i in range(0, len(tracks)):
+            # See "def_nonmb-track"
+            # unused: length
             track = tracks[i]
-            new_tags = dict()
-            new_tags['album'] = album_title
+            track_tags = album_tags.copy() 
             
-            if barcode is not None:
-                new_tags['barcode'] = barcode
-                
-            if artist is not None:
-                new_tags['artist'] = artist
-            track_title = track_list[i].get('title')
-            if track_title is not None:
-                new_tags['title'] = track_title
+            track_tags['title'] = track_list[i]['title']
             
-            if artist is not None:
-                new_tags['artist'] = artist
-                new_tags['albumartist'] = artist
+            track_artist = track_list[i].get('artist')
+            if track_artist is not None:
+                track_tags['artist'] = track_artist
             
-            track.set_tags(**new_tags)
+            track.set_tags(**track_tags)
     return tracks, album_title
 
 
@@ -112,7 +135,7 @@ def __parse_musicbrainz_disc_data(disc_data, disc_id, device):
     
     (release, medium) = __choose_release_and_medium(suitable_releases)
     
-    return __parse_from_disc_data(release, medium, device, disc_id)
+    return __parse_medium_from_disc_data(release, medium, device, disc_id)
 
 
 def __choose_release_and_medium(suitable_releases):
@@ -139,24 +162,28 @@ def __choose_release_and_medium(suitable_releases):
 
 def __check_single_release(single_release, disc_id):
     # https://wiki.musicbrainz.org/Recording
-    
+
     priority = 0
-    
     # See https://wiki.musicbrainz.org/Barcode
-    if single_release.get('barcode') is not None and disc_id.mcn is not None:
-        mb_barcode = single_release['barcode'].lstrip('0')
+    mb_barcode = single_release.get('barcode')
+    if mb_barcode is not None and disc_id.mcn is not None:
+        mb_barcode = mb_barcode.lstrip('0')
         disc_barcode = disc_id.mcn.lstrip('0')
         
         if len(disc_barcode) > 5:  # empty string indicates missing barcode
             if mb_barcode == disc_barcode:
-                logger.info('Found exact barcode match: %s', disc_barcode)
+                logger.debug('Found exact barcode match: %s', disc_barcode)
                 priority = 100
             else:  # could be a different barcode format or a weak match
-                logger.info('Barcode mismatch: real disc has %s, musicbrainz says %s.',
+                logger.debug('Barcode mismatch: real disc has %s, musicbrainz says %s.',
                             disc_barcode, mb_barcode)
                 priority = -19
     
-    medium_list = single_release['medium-list']
+    medium_list = single_release.get('medium-list')
+    if medium_list is None:
+        logger.debug('Release contains no `medium-list`. This sounds fishy, ignoring.')
+        return None
+
     suitable_media = []
     for single_medium in medium_list:
         medium_priority = __check_single_medium(single_medium, disc_id)
@@ -173,45 +200,52 @@ def __check_single_release(single_release, disc_id):
 def __check_single_medium(single_medium, disc_id):
     # https://wiki.musicbrainz.org/Medium
     priority = 0
-    if single_medium.get('format') is not None:
-        if not 'CD' == single_medium['format']:
-            logger.info('Medium format mismatch: real disc is CD, musicbrainz says %s. Ignoring.',
-                  single_medium['format'])
+    format = single_medium.get('format')
+    if format is not None:
+        if not format == 'CD':
+            logger.debug('Medium format mismatch: real disc is CD, musicbrainz says %s. Ignoring.',
+                  format)
             return None
         priority = priority + 7
     
-    if single_medium.get('track-count') is not None:
-        if not single_medium['track-count'] == len(disc_id.tracks):
-            logger.info('Track count mismatch: real disc has %i, musicbrainz says %i. Ignoring.',
-                  len(disc_id.tracks), single_medium['track-count'])
+    track_count = single_medium.get('track-count')
+    if track_count is not None:
+        if not track_count == len(disc_id.tracks):
+            logger.debug('Track count mismatch: real disc has %i, musicbrainz says %i. Ignoring.',
+                  len(disc_id.tracks), track_count)
             return None
         priority = priority + 2
     
-    if not len(single_medium['track-list']) == len(disc_id.tracks):
-        logger.info('Track number mismatch: real disc has %i, musicbrainz says %i. Ignoring.',
-                  len(disc_id.tracks), single_medium['track-count'])
+    track_list = single_medium.get('track-list')
+    if track_list is None:
+        logger.debug('Medium contains no `track-list`. This sounds fishy, ignoring.')
+    if not len(track_list) == len(disc_id.tracks):
+        logger.debug('Track number mismatch: real disc has %i, musicbrainz says %i. Ignoring.',
+                  len(disc_id.tracks), track_list)
         return None
 
     # disc-list does not seem to contain important information.
 
     priority = 0
-    for i in range(0, len(single_medium['track-list'])):
-        single_mb_track = single_medium['track-list'][i]
+    for i in range(0, len(track_list)):
+        single_mb_track = track_list[i]
         single_disc_track = disc_id.tracks[i]
         track_prio = __check_single_track(single_mb_track, single_disc_track)
         if not track_prio:
-            logger.info('Track mismatch, ignoring this disk.')
+            logger.debug('Track mismatch, ignoring this disk.')
             return None
         priority = priority + track_prio
     return priority
 
 
 def __check_single_track(single_mb_track, single_disc_track):
+    # See "def_track-data"
     priority = 0
     
     # TODO: position or number?
-    if single_mb_track.get('position') is not None:
-        mb_position = int(single_mb_track['position'])
+    position = single_mb_track.get('position')
+    if position is not None:
+        mb_position = int(position)
         if mb_position == single_disc_track.number:
             priority = priority + 9
         else:
@@ -234,54 +268,161 @@ def __check_single_track(single_mb_track, single_disc_track):
         real_length_ms = single_disc_track.sectors * 1000 / 75
         len_diff = abs(real_length_ms - mb_length_ms)
         if len_diff > 10000:  # up to 5 seconds fade in / fade out time at start and end
-            logger.info('Massive track length mismatch: real disc has %ims, musicbrainz says %ims.',
+            logger.debug('Massive track length mismatch: real disc has %ims, musicbrainz says %ims.',
                         real_length_ms, mb_length_ms)
             return None
-        elif len_diff < 20:  # sector length = 1000ms/75 = 13+1/3
-            # exact track length match!
-            priority = priority + 50
+        elif len_diff < 20:  # sector length = 1000ms/75 = (13+1/3)ms
+            priority = priority + 50  # priority bonus for "exact" length match
         else:
-            print(len_diff)
             priority = priority - len_diff/100
-            logger.info('Slight track length mismatch: real disc has %i, musicbrainz says %i.',
+            logger.debug('Slight track length mismatch: real disc has %i, musicbrainz says %i.',
                         real_length_ms, mb_length_ms)
     
-    # TODO read and compare isrc? Musicbrainz does not seem to support that.
+    if single_mb_track.get('recording') is not None:
+        resource_priority = __check_single_track_as_recording(
+            single_mb_track.get('recording'), single_disc_track)
+        if resource_priority is None:
+            return None
+        else:
+            priority = priority + resource_priority
     
     return priority
 
 
-def __parse_from_disc_data(release, medium, device, disk_id):
-    # prepopulate from disc_id parser
+def __check_single_track_as_recording(mb_recording, disc_track):
+    # See "def_recording-element"
+
+    priority = 0
+    if hasattr(disc_track, 'isrc') and disc_track.isrc is not None:
+        mb_isrc_list = mb_recording.get('isrc-list')
+        if mb_isrc_list is not None:
+            if disc_track.isrc in mb_isrc_list:
+                priority = +1000
+            else:
+                priority = -100
+    return priority
+
+
+def __parse_medium_from_disc_data(release, medium, device, disc_id):
+    # populate from disc_id parser
     tracks = discid_parser.parse_disc(disc_id, device)
+    medium_tags = dict()
     
-    artist = release['artist-credit-phrase']
-    album_title = release['title']
-    date = release['date']
-    track_list = medium['track-list']
-    disc_number = '{0}/{1}'.format(medium['position'], 1)  # TODO calculate disc number?
+    disc_number = __get_disc_number(medium, release)
+    if disc_number is not None:
+        medium_tags['discnumber'] = disc_number
     
-    track_count = medium['track-count']
-    for track_index in range(0, track_count):
-        track = tracks[track_index]
-        #track_number = '{0}/{1}'.format(
-        #    track_list[track_index]['number'],  # TODO or position?
-        #    medium['track-count'])
-        track.set_tags(
-            artist=artist,
-            title=track_list[track_index]['recording']['title'],
-            albumartist=artist,
-            album=album_title,
-            #tracknumber=track_number,
-            discnumber=disc_number,
-            date=date,
-            #__length=int(track_list[track_index]['length']) / 1000,
-            # or track_list[track_index]['recording']['length']
-            # or track_list[track_index]['track_or_recording_length']
-            # TODO Get more data with secondary query, e.g. genre ("tags")? 
-            # https://wiki.musicbrainz.org/Genre
-            )
-        tracks.append(track)
+    if release.get('id') is not None:
+        medium_tags['__release_id'] = release['id']
+
+    if release.get('date') is not None:
+        medium_tags['date'] = release['date']
+
+    # TODO difference of medium.title vs. release.title?
+    album_title = medium.get('title')
+    if album_title is not None:
+        medium_tags['album'] = album_title
+    else:
+        album_title = release.get('title')
+        if album_title is not None:
+            medium_tags['album'] = album_title
+
+    artist = release.get('artist-credit-phrase')
+    if artist is not None:
+        medium_tags['albumartist'] = artist
+        medium_tags['artist'] = artist
+    
+    if release.get('barcode') is not None:
+        medium_tags['barcode'] = release.get('barcode')
+
+    mb_tracks = medium['track-list']
+    for track_index in range(0, len(mb_tracks)):
+        __parse_track_from_disc_data(
+            medium_tags.copy(), tracks[track_index], mb_tracks[track_index])
+
+    # needs the 'musicbrainz_albumid' tag to be set, thus this happens after writing track tags
+    __get_cover_image(release, tracks)
     
     return (tracks, album_title)
+
+
+def __get_cover_image(release, tracks):
+    """
+        Fetch a cover using musicbrainzcover's cover provider.
+        Requires the 'musicbrainz_albumid' tag to be set on the tracks.
+        
+        Documentation:
+        * https://musicbrainz.org/doc/Cover_Art_Archive/API
+    """
+    if release.get('id') is None:
+        return None
+    
+    try:
+        import plugins.musicbrainzcovers as musicbrainzcovers
+    except ImportError:
+        logger.warn('Cannot load musicbrainzcovers, will not fetch covers.')
+        return None
+    
+    cover_searcher = musicbrainzcovers.MusicBrainzCoverSearch(main.exaile())
+    cover_data = None
+    for resolution in ['500', '1200', '250']:
+        try:
+            db_string = '%s:%s' % (release['id'], resolution)
+            cover_data = cover_searcher.get_cover_data(db_string)
+            break
+        except:
+            logger.debug('Cannot fetch cover for %s in resolution %s', 
+                        release['id'], resolution)
+
+    if cover_data is not None:
+        for track in tracks:
+            db_string = 'musicbrainz:bar'
+            CoverManager.set_cover(track, db_string, cover_data)
+
+
+def __parse_track_from_disc_data(track_tags, xl_track, mb_track):
+    # See "def_track-data" in https://github.com/metabrainz/mmd-schema/blob/master/schema/musicbrainz_mmd-2.0.rng
+    # unused and populated from discid: position, number, length
+    
+    if mb_track.get('id') is not None:
+        track_tags['__musicbrainz_track_id'] = mb_track['id']
+    
+    if mb_track.get('title') is not None:
+        track_tags['title'] = mb_track['title']
+    
+    track_artist = mb_track.get('artist-credit-phrase')
+    if track_artist is not None:
+        track_tags['artist'] = track_artist
+    
+    if mb_track.get('recording') is not None:
+        mb_recording = mb_track['recording']
+        # see "def_recording-element"
+        # unused fields: length, annotation, disambiguation, ...
+        
+        recording_title = mb_recording.get('title')
+        if recording_title is not None and track_tags.get('title') is None:
+            track_tags['title'] = recording_title
+        
+        recording_id = mb_recording.get('id')
+        if recording_id is not None:
+            track_tags['musicbrainz_albumid'] = recording_id
+        
+    xl_track.set_tags(**track_tags)
+
+
+def __get_disc_number(medium, release):
+    """ Helper function to extract disc number string, e.g. 1/2 for the first of 2 CDs """
+    # We may also be able to use the 'disc-count' field of "medium"
+    medium_position = medium.get('position')
+    medium_count = release.get('medium-count')
+    if medium_count is None:
+        medium_count = len(release['medium-list'])
+    if medium_position is not None:
+        if medium_count is not None:
+            return '{0}/{1}'.format(medium_position, medium_count)
+        else:
+            return medium_position
+    elif medium_count is not None and medium_count == 1:
+        return '1/1'
+    return None
 

--- a/plugins/cd/musicbrainzngs_parser.py
+++ b/plugins/cd/musicbrainzngs_parser.py
@@ -38,26 +38,27 @@ from plugins.cd import discid_parser
 logger = logging.getLogger(__name__)
 
 
-def __init_musicbrainzngs():
+def fetch_with_disc_id(disc_id, device):
     version = main.exaile().get_user_agent_for_musicbrainz()
     musicbrainzngs.set_useragent(*version)
 
-
-__init_musicbrainzngs()
-
-
-def fetch_with_disc_id(disc_id, device):
     musicbrainz_data = musicbrainzngs.get_releases_by_discid(
-        disc_id.id, toc=disc_id.toc_string, includes=[
-            'artists', 'recordings', 'isrcs', 'artist-credits'])
+        disc_id.id,
+        toc=disc_id.toc_string,
+        includes=['artists', 'recordings', 'isrcs', 'artist-credits'],
+    )
 
     if musicbrainz_data.get('disc') is not None:  # preferred: good quality
-        disc_tracks = __parse_musicbrainz_disc_data(musicbrainz_data['disc'], disc_id, device)
+        disc_tracks = __parse_musicbrainz_disc_data(
+            musicbrainz_data['disc'], disc_id, device
+        )
         if disc_tracks is not None:
             return disc_tracks
 
     if musicbrainz_data.get('cdstub') is not None:  # bad quality, use as fallback
-        disc_tracks = __parse_musicbrainz_cdstub_data(musicbrainz_data['cdstub'], disc_id, device)
+        disc_tracks = __parse_musicbrainz_cdstub_data(
+            musicbrainz_data['cdstub'], disc_id, device
+        )
         if disc_tracks is not None:
             return disc_tracks
 
@@ -77,8 +78,12 @@ def __parse_musicbrainz_cdstub_data(cdstub_data, disc_id, device):
     track_count = cdstub_data.get('track-count')
     if track_count is not None:
         if len(tracks) is not track_count:
-            logger.debug('Track count mismatch: real disc has %i, musicbrainz says %i. '
-                         'Ignoring all data.', len(tracks), track_count)
+            logger.debug(
+                'Track count mismatch: real disc has %i, musicbrainz says %i. '
+                'Ignoring all data.',
+                len(tracks),
+                track_count,
+            )
             return None
 
     album_tags = dict()
@@ -169,8 +174,11 @@ def __check_single_release(single_release, disc_id):
                 logger.debug('Found exact barcode match: %s', disc_barcode)
                 priority = 100
             else:  # could be a different barcode format or a weak match
-                logger.debug('Barcode mismatch: real disc has %s, musicbrainz says %s.',
-                             disc_barcode, mb_barcode)
+                logger.debug(
+                    'Barcode mismatch: real disc has %s, musicbrainz says %s.',
+                    disc_barcode,
+                    mb_barcode,
+                )
                 priority = -19
 
     medium_list = single_release.get('medium-list')
@@ -197,16 +205,21 @@ def __check_single_medium(single_medium, disc_id):
     mb_format = single_medium.get('format')
     if mb_format is not None:
         if not mb_format == 'CD':
-            logger.debug('Medium format mismatch: real disc is CD, musicbrainz says %s. Ignoring.',
-                         mb_format)
+            logger.debug(
+                'Medium format mismatch: real disc is CD, musicbrainz says %s. Ignoring.',
+                mb_format,
+            )
             return None
         priority = priority + 7
 
     track_count = single_medium.get('track-count')
     if track_count is not None:
         if not track_count == len(disc_id.tracks):
-            logger.debug('Track count mismatch: real disc has %i, musicbrainz says %i. Ignoring.',
-                         len(disc_id.tracks), track_count)
+            logger.debug(
+                'Track count mismatch: real disc has %i, musicbrainz says %i. Ignoring.',
+                len(disc_id.tracks),
+                track_count,
+            )
             return None
         priority = priority + 2
 
@@ -214,8 +227,11 @@ def __check_single_medium(single_medium, disc_id):
     if track_list is None:
         logger.debug('Medium contains no `track-list`. This sounds fishy, ignoring.')
     if not len(track_list) == len(disc_id.tracks):
-        logger.debug('Track number mismatch: real disc has %i, musicbrainz says %i. Ignoring.',
-                     len(disc_id.tracks), track_list)
+        logger.debug(
+            'Track number mismatch: real disc has %i, musicbrainz says %i. Ignoring.',
+            len(disc_id.tracks),
+            track_list,
+        )
         return None
 
     # disc-list does not seem to contain important information.
@@ -243,8 +259,11 @@ def __check_single_track(single_mb_track, single_disc_track):
         if mb_position == single_disc_track.number:
             priority = priority + 9
         else:
-            logger.info('Track position mismatch: real disc has %i, musicbrainz says %i.',
-                        single_disc_track.number, mb_position)
+            logger.info(
+                'Track position mismatch: real disc has %i, musicbrainz says %i.',
+                single_disc_track.number,
+                mb_position,
+            )
             return None
 
     if single_mb_track.get('number') is not None:
@@ -252,8 +271,11 @@ def __check_single_track(single_mb_track, single_disc_track):
         if mb_number == single_disc_track.number:
             priority = priority + 9
         else:
-            logger.info('Track number mismatch: real disc has %i, musicbrainz says %i.',
-                        single_disc_track.number, mb_number)
+            logger.info(
+                'Track number mismatch: real disc has %i, musicbrainz says %i.',
+                single_disc_track.number,
+                mb_number,
+            )
             return None
 
     # compare length
@@ -262,19 +284,26 @@ def __check_single_track(single_mb_track, single_disc_track):
         real_length_ms = single_disc_track.sectors * 1000 / 75
         len_diff = abs(real_length_ms - mb_length_ms)
         if len_diff > 10000:  # up to 5 seconds fade in / fade out time at start and end
-            logger.debug('Massive track length mismatch: real disc has %ims, musicbrainz says %ims.',
-                         real_length_ms, mb_length_ms)
+            logger.debug(
+                'Massive track length mismatch: real disc has %ims, musicbrainz says %ims.',
+                real_length_ms,
+                mb_length_ms,
+            )
             return None
         elif len_diff < 20:  # sector length = 1000ms/75 = (13+1/3)ms
             priority = priority + 50  # priority bonus for "exact" length match
         else:
             priority = priority - len_diff / 100
-            logger.debug('Slight track length mismatch: real disc has %i, musicbrainz says %i.',
-                         real_length_ms, mb_length_ms)
+            logger.debug(
+                'Slight track length mismatch: real disc has %i, musicbrainz says %i.',
+                real_length_ms,
+                mb_length_ms,
+            )
 
     if single_mb_track.get('recording') is not None:
         resource_priority = __check_single_track_as_recording(
-            single_mb_track.get('recording'), single_disc_track)
+            single_mb_track.get('recording'), single_disc_track
+        )
         if resource_priority is None:
             return None
         else:
@@ -332,7 +361,8 @@ def __parse_medium_from_disc_data(release, medium, device, disc_id):
     mb_tracks = medium['track-list']
     for track_index in range(0, len(mb_tracks)):
         __parse_track_from_disc_data(
-            medium_tags.copy(), tracks[track_index], mb_tracks[track_index])
+            medium_tags.copy(), tracks[track_index], mb_tracks[track_index]
+        )
 
     # needs the 'musicbrainz_albumid' tag to be set, thus this happens after writing track tags
     __get_cover_image(release, tracks)
@@ -365,8 +395,9 @@ def __get_cover_image(release, tracks):
             cover_data = cover_searcher.get_cover_data(db_string)
             break
         except Exception:
-            logger.debug('Cannot fetch cover for %s in resolution %s',
-                         release['id'], resolution)
+            logger.debug(
+                'Cannot fetch cover for %s in resolution %s', release['id'], resolution
+            )
 
     if cover_data is not None:
         for track in tracks:

--- a/plugins/cd/musicbrainzngs_parser.py
+++ b/plugins/cd/musicbrainzngs_parser.py
@@ -1,10 +1,8 @@
-'''
-Created on 03.05.2019
-
-@author: christian
-'''
-
-
+"""
+    This module is a parser for audio CDs based on musicbrainzngs and discid.
+    
+    It uses the online database provided by musicbrainzngs.
+"""
 
 
 import musicbrainzngs
@@ -16,6 +14,8 @@ from xl.trax import Track
 
 MUSICBRAINZNGS_INITIALIZED = False
 
+# TODO some of the stuff in this module is not implemented yet
+# TODO add musicbrainz disc id, freedb disc id, MCN, ISRC
 
 
 def parse_disc_id(disc_id, device):

--- a/plugins/cd/musicbrainzngs_parser.py
+++ b/plugins/cd/musicbrainzngs_parser.py
@@ -2,58 +2,274 @@
     This module is a parser for audio CDs based on musicbrainzngs and discid.
     
     It uses the online database provided by musicbrainzngs.
+    
+    musicbrainz documentation:
+    * Web API: https://musicbrainz.org/doc/Development/XML%20Web%20Service/Version%202
+    * Web API format: https://github.com/metabrainz/mmd-schema/blob/master/schema/musicbrainz_mmd-2.0.rng
+    
+    Note: All the "priority" values are arbitrary/random choices and may need improvement
 """
 
 
-import musicbrainzngs
+from __future__ import division
 
+import logging
+
+import musicbrainzngs
 
 from xl import main
 from xl.trax import Track
+from plugins.cd import discid_parser
+
+
+logger = logging.getLogger(__name__)
 
 
 MUSICBRAINZNGS_INITIALIZED = False
 
-# TODO some of the stuff in this module is not implemented yet
 # TODO add musicbrainz disc id, freedb disc id, MCN, ISRC
+# TODO which fields are optional?
+# TODO test
+# TODO adapt log levels
 
 
-def parse_disc_id(disc_id, device):
+def fetch_with_disc_id(disc_id, device):
+    global MUSICBRAINZNGS_INITIALIZED
     if not MUSICBRAINZNGS_INITIALIZED:
         version = main.exaile().get_user_agent_for_musicbrainz()
         musicbrainzngs.set_useragent(*version)
+        MUSICBRAINZNGS_INITIALIZED = True
 
     musicbrainz_data = musicbrainzngs.get_releases_by_discid(
         disc_id.id, toc=disc_id.toc_string, includes=["artists", "recordings"])
     
-    if musicbrainz_data.get('disc'):  # preferred: good quality
-        return __parse_musicbrainz_disc(musicbrainz_data['disc'], device)
-    elif musicbrainz_data.get('cdstub'):  # not so nice
-        raise NotImplementedError
+    if musicbrainz_data.get('disc') is not None:  # preferred: good quality
+        disc_tracks = __parse_musicbrainz_disc_data(musicbrainz_data['disc'], disc_id, device)
+        if disc_tracks is not None:
+            return disc_tracks
+
+    if musicbrainz_data.get('cdstub') is not None:  # bad quality, use as fallback
+        disc_tracks = __parse_musicbrainz_cdstub_data(musicbrainz_data['cdstub'], disc_id, device)
+        if disc_tracks is not None:
+            return disc_tracks
+    
+    # no useful data returned
+    logger.info('Musicbrainz returned not useful data: %s', musicbrainz_data)
+    return None
 
 
-def __parse_musicbrainz_disc(disc_data, device):
-    # arbitrarily choose first release. There may be more!
-    release = disc_data['release-list'][0]
+def __parse_musicbrainz_cdstub_data(cdstub_data, disc_id, device):
+    # use discid_parser first to get some data t rely on
+    tracks = discid_parser.parse_disc(disc_id, device)
+    
+    if cdstub_data['track-count']:
+        track_count = cdstub_data['track-count']
+        if len(tracks) is not track_count:
+            logger.info('Track count mismatch: real disc has %i, musicbrainz says %i. Ignoring all data.',
+                  len(tracks), track_count)
+            return None
+    
+    album_title = cdstub_data['title']
+    
+    artist = cdstub_data.get('artist')
+    barcode = cdstub_data.get('barcode')
+    
+    track_list = cdstub_data.get('track-list')
+    if track_list is not None:
+        for i in range(0, len(tracks)):
+            track = tracks[i]
+            new_tags = dict()
+            new_tags['album'] = album_title
+            
+            if barcode is not None:
+                new_tags['barcode'] = barcode
+                
+            if artist is not None:
+                new_tags['artist'] = artist
+            track_title = track_list[i].get('title')
+            if track_title is not None:
+                new_tags['title'] = track_title
+            
+            new_tags['tracknumber'] = '{0}/{1}'.format(i + 1, len(tracks))
+            
+            if artist is not None:
+                new_tags['artist'] = artist
+                new_tags['albumartist'] = artist
+            
+            track.set_tags(**new_tags)
+    return (tracks, album_title)
+
+
+def __parse_musicbrainz_disc_data(disc_data, disc_id, device):
+    
+    # get list of potential candidates, throw away the rest
+    release_list = disc_data['release-list']
+    suitable_releases = []
+    for single_release in release_list:
+        release = __check_single_release(single_release, disc_id)
+        if release is not None:
+            suitable_releases.append(release)
+    
+    if len(suitable_releases) < 1:
+        return None
+    
+    (release, medium) = __choose_release_and_medium(suitable_releases)
+    
+    return __parse_from_disc_data(release, medium, device)
+
+
+def __choose_release_and_medium(suitable_releases):
+    # find the most suitable release
+    chosen_prio = -10  # this is a threshold
+    chosen_release = None
+    chosen_release_media = None
+    for (prio, release_media, release) in suitable_releases:
+        if prio > chosen_prio:
+            chosen_prio = prio
+            chosen_release_media = release_media
+            chosen_release = release
+    
+    # find the most suitable medium
+    chosen_prio = -50  # this is a threshold
+    chosen_medium = None
+    for (prio, medium) in chosen_release_media:
+        if prio > chosen_prio:
+            chosen_prio = prio
+            chosen_medium = medium
+    
+    return (chosen_release, chosen_medium)
+
+
+def __check_single_release(single_release, disc_id):
+    # https://wiki.musicbrainz.org/Recording
+    
+    priority = 0
+    
+    # See https://wiki.musicbrainz.org/Barcode
+    if single_release.get('barcode') is not None and disc_id.mcn is not None:
+        mb_barcode = single_release['barcode'].lstrip('0')
+        disc_barcode = disc_id.mcn.lstrip('0')
+        
+        if len(disc_barcode) > 5:  # empty string indicates missing barcode
+            if mb_barcode == disc_barcode:
+                logger.info('Found exact barcode match: %s', disc_barcode)
+                priority = 100
+            else:  # could be a different barcode format or a weak match
+                logger.info('Barcode mismatch: real disc has %s, musicbrainz says %s.',
+                            disc_barcode, mb_barcode)
+                priority = -19
+    
+    medium_list = single_release['medium-list']
+    suitable_media = []
+    for single_medium in medium_list:
+        medium_priority = __check_single_medium(single_medium, disc_id)
+        if medium_priority is not None:
+            suitable_media.append((medium_priority, single_medium))
+            priority = priority + medium_priority/20
+
+    if len(suitable_media) == 0:
+        return None
+    else:
+        return (priority, suitable_media, single_release)
+
+
+def __check_single_medium(single_medium, disc_id):
+    # https://wiki.musicbrainz.org/Medium
+    priority = 0
+    if single_medium.get('format') is not None:
+        if not 'CD' == single_medium['format']:
+            logger.info('Medium format mismatch: real disc is CD, musicbrainz says %s. Ignoring.',
+                  single_medium['format'])
+            return None
+        priority = priority + 7
+    
+    if single_medium.get('track-count') is not None:
+        if not single_medium['track-count'] == len(disc_id.tracks):
+            logger.info('Track count mismatch: real disc has %i, musicbrainz says %i. Ignoring.',
+                  len(disc_id.tracks), single_medium['track-count'])
+            return None
+        priority = priority + 2
+    
+    if not len(single_medium['track-list']) == len(disc_id.tracks):
+        logger.info('Track number mismatch: real disc has %i, musicbrainz says %i. Ignoring.',
+                  len(disc_id.tracks), single_medium['track-count'])
+        return None
+
+    # disc-list does not seem to contain important information.
+
+    priority = 0
+    for i in range(0, len(single_medium['track-list'])):
+        single_mb_track = single_medium['track-list'][i]
+        single_disc_track = disc_id.tracks[i]
+        track_prio = __check_single_track(single_mb_track, single_disc_track)
+        if not track_prio:
+            logger.info('Track mismatch, ignoring this disk.')
+            return None
+        priority = priority + track_prio
+    return priority
+
+
+def __check_single_track(single_mb_track, single_disc_track):
+    priority = 0
+    
+    # TODO: position or number?
+    if single_mb_track.get('position') is not None:
+        mb_position = int(single_mb_track['position'])
+        if mb_position == single_disc_track.number:
+            priority = priority + 9
+        else:
+            logger.info('Track position mismatch: real disc has %i, musicbrainz says %i.',
+                        single_disc_track.number, mb_position)
+            return None
+    
+    if single_mb_track.get('number') is not None:
+        mb_number = int(single_mb_track['number'])
+        if mb_number == single_disc_track.number:
+            priority = priority + 9
+        else:
+            logger.info('Track number mismatch: real disc has %i, musicbrainz says %i.',
+                        single_disc_track.number, mb_number)
+            return None
+    
+    # compare length
+    if single_mb_track.get('length') is not None:
+        mb_length_ms = int(single_mb_track['length'])
+        real_length_ms = single_disc_track.sectors * 1000 / 75
+        len_diff = abs(real_length_ms - mb_length_ms)
+        if len_diff > 10000:  # up to 5 seconds fade in / fade out time at start and end
+            logger.info('Massive track length mismatch: real disc has %ims, musicbrainz says %ims.',
+                        real_length_ms, mb_length_ms)
+            return None
+        elif len_diff < 20:  # sector length = 1000ms/75 = 13+1/3
+            # exact track length match!
+            priority = priority + 50
+        else:
+            print(len_diff)
+            priority = priority - len_diff/100
+            logger.info('Slight track length mismatch: real disc has %i, musicbrainz says %i.',
+                        real_length_ms, mb_length_ms)
+    
+    # TODO read and compare isrc? Musicbrainz does not seem to support that.
+    
+    return priority
+
+
+def __parse_from_disc_data(release, medium, device):
     artist = release['artist-credit-phrase']
     album_title = release['title']
     date = release['date']
-    if release['medium-count'] > 1 or release['medium-list'][0]['disc-count'] > 1:
-        raise NotImplementedError
-    track_list = release['medium-list'][0]['track-list']
-    disc_number = '{0}/{1}'.format(
-        release['medium-list'][0]['position'],
-        1)  # TODO calculate disk number?
+    track_list = medium['track-list']
+    disc_number = '{0}/{1}'.format(medium['position'], 1)  # TODO calculate disc number?
     
-    track_count = release['medium-list'][0]['track-count']
+    track_count = medium['track-count']
     tracks = []
     for track_index in range(0, track_count):
-        # TODO put this into a new musicbrainz parser in xl/metadata
+        # TODO put this into a new musicbrainz parser in xl/metadata?
         track_uri = "cdda://%d/#%s" % (track_index+1, device)
         track = Track(uri=track_uri, scan=False)
         track_number = '{0}/{1}'.format(
             track_list[track_index]['number'],  # TODO or position?
-            release['medium-list'][0]['track-count'])
+            medium['track-count'])
         track.set_tags(
             artist=artist,
             title=track_list[track_index]['recording']['title'],
@@ -66,7 +282,9 @@ def __parse_musicbrainz_disc(disc_data, device):
             # or track_list[track_index]['recording']['length']
             # or track_list[track_index]['track_or_recording_length']
             # TODO Get more data with secondary query, e.g. genre ("tags")? 
+            # https://wiki.musicbrainz.org/Genre
             )
         tracks.append(track)
     
     return (tracks, album_title)
+

--- a/plugins/cd/musicbrainzngs_parser.py
+++ b/plugins/cd/musicbrainzngs_parser.py
@@ -1,38 +1,34 @@
 """
     This module is a parser for audio CDs based on musicbrainzngs and discid.
-    
+
     It uses the online database provided by musicbrainzngs.
-    
+
     musicbrainz documentation:
     * Wiki: https://wiki.musicbrainz.org/
     * Web API: https://musicbrainz.org/doc/Development/XML%20Web%20Service/Version%202
     * Web API format: https://github.com/metabrainz/mmd-schema/blob/master/schema/musicbrainz_mmd-2.0.rng
     * Database schema: https://wiki.musicbrainz.org/MusicBrainz_Database/Schema
-    
+
     musicbrainzngs documentation:
     * https://python-musicbrainzngs.readthedocs.io/
-    
+
     Note: All the "priority" values are arbitrary/random choices and may need improvement
-    
+
     TODO: Room for improvement:
     * fetch composers (especially interesting for classical music)
     * test text-representation for non-latin languages
-    * get more data with secondary query, e.g. genre ("medium_tags") 
+    * get more data with secondary query, e.g. genre ("medium_tags")
         see https://wiki.musicbrainz.org/Genre
 """
 
 
 from __future__ import division
 
-import json
 import logging
-import urllib2
 
 import musicbrainzngs
 
 from xl import main
-from xl.metadata import CoverImage
-from xl.trax import Track
 
 from xl.covers import MANAGER as CoverManager
 
@@ -54,7 +50,7 @@ def fetch_with_disc_id(disc_id, device):
     musicbrainz_data = musicbrainzngs.get_releases_by_discid(
         disc_id.id, toc=disc_id.toc_string, includes=[
             'artists', 'recordings', 'isrcs', 'artist-credits'])
-    
+
     if musicbrainz_data.get('disc') is not None:  # preferred: good quality
         disc_tracks = __parse_musicbrainz_disc_data(musicbrainz_data['disc'], disc_id, device)
         if disc_tracks is not None:
@@ -64,7 +60,7 @@ def fetch_with_disc_id(disc_id, device):
         disc_tracks = __parse_musicbrainz_cdstub_data(musicbrainz_data['cdstub'], disc_id, device)
         if disc_tracks is not None:
             return disc_tracks
-    
+
     # no useful data returned
     logger.info('Musicbrainz returned no useful data: %s', musicbrainz_data)
     return None
@@ -74,54 +70,53 @@ def __parse_musicbrainz_cdstub_data(cdstub_data, disc_id, device):
     """ Parses cdstub data into xl.trax.Track """
     # populate from disc_id parser
     tracks = discid_parser.parse_disc(disc_id, device)
-    
+
     # See "def_cdstub"
     # Unused: disambiguation, def_cdstub-attribute_extension, def_cdstub-element_extension
-    
+
     track_count = cdstub_data.get('track-count')
     if track_count is not None:
         if len(tracks) is not track_count:
-            logger.debug('Track count mismatch: real disc has %i, musicbrainz says %i. Ignoring all data.',
-                  len(tracks), track_count)
+            logger.debug('Track count mismatch: real disc has %i, musicbrainz says %i. '
+                         'Ignoring all data.', len(tracks), track_count)
             return None
-    
+
     album_tags = dict()
-    
+
     if cdstub_data.get('id') is not None:
         album_tags['__musicbrainz_cdstub_id'] = cdstub_data['id']
-    
+
     album_title = cdstub_data['title']
     album_tags['album'] = album_title
-    
+
     artist = cdstub_data.get('artist')
     if artist is not None:
         album_tags['albumartist'] = artist
         album_tags['artist'] = artist
-    
+
     barcode = cdstub_data.get('barcode')
     if barcode is not None:
         album_tags['barcode'] = barcode
-    
+
     track_list = cdstub_data.get('track-list')
     if track_list is not None:
         for i in range(0, len(tracks)):
             # See "def_nonmb-track"
             # unused: length
             track = tracks[i]
-            track_tags = album_tags.copy() 
-            
+            track_tags = album_tags.copy()
             track_tags['title'] = track_list[i]['title']
-            
+
             track_artist = track_list[i].get('artist')
             if track_artist is not None:
                 track_tags['artist'] = track_artist
-            
+
             track.set_tags(**track_tags)
     return tracks, album_title
 
 
 def __parse_musicbrainz_disc_data(disc_data, disc_id, device):
-    
+
     # get list of potential candidates, throw away the rest
     release_list = disc_data['release-list']
     suitable_releases = []
@@ -129,12 +124,11 @@ def __parse_musicbrainz_disc_data(disc_data, disc_id, device):
         release = __check_single_release(single_release, disc_id)
         if release is not None:
             suitable_releases.append(release)
-    
+
     if len(suitable_releases) < 1:
         return None
-    
+
     (release, medium) = __choose_release_and_medium(suitable_releases)
-    
     return __parse_medium_from_disc_data(release, medium, device, disc_id)
 
 
@@ -148,7 +142,7 @@ def __choose_release_and_medium(suitable_releases):
             chosen_prio = prio
             chosen_release_media = release_media
             chosen_release = release
-    
+
     # find the most suitable medium
     chosen_prio = -50  # this is a threshold
     chosen_medium = None
@@ -156,7 +150,7 @@ def __choose_release_and_medium(suitable_releases):
         if prio > chosen_prio:
             chosen_prio = prio
             chosen_medium = medium
-    
+
     return (chosen_release, chosen_medium)
 
 
@@ -169,16 +163,16 @@ def __check_single_release(single_release, disc_id):
     if mb_barcode is not None and disc_id.mcn is not None:
         mb_barcode = mb_barcode.lstrip('0')
         disc_barcode = disc_id.mcn.lstrip('0')
-        
+
         if len(disc_barcode) > 5:  # empty string indicates missing barcode
             if mb_barcode == disc_barcode:
                 logger.debug('Found exact barcode match: %s', disc_barcode)
                 priority = 100
             else:  # could be a different barcode format or a weak match
                 logger.debug('Barcode mismatch: real disc has %s, musicbrainz says %s.',
-                            disc_barcode, mb_barcode)
+                             disc_barcode, mb_barcode)
                 priority = -19
-    
+
     medium_list = single_release.get('medium-list')
     if medium_list is None:
         logger.debug('Release contains no `medium-list`. This sounds fishy, ignoring.')
@@ -189,7 +183,7 @@ def __check_single_release(single_release, disc_id):
         medium_priority = __check_single_medium(single_medium, disc_id)
         if medium_priority is not None:
             suitable_media.append((medium_priority, single_medium))
-            priority = priority + medium_priority/20
+            priority = priority + medium_priority / 20
 
     if len(suitable_media) == 0:
         return None
@@ -200,28 +194,28 @@ def __check_single_release(single_release, disc_id):
 def __check_single_medium(single_medium, disc_id):
     # https://wiki.musicbrainz.org/Medium
     priority = 0
-    format = single_medium.get('format')
-    if format is not None:
-        if not format == 'CD':
+    mb_format = single_medium.get('format')
+    if mb_format is not None:
+        if not mb_format == 'CD':
             logger.debug('Medium format mismatch: real disc is CD, musicbrainz says %s. Ignoring.',
-                  format)
+                         mb_format)
             return None
         priority = priority + 7
-    
+
     track_count = single_medium.get('track-count')
     if track_count is not None:
         if not track_count == len(disc_id.tracks):
             logger.debug('Track count mismatch: real disc has %i, musicbrainz says %i. Ignoring.',
-                  len(disc_id.tracks), track_count)
+                         len(disc_id.tracks), track_count)
             return None
         priority = priority + 2
-    
+
     track_list = single_medium.get('track-list')
     if track_list is None:
         logger.debug('Medium contains no `track-list`. This sounds fishy, ignoring.')
     if not len(track_list) == len(disc_id.tracks):
         logger.debug('Track number mismatch: real disc has %i, musicbrainz says %i. Ignoring.',
-                  len(disc_id.tracks), track_list)
+                     len(disc_id.tracks), track_list)
         return None
 
     # disc-list does not seem to contain important information.
@@ -241,7 +235,7 @@ def __check_single_medium(single_medium, disc_id):
 def __check_single_track(single_mb_track, single_disc_track):
     # See "def_track-data"
     priority = 0
-    
+
     # TODO: position or number?
     position = single_mb_track.get('position')
     if position is not None:
@@ -252,7 +246,7 @@ def __check_single_track(single_mb_track, single_disc_track):
             logger.info('Track position mismatch: real disc has %i, musicbrainz says %i.',
                         single_disc_track.number, mb_position)
             return None
-    
+
     if single_mb_track.get('number') is not None:
         mb_number = int(single_mb_track['number'])
         if mb_number == single_disc_track.number:
@@ -261,7 +255,7 @@ def __check_single_track(single_mb_track, single_disc_track):
             logger.info('Track number mismatch: real disc has %i, musicbrainz says %i.',
                         single_disc_track.number, mb_number)
             return None
-    
+
     # compare length
     if single_mb_track.get('length') is not None:
         mb_length_ms = int(single_mb_track['length'])
@@ -269,15 +263,15 @@ def __check_single_track(single_mb_track, single_disc_track):
         len_diff = abs(real_length_ms - mb_length_ms)
         if len_diff > 10000:  # up to 5 seconds fade in / fade out time at start and end
             logger.debug('Massive track length mismatch: real disc has %ims, musicbrainz says %ims.',
-                        real_length_ms, mb_length_ms)
+                         real_length_ms, mb_length_ms)
             return None
         elif len_diff < 20:  # sector length = 1000ms/75 = (13+1/3)ms
             priority = priority + 50  # priority bonus for "exact" length match
         else:
-            priority = priority - len_diff/100
+            priority = priority - len_diff / 100
             logger.debug('Slight track length mismatch: real disc has %i, musicbrainz says %i.',
-                        real_length_ms, mb_length_ms)
-    
+                         real_length_ms, mb_length_ms)
+
     if single_mb_track.get('recording') is not None:
         resource_priority = __check_single_track_as_recording(
             single_mb_track.get('recording'), single_disc_track)
@@ -285,7 +279,7 @@ def __check_single_track(single_mb_track, single_disc_track):
             return None
         else:
             priority = priority + resource_priority
-    
+
     return priority
 
 
@@ -307,11 +301,11 @@ def __parse_medium_from_disc_data(release, medium, device, disc_id):
     # populate from disc_id parser
     tracks = discid_parser.parse_disc(disc_id, device)
     medium_tags = dict()
-    
+
     disc_number = __get_disc_number(medium, release)
     if disc_number is not None:
         medium_tags['discnumber'] = disc_number
-    
+
     if release.get('id') is not None:
         medium_tags['__release_id'] = release['id']
 
@@ -331,7 +325,7 @@ def __parse_medium_from_disc_data(release, medium, device, disc_id):
     if artist is not None:
         medium_tags['albumartist'] = artist
         medium_tags['artist'] = artist
-    
+
     if release.get('barcode') is not None:
         medium_tags['barcode'] = release.get('barcode')
 
@@ -342,7 +336,7 @@ def __parse_medium_from_disc_data(release, medium, device, disc_id):
 
     # needs the 'musicbrainz_albumid' tag to be set, thus this happens after writing track tags
     __get_cover_image(release, tracks)
-    
+
     return (tracks, album_title)
 
 
@@ -350,19 +344,19 @@ def __get_cover_image(release, tracks):
     """
         Fetch a cover using musicbrainzcover's cover provider.
         Requires the 'musicbrainz_albumid' tag to be set on the tracks.
-        
+
         Documentation:
         * https://musicbrainz.org/doc/Cover_Art_Archive/API
     """
     if release.get('id') is None:
         return None
-    
+
     try:
         import plugins.musicbrainzcovers as musicbrainzcovers
     except ImportError:
         logger.warn('Cannot load musicbrainzcovers, will not fetch covers.')
         return None
-    
+
     cover_searcher = musicbrainzcovers.MusicBrainzCoverSearch(main.exaile())
     cover_data = None
     for resolution in ['500', '1200', '250']:
@@ -370,43 +364,42 @@ def __get_cover_image(release, tracks):
             db_string = '%s:%s' % (release['id'], resolution)
             cover_data = cover_searcher.get_cover_data(db_string)
             break
-        except:
-            logger.debug('Cannot fetch cover for %s in resolution %s', 
-                        release['id'], resolution)
+        except Exception:
+            logger.debug('Cannot fetch cover for %s in resolution %s',
+                         release['id'], resolution)
 
     if cover_data is not None:
         for track in tracks:
-            db_string = 'musicbrainz:bar'
+            # TODO: This is a hack: set_cover() expects a db_string to start with this, but why?
+            # We could use CoverManager.get_cover(track) but this does not work because
+            # CoverManager.get_db_string(track) fails to get the right string.
+            db_string = 'musicbrainz: '
             CoverManager.set_cover(track, db_string, cover_data)
 
 
 def __parse_track_from_disc_data(track_tags, xl_track, mb_track):
     # See "def_track-data" in https://github.com/metabrainz/mmd-schema/blob/master/schema/musicbrainz_mmd-2.0.rng
     # unused and populated from discid: position, number, length
-    
+
     if mb_track.get('id') is not None:
         track_tags['__musicbrainz_track_id'] = mb_track['id']
-    
+
     if mb_track.get('title') is not None:
         track_tags['title'] = mb_track['title']
-    
+
     track_artist = mb_track.get('artist-credit-phrase')
     if track_artist is not None:
         track_tags['artist'] = track_artist
-    
+
     if mb_track.get('recording') is not None:
         mb_recording = mb_track['recording']
         # see "def_recording-element"
         # unused fields: length, annotation, disambiguation, ...
-        
+
         recording_title = mb_recording.get('title')
         if recording_title is not None and track_tags.get('title') is None:
             track_tags['title'] = recording_title
-        
-        recording_id = mb_recording.get('id')
-        if recording_id is not None:
-            track_tags['musicbrainz_albumid'] = recording_id
-        
+
     xl_track.set_tags(**track_tags)
 
 
@@ -425,4 +418,3 @@ def __get_disc_number(medium, release):
     elif medium_count is not None and medium_count == 1:
         return '1/1'
     return None
-

--- a/plugins/cd/musicbrainzngs_parser.py
+++ b/plugins/cd/musicbrainzngs_parser.py
@@ -1,0 +1,72 @@
+'''
+Created on 03.05.2019
+
+@author: christian
+'''
+
+
+
+
+import musicbrainzngs
+
+
+from xl import main
+from xl.trax import Track
+
+
+MUSICBRAINZNGS_INITIALIZED = False
+
+
+
+def parse_disc_id(disc_id, device):
+    if not MUSICBRAINZNGS_INITIALIZED:
+        version = main.exaile().get_user_agent_for_musicbrainz()
+        musicbrainzngs.set_useragent(*version)
+
+    musicbrainz_data = musicbrainzngs.get_releases_by_discid(
+        disc_id.id, toc=disc_id.toc_string, includes=["artists", "recordings"])
+    
+    if musicbrainz_data.get('disc'):  # preferred: good quality
+        return __parse_musicbrainz_disc(musicbrainz_data['disc'], device)
+    elif musicbrainz_data.get('cdstub'):  # not so nice
+        raise NotImplementedError
+
+
+def __parse_musicbrainz_disc(disc_data, device):
+    # arbitrarily choose first release. There may be more!
+    release = disc_data['release-list'][0]
+    artist = release['artist-credit-phrase']
+    album_title = release['title']
+    date = release['date']
+    if release['medium-count'] > 1 or release['medium-list'][0]['disc-count'] > 1:
+        raise NotImplementedError
+    track_list = release['medium-list'][0]['track-list']
+    disc_number = '{0}/{1}'.format(
+        release['medium-list'][0]['position'],
+        1)  # TODO calculate disk number?
+    
+    track_count = release['medium-list'][0]['track-count']
+    tracks = []
+    for track_index in range(0, track_count):
+        # TODO put this into a new musicbrainz parser in xl/metadata
+        track_uri = "cdda://%d/#%s" % (track_index+1, device)
+        track = Track(uri=track_uri, scan=False)
+        track_number = '{0}/{1}'.format(
+            track_list[track_index]['number'],  # TODO or position?
+            release['medium-list'][0]['track-count'])
+        track.set_tags(
+            artist=artist,
+            title=track_list[track_index]['recording']['title'],
+            albumartist=artist,
+            album=album_title,
+            tracknumber=track_number,
+            discnumber=disc_number,
+            date=date,
+            __length=int(track_list[track_index]['length']) / 1000,
+            # or track_list[track_index]['recording']['length']
+            # or track_list[track_index]['track_or_recording_length']
+            # TODO Get more data with secondary query, e.g. genre ("tags")? 
+            )
+        tracks.append(track)
+    
+    return (tracks, album_title)

--- a/plugins/cd/musicbrainzngs_parser.py
+++ b/plugins/cd/musicbrainzngs_parser.py
@@ -95,10 +95,11 @@ def __parse_musicbrainz_data(musicbrainz_data, disc_id, tracks, callback):
 
 
 def __parse_musicbrainz_cdstub_data(cdstub_data, tracks):
-    """ Parses cdstub data into xl.trax.Track """
-    # See "def_cdstub"
-    # Unused: disambiguation, def_cdstub-attribute_extension, def_cdstub-element_extension
-
+    """
+        Parses cdstub data into xl.trax.Track
+        See "def_cdstub"
+        Unused: disambiguation, def_cdstub-attribute_extension, def_cdstub-element_extension
+    """
     track_count = cdstub_data.get('track-count')
     if track_count is not None:
         if len(tracks) is not track_count:
@@ -145,7 +146,6 @@ def __parse_musicbrainz_cdstub_data(cdstub_data, tracks):
 
 
 def __parse_musicbrainz_disc_data(disc_data, disc_id, tracks):
-
     # get list of potential candidates, throw away the rest
     release_list = disc_data['release-list']
     suitable_releases = []
@@ -162,7 +162,9 @@ def __parse_musicbrainz_disc_data(disc_data, disc_id, tracks):
 
 
 def __choose_release_and_medium(suitable_releases):
-    # find the most suitable release
+    """
+        find the most suitable release
+    """
     chosen_prio = -10  # this is a threshold
     chosen_release = None
     chosen_release_media = None
@@ -184,7 +186,9 @@ def __choose_release_and_medium(suitable_releases):
 
 
 def __check_single_release(single_release, disc_id):
-    # https://wiki.musicbrainz.org/Recording
+    """
+        Documentation: https://wiki.musicbrainz.org/Recording
+    """
 
     priority = 0
     # See https://wiki.musicbrainz.org/Barcode
@@ -224,7 +228,9 @@ def __check_single_release(single_release, disc_id):
 
 
 def __check_single_medium(single_medium, disc_id):
-    # https://wiki.musicbrainz.org/Medium
+    """
+        Documentation: https://wiki.musicbrainz.org/Medium
+    """
     priority = 0
     mb_format = single_medium.get('format')
     if mb_format is not None:
@@ -273,7 +279,9 @@ def __check_single_medium(single_medium, disc_id):
 
 
 def __check_single_track(single_mb_track, single_disc_track):
-    # See "def_track-data"
+    """
+        See "def_track-data"
+    """
     priority = 0
 
     # TODO: position or number?
@@ -337,7 +345,9 @@ def __check_single_track(single_mb_track, single_disc_track):
 
 
 def __check_single_track_as_recording(mb_recording, disc_track):
-    # See "def_recording-element"
+    """
+        See "def_recording-element"
+    """
 
     priority = 0
     if hasattr(disc_track, 'isrc') and disc_track.isrc is not None:
@@ -431,9 +441,11 @@ def __get_cover_image(release, tracks):
 
 
 def __parse_track_from_disc_data(track_tags, xl_track, mb_track):
-    # See "def_track-data" in https://github.com/metabrainz/mmd-schema/blob/master/schema/musicbrainz_mmd-2.0.rng
-    # unused and populated from discid: position, number, length
-
+    """
+        See "def_track-data" in
+        https://github.com/metabrainz/mmd-schema/blob/master/schema/musicbrainz_mmd-2.0.rng
+        unused and populated from discid: position, number, length
+    """
     if mb_track.get('id') is not None:
         track_tags['__musicbrainz_track_id'] = mb_track['id']
 
@@ -457,7 +469,9 @@ def __parse_track_from_disc_data(track_tags, xl_track, mb_track):
 
 
 def __get_disc_number(medium, release):
-    """ Helper function to extract disc number string, e.g. 1/2 for the first of 2 CDs """
+    """
+        Helper function to extract disc number string, e.g. 1/2 for the first of 2 CDs
+    """
     # We may also be able to use the 'disc-count' field of "medium"
     medium_position = medium.get('position')
     medium_count = release.get('medium-count')

--- a/xl/main.py
+++ b/xl/main.py
@@ -908,6 +908,14 @@ class Exaile(object):
         else:
             return self._user_agent_no_plugin % fmt
 
+    def get_user_agent_for_musicbrainz(self):
+        '''
+            Returns an appropriately formatted User-agent tuple for
+            musicbrainzngs. When possible, plugins should use this to
+            access musicbrainz.
+        '''
+        return ('Exaile', __version__, 'https://www.exaile.org')
+
     def quit(self, restart=False):
         """
             Exits Exaile normally. Takes care of saving


### PR DESCRIPTION
This is an almost complete rework of the cd plugin to replace the CDDB dependency by libdiscid. CDDB is the last external dependency not available on python 3 so this is a blocker to python 3.

If you wish, I may squash the changes into less or one single commit.

I already did test this code, but you can probably still find issues when testing it too – especially because you will test it differently.

I introduced quite some `TODO:`s in the code for places where the code could be improved. The most important step would be communicating some progress to the user.

Please note that this change introduces string changes and thus is not suitable for a 4.0.x release.

Fixes #608, which is part of #246.