### PR TITLE
xlgui: collection manager dialog: disallow addition of duplicated locations

### DIFF
--- a/xlgui/collection.py
+++ b/xlgui/collection.py
@@ -130,7 +130,9 @@ class CollectionManagerDialog(Gtk.Dialog):
                 # monitored = row[1]
                 # scan_on_startup = row[2]
 
-                if location.has_prefix(library_location):
+                if location.equal(library_location) or location.has_prefix(
+                    library_location
+                ):
                     self.message.show_warning(
                         _('Directory not added.'),
                         _(


### PR DESCRIPTION
The collection manager dialog disallows addition of locations that are subdirectories of locations already existing in collection,
but does not disallow addition of location that is the same as a location that already exists in collection.

This is because a Gio.File is not a prefix of itself, so we also need to check for equality using Gio.File.equal().