### PR TITLE
[py3] Fix SyntaxWarnings

### DIFF
--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -566,7 +566,7 @@ class DaapConnection:
                             temp.set_tag_raw(field, [tag], notify_changed=False)
 
                     except Exception:
-                        if field is 'tracknumber':
+                        if field == 'tracknumber':
                             temp.set_tag_raw('tracknumber', [0], notify_changed=False)
 
                 # TODO: convert year (asyr) here as well, what's the formula?

--- a/plugins/inhibitsuspend/__init__.py
+++ b/plugins/inhibitsuspend/__init__.py
@@ -80,7 +80,7 @@ class SuspendInhibit:
         elif 'xfce' in session or 'xfce' in xdg_session:
             self.adapter = XfceAdapter()
         # TODO implement for LXDE, X-Cinnamon, Unity; systemd-inhibit
-        elif session is '' and xdg_session is '':
+        elif session == '' and xdg_session == '':
             logger.warning(
                 'Could not detect Desktop Session, will try default \
                     Power Manager then Gnome'

--- a/xlgui/preferences/collection.py
+++ b/xlgui/preferences/collection.py
@@ -34,7 +34,7 @@ def _get_default_strip_list():
     # If this practice is not common in your locale, simply
     # translate this to string with single space.
     default_strip_list = _("the")
-    return [v.lower() for v in default_strip_list.split(' ') if v is not '']
+    return [v.lower() for v in default_strip_list.split(' ') if v]
 
 
 class CollectionStripArtistPreference(widgets.ListPreference):
@@ -51,7 +51,7 @@ class CollectionStripArtistPreference(widgets.ListPreference):
             because we don't need shlex parsing. We actually
             want values like "l'" here.
         """
-        values = [v.lower() for v in self.widget.get_text().split(' ') if v is not '']
+        values = [v.lower() for v in self.widget.get_text().split(' ') if v]
         return values
 
     def _populate_popup_cb(self, entry, menu):


### PR DESCRIPTION
```
/home/travis/devel/exaile/xlgui/preferences/collection.py:37:
SyntaxWarning: "is not" with a literal. Did you mean "!="?
  return [v.lower() for v in default_strip_list.split(' ') if v is not '']
/home/travis/devel/exaile/xlgui/preferences/collection.py:54:
SyntaxWarning: "is not" with a literal. Did you mean "!="?
  values = [v.lower() for v in self.widget.get_text().split(' ') if v is not '']
```