### PR TITLE
py3: Fix code formatting after #673

### DIFF
--- a/plugins/massstorage/__init__.py
+++ b/plugins/massstorage/__init__.py
@@ -60,9 +60,7 @@ class MassStorageDevice(Device):
 
     def connect(self):
         self.mountpoints = [
-            str(x)
-            for x in self._mountpoints
-            if str(x) != "" and os.path.exists(str(x))
+            str(x) for x in self._mountpoints if str(x) != "" and os.path.exists(str(x))
         ]
         if self.mountpoints == []:
             raise IOError("Device is not mounted.")


### PR DESCRIPTION
#673 broke the CI format-check. Let's unbreak it.