### PR TITLE
Travis: Enable CI on ubuntu 18.04 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: python
 env:
   - IMGTAG=debian10-python3
   - IMGTAG=fedora31-python3
+  - IMGTAG=ubuntu18.04-python3
   - IMGTAG=ubuntu19.10-python3
 
 before_install:


### PR DESCRIPTION
Our code *should* also compile with the latest ubuntu LTS which is 18.04 and has python 3.6.