### PR TITLE
daapclient: python-zeroconf support

### DIFF
--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -164,7 +164,7 @@ class DaapAvahiInterface(GObject.GObject):  # derived from python-daap/examples
         '''
         if self.menu:
             for item in self.menu._items:
-                if item.name == 'manual' or item.name == 'sep':
+                if item.name in ('manual', 'history', 'sep'):
                     continue
                 self.menu.remove_item(item)
 

--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -163,9 +163,12 @@ class DaapAvahiInterface(GObject.GObject):  # derived from python-daap/examples
             This function is used to clear all the menu items out of a menu.
         '''
         if self.menu:
-            for item in self.menu._items:
-                if item.name in ('manual', 'history', 'sep'):
-                    continue
+            items_to_remove = [
+                item
+                for item in self.menu._items
+                if item.name not in ('manual', 'history', 'sep')
+            ]
+            for item in items_to_remove:
                 self.menu.remove_item(item)
 
     def rebuild_share_menu_items(self):

--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -141,7 +141,6 @@ class DaapAvahiInterface(GObject.GObject):  # derived from python-daap/examples
         nstr = '%s%s%s%s%s' % (interface, protocol, name, type, domain)
 
         if nstr in self.services:
-            #            self.remove_share_menu_item(name)
             del self.services[nstr]
             self.rebuild_share_menu_items()
 
@@ -158,17 +157,6 @@ class DaapAvahiInterface(GObject.GObject):  # derived from python-daap/examples
                 name, ['sep'], name, callback=lambda *_x: self.clicked(key)
             )
             self.menu.add_item(menu_item)
-
-    def remove_share_menu_item(self, name):
-        '''
-            This function is called to remove a server from the connect menu.
-        '''
-
-        if self.menu:
-            for item in self.menu._items:
-                if item.name == name:
-                    self.menu.remove_item(item)
-                    break
 
     def clear_share_menu_items(self):
         '''

--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -219,7 +219,7 @@ class DaapAvahiInterface(GObject.GObject):  # derived from python-daap/examples
     def clicked(self, key):
         '''
             This function is called in response to a menu_item click.
-        Fire away.
+            Fire away.
         '''
         x = self.services[key]
         GObject.idle_add(self.emit, "connect", (x.name, x.address, x.port))
@@ -340,7 +340,7 @@ class DaapZeroconfInterface(GObject.GObject):
     def clicked(self, service_name, address, port):
         '''
             This function is called in response to a menu_item click.
-        Fire away.
+            Fire away.
         '''
         GObject.idle_add(self.emit, "connect", (service_name, address, port))
 
@@ -468,8 +468,8 @@ class DaapManager:
     def connect_share(self, obj, args):
         '''
             This function is called when a user wants to connec to
-        a DAAP share.  It creates a new panel for the share, and
-        requests a track list.
+            a DAAP share.  It creates a new panel for the share, and
+            requests a track list.
             `args` is a tuple of (name, address, port, service)
         '''
         name, address, port = args  # unpack tuple
@@ -493,7 +493,7 @@ class DaapManager:
     def disconnect_share(self, name):
         '''
             This function is called to disconnect a previously connected
-        share.  It calls the DAAP disconnect, and removes the panel.
+            share.  It calls the DAAP disconnect, and removes the panel.
         '''
 
         panel = self.panels[name]
@@ -506,8 +506,8 @@ class DaapManager:
     def manual_connect(self, *_args):
         '''
             This function is called when the user selects the manual
-        connection option from the menu.  It requests a host/ip to connect
-        to.
+            connection option from the menu.  It requests a host/ip to
+            connect to.
         '''
         dialog = dialogs.TextEntryDialog(
             _("Enter IP address and port for share"), _("Enter IP address and port.")
@@ -561,7 +561,7 @@ class DaapManager:
     def close(self, remove=False):
         '''
             This function disconnects active DaapConnections, and optionally
-        removes the panels from the UI.
+            removes the panels from the UI.
         '''
         # disconnect active shares
         for panel in self.panels.values():
@@ -742,7 +742,7 @@ You must stop playback before downloading songs."""
 class DaapLibrary(collection.Library):
     '''
         Library subclass for better management of collection??
-    Or something to do with devices or somesuch.  Ask Aren.
+        Or something to do with devices or somesuch. Ask Aren.
     '''
 
     def __init__(self, daap_share, col=None):

--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -208,7 +208,7 @@ class DaapAvahiInterface(GObject.GObject):  # derived from python-daap/examples
         Fire away.
         '''
         x = self.services[key]
-        GObject.idle_add(self.emit, "connect", (x.name, x.address, x.port, x))
+        GObject.idle_add(self.emit, "connect", (x.name, x.address, x.port))
 
     def __init__(self, _exaile, _menu):
         """
@@ -325,7 +325,7 @@ class DaapManager:
         requests a track list.
             `args` is a tuple of (name, address, port, service)
         '''
-        name, address, port, _svc = args  # unpack tuple
+        name, address, port = args  # unpack tuple
         user_agent = self.exaile.get_user_agent_string(__name__)
         conn = DaapConnection(name, address, port, user_agent)
 


### PR DESCRIPTION
Fedora 32 dropped python3-avahi, so this might be a good opportunity to enable DAAP share discovery via python-zeroconf.

The PR contains fixes for some subtle menu-management issues in the existing Avahi backend, an addition of a zeroconf-based backend, and a subsequent extension to accomodate older python-zeroconf versions. As #517 indicates that we may want to drop the Avahi backend altogether, no attempt has been made to consolidate the shared/duplicated code between both backends.

Tested with python-zeroconf v.0.25.1 on Fedora 32, and with v.0.17.6 and v.0.21.3 on Debian Buster.

Fixes #517.