### PR TITLE
[py3] SyntaxWarning and removed API fixes

### DIFF
--- a/plugins/massstorage/__init__.py
+++ b/plugins/massstorage/__init__.py
@@ -62,7 +62,7 @@ class MassStorageDevice(Device):
         self.mountpoints = [
             str(x)
             for x in self._mountpoints
-            if str(x) is not "" and os.path.exists(str(x))
+            if str(x) != "" and os.path.exists(str(x))
         ]
         if self.mountpoints == []:
             raise IOError("Device is not mounted.")

--- a/xl/playlist.py
+++ b/xl/playlist.py
@@ -31,7 +31,6 @@ in playlists as well as methods to import and export from various file formats.
 
 from gi.repository import Gio
 
-import cgi
 from collections import deque
 from datetime import datetime, timedelta
 import logging
@@ -1529,7 +1528,7 @@ class Playlist:
             if not track:
                 continue
             if not track.is_local() and meta is not None:
-                meta = cgi.parse_qs(meta)
+                meta = urllib.parse.parse_qs(meta)
                 for k, v in meta.items():
                     track.set_tag_raw(k, v[0], notify_changed=False)
 


### PR DESCRIPTION
This PR is based on py3 branch and testing with Python 3.8:

- Python3 SyntaxWarning fix: is not "" (use !=)
- cgi.parse_qs deprecated in python3 and removed in python3.8; use urllib.parse

