### PR TITLE
Double-clicked playlists in playlist pane now replace current playlist if enabled in options

### DIFF
--- a/xlgui/panel/playlists.py
+++ b/xlgui/panel/playlists.py
@@ -210,10 +210,9 @@ class BasePlaylistPanelMixin(GObject.GObject):
             if isinstance(item, (Playlist, SmartPlaylist)):
                 if replace:
                     # what we want to do if replace is true
-                    playlist = self.get_selected_item(raw=raw)
+                    selected_playlist = self.tree.get_selected_page()
                     tracks = [track for track in playlist]
                     self.emit('replace-items', tracks)
-        
                 else:
                     # for smart playlists
                     if hasattr(item, 'get_playlist'):

--- a/xlgui/panel/playlists.py
+++ b/xlgui/panel/playlists.py
@@ -233,9 +233,10 @@ class BasePlaylistPanelMixin(GObject.GObject):
                     self.emit('playlist-selected', item)
             else:
                 if replace:
-                    self.emit('replace-items', [item.track]))
+                    self.emit('replace-items', [item.track])
                 else:             
-                    self.emit('append-items', [item.track], True)    
+                    self.emit('append-items', [item.track], True)  
+                      
     def add_new_playlist(self, tracks=[], name=None):
         """
             Adds a new playlist to the list of playlists. If name is

--- a/xlgui/panel/playlists.py
+++ b/xlgui/panel/playlists.py
@@ -211,7 +211,7 @@ class BasePlaylistPanelMixin(GObject.GObject):
                 if replace:
                     # what we want to do if replace is true
                     selected_playlist = self.tree.get_selected_page()
-                    tracks = [track for track in playlist]
+                    tracks = [track for track in selected_playlist]
                     self.emit('replace-items', tracks)
                 else:
                     # for smart playlists

--- a/xlgui/panel/playlists.py
+++ b/xlgui/panel/playlists.py
@@ -203,28 +203,39 @@ class BasePlaylistPanelMixin(GObject.GObject):
         """
         iter = self.model.get_iter(path)
         item = self.model.get_value(iter, 2)
+        
+        replace = settings.get_option('playlist/replace_content', False)
+        
         if item is not None:
             if isinstance(item, (Playlist, SmartPlaylist)):
-                # for smart playlists
-                if hasattr(item, 'get_playlist'):
-                    try:
-                        item = item.get_playlist(self.collection)
-                    except Exception as e:
-                        logger.exception("Error loading smart playlist")
-                        dialogs.error(
-                            self.parent, _("Error loading smart playlist: %s") % str(e)
-                        )
-                        return
+                if replace:
+                    # what we want to do if replace is true
+                    playlist = self.get_selected_item(raw=raw)
+                    tracks = [track for track in playlist]
+                    self.emit('replace-items', tracks)
+        
                 else:
-                    # Get an up to date copy
-                    item = self.playlist_manager.get_playlist(item.name)
-                    # item.set_is_custom(True)
-
-                #                self.controller.main.add_playlist(item)
-                self.emit('playlist-selected', item)
+                    # for smart playlists
+                    if hasattr(item, 'get_playlist'):
+                        try:
+                            item = item.get_playlist(self.collection)
+                        except Exception as e:
+                            logger.exception("Error loading smart playlist")
+                            dialogs.error(
+                                self.parent, _("Error loading smart playlist: %s") % str(e)
+                            )
+                            return
+                    else:
+                        # Get an up to date copy
+                        item = self.playlist_manager.get_playlist(item.name)
+                        # item.set_is_custom(True)
+                    #                self.controller.main.add_playlist(item)
+                    self.emit('playlist-selected', item)
             else:
-                self.emit('append-items', [item.track], True)
-
+                if replace:
+                    self.emit('replace-items', [item.track]))
+                else:             
+                    self.emit('append-items', [item.track], True)    
     def add_new_playlist(self, tracks=[], name=None):
         """
             Adds a new playlist to the list of playlists. If name is


### PR DESCRIPTION
Addresses #683 

Playlists double-clicked in the Playlists pane when 'double-click in lefthand pane replaces current' option is enabled now replace the current playlist entirely. This also applies to if a particular track under a particular playlist is double-clicked - that track will replace the existing playlist as well, just as if I had double-clicked that track in Collection.

PS: I am an R developer of ten years, and this is the first time I have ever edited Python code (even though I helped teach several Python workshops). I apologize for any striking errors, frankly I am amazed I was even able to do this.