### PR TITLE
py3: fix documentation generation on python 3.6+ (try 2)

### DIFF
--- a/doc/mocks.py
+++ b/doc/mocks.py
@@ -8,29 +8,32 @@
 import sys
 
 
-class Mock:
-
-    __all__ = []
-
+class MockGiModule:
     def __init__(self, *args, **kwargs):
         pass
 
     def __call__(self, *args, **kwargs):
-        return Mock()
-
-    # Fix for python 3.7+ (issue #667)
-    def __mro_entries__ (self, bases):
-        return ()
+        return MockGiModule()
 
     @classmethod
     def __getattr__(cls, name):
         if name in ('__file__', '__path__'):
             return '/dev/null'
+        elif name in '__mro_entries__':
+            raise AttributeError("'MockGiModule' object has no attribute '%s'" % (name))
+        elif name in 'GObject':
+            # This corresponds to GObject class in the GI (GObject)
+            # module - we need to return type instead of an instance!
+            #
+            # Note: we need to do this for each class that comes from
+            # a GI module AND is involved in multiple-inheritance in our
+            # codebase in order to avoid "TypeError: metaclass conflict"
+            # errors.
+            return MockGiModule
         else:
-            return Mock()
+            return MockGiModule()
 
     # glib mocks
-
     @classmethod
     def get_user_data_dir(cls):
         return '/tmp'
@@ -44,7 +47,6 @@ class Mock:
         return '/tmp'
 
     # gtk/gdk mocks
-
     class ModifierType:
         SHIFT_MASK = 0
 
@@ -52,6 +54,28 @@ class Mock:
     def accelerator_parse(cls, *args):
         return [0, 0]
 
+class Mock:
+    __all__ = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return Mock()
+
+    @classmethod
+    def __getattr__(cls, name):
+        if name in ('__file__', '__path__'):
+            return '/dev/null'
+        elif name in '__mro_entries__':
+            raise AttributeError("'Mock' object has no attribute '%s'" % (name))
+        elif name in ('Gio', 'GLib', 'GObject', 'Gst', 'Gtk', 'Gdk'):
+            # These are reached via 'from gi.repository import x' and
+            # correspond to GI sub-modules - need to return an instance
+            # of our mock GI module
+            return MockGiModule()
+        else:
+            return Mock()
 
 MOCK_MODULES = [
     'bsddb',

--- a/doc/mocks.py
+++ b/doc/mocks.py
@@ -78,7 +78,7 @@ class Mock:
             return Mock()
 
 MOCK_MODULES = [
-    'bsddb',
+    'bsddb3',
     'cairo',
 
     'dbus',


### PR DESCRIPTION
Second attempt at fixing the documentation generation issue, tested both with python 3.6.x on Ubuntu 18.04 and 3.7.x on Fedora 31.

This time, the ```__mro_entries__``` issue is addressed by raising the ```AttributeError```.

However, this still leaves the ```TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases``` error, which is caused by the mocked ```GObject.GObject``` being involved in multiple inheritance in ```xl.common.ProgressThread```. For this to work, we need our ```Mock``` object for the ```GObject``` module return a type instead of an instance for ```GObject``` (class).

Due to the name repetition (```gi.repository.GObject.GObject```, with ```GObject``` referring both to the module and the class) and ```__getattr__``` being a class method, distinction between the two is handled by introduction of a new ```MockGiModule``` class, which now also collects all mock functionality of GI (sub)modules.