### PR TITLE
[RFC/WIP] Optional per-playlist column settings

### DIFF
--- a/xl/playlist.py
+++ b/xl/playlist.py
@@ -927,6 +927,11 @@ class Playlist:
         'dynamic_mode',
         'current_position',
         'name',
+        # GUI
+        'global_playlist_columns',
+        'playlist_columns',
+        'resizable_cols',
+        'playlist_column_widths',
     ]
     __playlist_format_version = [2, 0]
 
@@ -960,6 +965,40 @@ class Playlist:
         self.__shuffle_history_counter = 1  # start positive so we can
         # just do an if directly on the value
         event.add_callback(self.on_playback_track_start, "playback_track_start")
+
+        # These are actually GUI properties, but are also stored here
+        # so that they get saved/restored using existing infrastructure
+        self.__global_playlist_columns = True
+        self.__playlist_columns = []
+        self.__resizable_cols = False
+        self.__playlist_column_widths = {}
+
+    def _set_global_playlist_columns(self, enable):
+        self.__dirty = self.__global_playlist_columns != enable
+        self.__global_playlist_columns = enable
+
+    def _set_playlist_columns(self, columns):
+        self.__dirty = self.__playlist_columns != columns
+        self.__playlist_columns = columns
+
+    def _set_resizable_cols(self, enable):
+        self.__dirty = self.__resizable_cols != enable
+        self.__resizable_cols = enable
+
+    def _set_playlist_column_widths(self, widths):
+        self.__dirty = self.__playlist_column_widths != widths
+        self.__playlist_column_widths = widths
+
+    global_playlist_columns = property(
+        lambda self: self.__global_playlist_columns, _set_global_playlist_columns
+    )
+    playlist_columns = property(
+        lambda self: self.__playlist_columns, _set_playlist_columns
+    )
+    resizable_cols = property(lambda self: self.__resizable_cols, _set_resizable_cols)
+    playlist_column_widths = property(
+        lambda self: self.__playlist_column_widths, _set_playlist_column_widths
+    )
 
     ### playlist-specific API ###
 

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -862,6 +862,17 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
 
         self._filter_matcher = None
 
+        self._global_playlist_columns = True
+        if self._global_playlist_columns:
+            self._playlist_columns = settings.get_option(
+                'gui/columns', playlist_columns.DEFAULT_COLUMNS
+            )
+            self._resizable_cols = settings.get_option('gui/resizable_cols', False)
+            self._playlist_column_widths = {}
+        else:
+            # FIXME
+            raise Exception("FIXME!")
+
         self._sort_columns = list(common.BASE_SORT_TAGS)  # Column sort order
 
         self._setup_models()
@@ -903,6 +914,72 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
         self.connect("drag-data-delete", self.on_drag_data_delete)
         self.connect("drag-end", self.on_drag_end)
         self.connect("drag-motion", self.on_drag_motion)
+
+    def _set_playlist_columns(self, columns):
+        self._playlist_columns = columns
+
+        self._refresh_columns()
+
+        # Save to settings
+        if self._global_playlist_columns:
+            if columns != settings.get_option('gui/columns', []):
+                settings.set_option('gui/columns', columns)
+        else:
+            raise Exception("FIXME!")
+
+    def _set_resizable_cols(self, resizable):
+        if self._resizable_cols == resizable:
+            return
+
+        self._resizable_cols = resizable
+
+        # Save to settings
+        if self._global_playlist_columns:
+            if resizable != settings.get_option('gui/resizable_cols', False):
+                settings.set_option('gui/resizable_cols', resizable)
+        else:
+            raise Exception("FIXME!")
+
+        # Emit event
+        event.log_event("resizable_cols_changed", self, resizable)
+
+    playlist_columns = property(
+        lambda self: self._playlist_columns, _set_playlist_columns
+    )
+
+    resizable_cols = property(lambda self: self._resizable_cols, _set_resizable_cols)
+
+    def get_playlist_column_width(self, name, width=-1):
+        if self._global_playlist_columns:
+            # Global settings
+            option_name = "gui/col_width_%s" % name
+            width = settings.get_option(option_name, width)
+        else:
+            # Custom settings
+            if name in self._playlist_column_widths:
+                width = self._playlist_column_widths[name]
+
+        return width
+
+    def set_playlist_column_width(self, name, width):
+        if self._global_playlist_columns:
+            # Global settings
+            option_name = "gui/col_width_%s" % name
+            if width != settings.get_option(option_name, width):
+                settings.set_option(option_name, width)
+        else:
+            # Custom settings
+            if (
+                name not in self._playlist_column_widths
+                or width != self._playlist_column_widths[name]
+            ):
+                self._playlist_column_widths[name] = width
+
+            # FIXME: store column widths
+            raise Exception("FIXME!")
+
+        # Emit event
+        event.log_event("column_width_changed", self, name)
 
     def do_destroy(self):
         # if this isn't disconnected, then the columns are emptied out and
@@ -1053,9 +1130,8 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
             self.player.queue.append(track)
 
     def _setup_columns(self):
-        columns = settings.get_option('gui/columns', playlist_columns.DEFAULT_COLUMNS)
         provider_names = [p.name for p in providers.get('playlist-columns')]
-        columns = [name for name in columns if name in provider_names]
+        columns = [name for name in self.playlist_columns if name in provider_names]
 
         if not columns:
             columns = playlist_columns.DEFAULT_COLUMNS
@@ -1190,8 +1266,7 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
 
     def on_columns_changed(self, widget):
         columns = [c.name for c in self.get_columns()[1:]]
