### PR TITLE
widgets/playlist: On dropping tracks, always scroll to them

### DIFF
--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -1673,12 +1673,15 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
         delete = context.get_selected_action() == Gdk.DragAction.MOVE
         context.finish(True, delete, etime)
 
-        scroll_when_appending_tracks = settings.get_option(
-            'gui/scroll_when_appending_tracks', False
-        )
-
-        if scroll_when_appending_tracks and tracks:
-            self.scroll_to_cell(self.playlist.index(tracks[-1]))
+        if tracks:
+            # HACK: If we don't do this, the view always scrolls to the top.
+            # https://github.com/exaile/exaile/issues/685
+            self.scroll_to_cell(
+                self.playlist.index(tracks[0]),
+                use_align=True,
+                row_align=0.25,
+                col_align=0,  # Not used
+            )
 
         # Restore state to `self.on_row_inserted` do not ignore inserted rows
         # see https://github.com/exaile/exaile/issues/487


### PR DESCRIPTION
This is a workaround for https://github.com/exaile/exaile/issues/685 ,
where DnD causes the view to scroll to the top. I can't figure out what
causes it, so let's go with a hack.

This change causes the view to scroll to the first of the dropped track,
putting it a quarter of the way from the top.

This makes the hidden `gui/scroll_when_appending_tracks` option (default:
False) obsolete because it's now the only supported behavior, so this
commit also removes that option. (The name of the option is misleading; it
only affects DnD.)

Fixes: https://github.com/exaile/exaile/issues/685
Closes: https://github.com/exaile/exaile/pull/684

---

@fuhry: Could you take a look at this and see if it addresses your issues?