### PR TITLE
py3: fix documentation generation on python 3.7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ before_install:
 - docker pull exaile/exaile-testimg:${IMGTAG}
 
 script:
-- docker run --rm -it -e HOME=/home -v $(pwd):/app -w /app exaile/exaile-testimg:${IMGTAG} make BUILDDIR=/tmp test test_compile
-  # TODO: re-enable `check-doc` build target!
+- docker run --rm -it -e HOME=/home -v $(pwd):/app -w /app exaile/exaile-testimg:${IMGTAG} make BUILDDIR=/tmp test test_compile check-doc
 
 jobs:
   include:

--- a/doc/mocks.py
+++ b/doc/mocks.py
@@ -18,6 +18,10 @@ class Mock:
     def __call__(self, *args, **kwargs):
         return Mock()
 
+    # Fix for python 3.7+ (issue #667)
+    def __mro_entries__ (self, bases):
+        return ()
+
     @classmethod
     def __getattr__(cls, name):
         if name in ('__file__', '__path__'):


### PR DESCRIPTION
This fixes #667  for me on Fedora 31 with python 3.7.6.

However, I am not really familiar enough with this area of python to be certain that there are no side effects.

This seems to be the relevant reference: https://www.python.org/dev/peps/pep-0560/