### PR TITLE
Remove deprecated keyword "sudo" from travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 
-sudo: required
 services:
   - docker
 language: python
@@ -20,7 +19,6 @@ script:
 jobs:
   include:
   - stage: format-check
-    sudo: false
     language: python
     python:
     - "3.6"


### PR DESCRIPTION
cf.
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

modified:   .travis.yml