### PR TITLE
[Py3] Remove a few deprecated functions

### DIFF
--- a/xl/main.py
+++ b/xl/main.py
@@ -440,25 +440,6 @@ def create_argument_parser():
 class Exaile:
     _exaile = None
 
-    def __get_player(self):
-        raise DeprecationWarning(
-            'Using exaile.player is deprecated: ' 'import xl.player.PLAYER instead.'
-        )
-
-    def __get_queue(self):
-        raise DeprecationWarning(
-            'Using exaile.queue is deprecated: ' 'import xl.player.QUEUE instead.'
-        )
-
-    def __get_lyrics(self):
-        raise DeprecationWarning(
-            'Using exaile.lyrics is deprecated: ' 'import xl.lyrics.MANAGER instead.'
-        )
-
-    player = property(__get_player)
-    queue = property(__get_queue)
-    lyrics = property(__get_lyrics)
-
     def __init__(self):
         """
             Initializes Exaile.

--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -291,20 +291,6 @@ class Track:
         """
         return self.__tags['__loc']
 
-    def local_file_name(self):
-        """
-            If the file is accessible on the local filesystem, returns a
-            standard path to it (e.g. "/home/foo/bar"), otherwise,
-            returns None.
-
-            If a path is returned, it is safe to use for IO operations.
-            Existence of a path does *not* guarantee file existence.
-        """
-        raise DeprecationWarning(
-            'get_local_path() is ' 'preferred over local_file_name()'
-        )
-        return self.get_local_path()
-
     def get_local_path(self):
         """
             If the file is accessible on a local filesystem, retrieves

--- a/xl/trax/trackdb.py
+++ b/xl/trax/trackdb.py
@@ -383,29 +383,5 @@ class TrackDB:
     def get_tracks(self):
         return list(self)
 
-    def search(self, query, sort_fields=[], return_lim=-1, tracks=None, reverse=False):
-        """
-            DEPRECATED, DO NOT USE IN NEW CODE
-        """
-        import warnings
-
-        warnings.warn("TrackDB.search is deprecated.", DeprecationWarning)
-        tracks = [
-            x.track
-            for x in search_tracks_from_string(
-                self,
-                query,
-                case_sensitive=False,
-                keyword_tags=['artist', 'albumartist', 'album', 'title'],
-            )
-        ]
-
-        if sort_fields:
-            tracks = sort_tracks(sort_fields, tracks, reverse)
-        if return_lim > 0:
-            tracks = tracks[:return_lim]
-
-        return tracks
-
 
 # vim: et sts=4 sw=4


### PR DESCRIPTION
* xl/main.py: These changes are hard to find, but they are deprecated for almost 10 years now so I think it is ok to remove them.
* xl/trax/{track,trackdb}.py: I could not find any code in our repo using these deprecated functions, so I removed them.