-        if columns != settings.get_option('gui/columns', []):
-            settings.set_option('gui/columns', columns)
+        self.playlist_columns = columns  # Store via public property, so that setting also gets saved, if neccessary
 
     def on_column_clicked(self, column):
         if self.model.data_loading:
@@ -1227,7 +1302,20 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
             self.playlist.sort(self._sort_columns, reverse=reverse)
 
     def on_option_set(self, typ, obj, data):
-        if data == "gui/columns" or data == 'gui/playlist_font':
+        if self._global_playlist_columns:
+            column_width_prefix = 'gui/col_width_'
+            if data == 'gui/columns':
+                self.playlist_columns = settings.get_option(
+                    'gui/columns', playlist_columns.DEFAULT_COLUMNS
+                )
+            elif data == 'gui/resizable_cols':
+                self.resizable_cols = settings.get_option('gui/resizable_cols', False)
+            elif data.startswith(column_width_prefix):
+                name = data[len(column_width_prefix) :]
+                width = settings.get_option(data)
+                self.set_playlist_column_width(name, width)
+
+        if data == 'gui/playlist_font':
             self._refresh_columns()
 
     def on_playback_start(self, type, player, track):
@@ -1752,28 +1840,30 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
         """
             Called when a column provider is removed
         """
-        columns = settings.get_option('gui/columns')
 
+        columns = self.playlist_columns
         if provider.name in columns:
             columns.remove(provider.name)
-            settings.set_option('gui/columns', columns)
+            self.playlist_columns = (
+                columns  # Commit change by explicitly setting the public property
+            )
 
 
 class PlaylistModel(Gtk.ListStore):
     '''
         This ListStore contains all the information needed to render a playlist
         via a PlaylistView. There are five columns:
-        
+
         * xl.trax.Track
         * dictionary (tag cache)
         * Gdk.Pixbuf (indicates whether track is playing or not)
         * boolean (indicates whether row is sensitive)
         * Pango.Weight (indicates if row is the playing track or not)
-        
+
         The cache keys correspond to the tags rendered by each column. When a
         track changes, the row's corresponding cache is cleared and the row
         change event is fired.
-        
+
         The cache keys are populated by the playlist columns. This arrangement
         ensures that we don't have to recreate the playlist model each time the
         columns are changed.

--- a/xlgui/widgets/playlist_columns.py
+++ b/xlgui/widgets/playlist_columns.py
@@ -760,12 +760,6 @@ def __register_playlist_columns_menuitems():
         Registers standard menu items for playlist columns
     """
 
-    def is_column_selected(name, parent, context):
-        """
-            Returns whether a menu item should be checked
-        """
-        return name in settings.get_option('gui/columns', DEFAULT_COLUMNS)
-
     def is_resizable(name, parent, context):
         """
             Returns whether manual or automatic sizing is requested
@@ -776,19 +770,6 @@ def __register_playlist_columns_menuitems():
             return resizable
         elif name == 'autosize':
             return not resizable
-
-    def on_column_item_activate(menu_item, name, parent, context):
-        """
-            Updates columns setting
-        """
-        columns = settings.get_option('gui/columns', DEFAULT_COLUMNS)
-
-        if name in columns:
-            columns.remove(name)
-        else:
-            columns.append(name)
-
-        settings.set_option('gui/columns', columns)
 
     def on_sizing_item_activate(menu_item, name, parent, context):
         """

--- a/xlgui/widgets/playlist_columns.py
+++ b/xlgui/widgets/playlist_columns.py
@@ -798,6 +798,20 @@ def __register_playlist_columns_menuitems():
         elif name == 'autosize':
             parent.resizable_cols = False
 
+    def use_global_columns_settings(name, parent, context):
+        """
+            Returns whether playlist is using global columns settings.
+        """
+
+        return parent.global_playlist_columns
+
+    def on_global_columns_settings_activate(menu_item, name, parent, context):
+        """
+            Updates the flag for use of global columns settings.
+        """
+
+        parent.global_playlist_columns = menu_item.get_active()
+
     columns = [
         'tracknumber',
         'title',
@@ -815,6 +829,20 @@ def __register_playlist_columns_menuitems():
 
     menu_items = []
     after = []
+
+    global_columns_item = menu.check_menu_item(
+        'global-columns',
+        after,
+        _('Global columns settings'),
+        use_global_columns_settings,
+        on_global_columns_settings_activate,
+    )
+    menu_items += [global_columns_item]
+    after = [global_columns_item.name]
+
+    separator_item = menu.simple_separator('global_columns_separator', after)
+    menu_items += [separator_item]
+    after = [separator_item.name]
 
     for name in columns:
         column = providers.get_provider('playlist-columns', name)


### PR DESCRIPTION
This PR implements an option to detach the playlist's column settings from the global state, and use private playlist-specific settings instead. The switch is added at the top of the columns context menu.

My primary use case is having the default columns (#, Title, Album, Artist, Length) for album-based playlists, and having only Title and Artist for custom-made playlists.

This involves reworking of how the column settings are managed; instead of direct access to the properties in the settings handle, the settings are now managed by the `PlaylistView` object in the GUI/widgets layer. However, to minimize the changes on the playlist save/restore codepath, the settings are also mirrored to the underlying `xl.playlist.Playlist` for storage purposes. I'm not entirely happy with this design, but it seems less intrusive than either trying to serialize/deserialize the column settings at the GUI layer, or trying to push the settings management all the way down to the `xl.playlist.Playlist`.
