### PR TITLE
track._MetadataCacher: Fix error when the time is the same

### DIFF
--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -27,6 +27,7 @@
 
 from copy import deepcopy
 import logging
+import operator
 import re
 import time
 from typing import List, Union
@@ -108,7 +109,7 @@ class _MetadataCacher:
         item = [trackobj, formatobj, time.time()]
         self._cache.append(item)
         if len(self._cache) > self.maxentries:
-            least = min((i[2], i) for i in self._cache)[1]
+            least = min(self._cache, key=operator.itemgetter(2))
             self._cache.remove(least)
         if not self._cleanup_id:
             self._cleanup_id = GLib.timeout_add_seconds(self.timeout, self.__cleanup)


### PR DESCRIPTION
If tracks are added to the cacher fast enough, multiple entries can have
the same time (i[2]). This then causes the min((i[2], i) ...) call to end
up comparing the track objects (i[0]), causing a spurious error preventing
the Track Properties dialog from opening:

    TypeError: '<' not supported between instances of 'Track' and 'Track'

After this change, the code will pick any arbitrary item with the lowest
time value.