### PR TITLE
Python: Replace calls to deprecated logging.warn()

### DIFF
--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -805,7 +805,7 @@ class DaapClientPlugin:
                 logger.error('is avahi-daemon running?')
         else:
             avahi_interface = None
-            logger.warn(
+            logger.warning(
                 'AVAHI could not be imported, you will not see broadcast shares.'
             )
 

--- a/plugins/daapserver/server.py
+++ b/plugins/daapserver/server.py
@@ -171,7 +171,7 @@ class DaapServer:
 #                                         spydaap.port,
 #                                         stype="_daap._tcp")
 #    zeroconf.publish()
-#    logger.warn("Listening.")
+#    logger.warning("Listening.")
 #    httpd = MyThreadedHTTPServer(('0.0.0.0', spydaap.port),
 #                                 spydaap.server.makeDAAPHandlerClass(spydaap.server_name, cache, md_cache, container_cache))
 #
@@ -185,7 +185,7 @@ class DaapServer:
 #            pass
 #    except KeyboardInterrupt:
 #        httpd.force_stop()
-#    logger.warn("Shutting down.")
+#    logger.warning("Shutting down.")
 #    zeroconf.unpublish()
 
 # def main():

--- a/plugins/osd/__init__.py
+++ b/plugins/osd/__init__.py
@@ -120,7 +120,7 @@ class OSDPlugin:
             # Setting opacity on Windows crashes with segfault,
             # see https://bugzilla.gnome.org/show_bug.cgi?id=674449
             self.__options['use_alpha'] = False
-            LOGGER.warn(
+            LOGGER.warning(
                 "OSD: Disabling alpha channel because it is not supported on Windows."
             )
         else:
@@ -566,7 +566,7 @@ class OSDWindow(Gtk.Window):
             # does not support transparency
             visual = screen.get_system_visual()
             self.__options['use_alpha'] = False
-            LOGGER.warn(
+            LOGGER.warning(
                 "OSD: Disabling alpha channel because the Gtk+ "
                 "backend does not support it."
             )

--- a/plugins/podcasts/__init__.py
+++ b/plugins/podcasts/__init__.py
@@ -210,7 +210,7 @@ class PodcastPanel(panel.Panel):
                 (url, title) = line.split('\t')
                 self.podcasts.append((title, url))
         except (IOError, OSError):
-            logger.warn('Could not open podcast file')
+            logger.warning('Could not open podcast file')
             self._set_status('')
             return
 

--- a/xl/migrations/database/to_bsddb.py
+++ b/xl/migrations/database/to_bsddb.py
@@ -42,7 +42,7 @@ def migrate(path):
     try:
         old_shelf = shelve.open(path, 'r', protocol=common.PICKLE_PROTOCOL)
     except Exception:
-        logger.warn("%s may be corrupt", path)
+        logger.warning("%s may be corrupt", path)
         raise
 
     db = common.bsddb.hashopen(bak_path, 'c')

--- a/xl/player/gst/engine.py
+++ b/xl/player/gst/engine.py
@@ -678,7 +678,7 @@ class AudioStream:
         elif message.type == Gst.MessageType.WARNING:
             # TODO there might be some useful warnings we ignore for now.
             gerror, debug_text = Gst.Message.parse_warning(message)
-            logger.warn(
+            logger.warning(
                 "Unhandled GStreamer warning received:\n\tGError: %s\n\tDebug text: %s",
                 gerror,
                 debug_text,

--- a/xl/player/gst/missing_plugin.py
+++ b/xl/player/gst/missing_plugin.py
@@ -83,7 +83,7 @@ def __handle_plugin_missing_message(message, engine):
 
     desc = GstPbutils.missing_plugin_message_get_description(message)
     installer_details = GstPbutils.missing_plugin_message_get_installer_detail(message)
-    LOGGER.warn("A plugin for %s is missing, stopping playback", desc)
+    LOGGER.warning("A plugin for %s is missing, stopping playback", desc)
 
     user_message = _(
         "A GStreamer 1.x plugin for %s is missing. "
@@ -97,7 +97,7 @@ def __handle_plugin_missing_message(message, engine):
     if GstPbutils.install_plugins_supported():
         if __run_installer_helper(installer_details):
             return
-    LOGGER.warn("Installation of GStreamer plugins not supported on this platform.")
+    LOGGER.warning("Installation of GStreamer plugins not supported on this platform.")
 
 
 def __notify_user_on_error(message_text, engine):
@@ -127,10 +127,10 @@ def __run_installer_helper(installer_details):
         return False
     elif start_result == GstPbutils.InstallPluginsReturn.HELPER_MISSING:
         # we expect that to happen on some platforms
-        LOGGER.warn("Helper missing for assisted installation of Gstreamer plugins")
+        LOGGER.warning("Helper missing for assisted installation of Gstreamer plugins")
         return False
     elif start_result == GstPbutils.InstallPluginsReturn.INSTALL_IN_PROGRESS:
-        LOGGER.warn("Another assisted plugin installation is already in progress")
+        LOGGER.warning("Another assisted plugin installation is already in progress")
         return False
     elif start_result == GstPbutils.InstallPluginsReturn.STARTED_OK:
         LOGGER.info("Successfully started assisted GStreamer plugin installation")
@@ -167,7 +167,7 @@ def __installer_finished_callback(result):
         # engine.initialize()
         pass
     elif result == GstPbutils.InstallPluginsReturn.NOT_FOUND:
-        LOGGER.warn("GStreamer helper was unable to install missing plugin.")
+        LOGGER.warning("GStreamer helper was unable to install missing plugin.")
         # we do not care about these, the user already got a notification how
         # to install plugins. There is nothing more we can do.
     elif (

--- a/xlgui/__init__.py
+++ b/xlgui/__init__.py
@@ -138,7 +138,7 @@ class Main:
                 self.tray_icon = tray.TrayIcon(self.main)
             else:
                 settings.set_option('gui/use_tray', False)
-                logger.warn(
+                logger.warning(
                     "Tray icons are not supported on your platform. Disabling tray icon."
                 )
 
@@ -418,7 +418,7 @@ class Main:
             gi.require_version('GtkosxApplication', '1.0')
             from gi.repository import GtkosxApplication
         except (ValueError, ImportError):
-            logger.warn("importing GtkosxApplication failed, no native menus")
+            logger.warning("importing GtkosxApplication failed, no native menus")
         else:
             osx_app = GtkosxApplication.Application()
             # self.main.setup_osx(osx_app)

--- a/xlgui/panels.py
+++ b/xlgui/panels.py
@@ -134,7 +134,9 @@ class PanelNotebook(notebook.SmartNotebook, providers.ProviderHandler):
     def on_provider_added(self, provider):
 
         if provider.name is None:
-            logger.warn("Ignoring improperly initialized panel provider: %s", provider)
+            logger.warning(
+                "Ignoring improperly initialized panel provider: %s", provider
+            )
             return
 
         panel = provider.get_panel()


### PR DESCRIPTION
logging.warning() is just the same without deprecation notice.

Note: `logging.warn()` is not only deprecated since python 3.3 but has never been documented ([Details](https://bugs.python.org/issue13235)).