### PR TITLE
Fix some Python, GTK, GIO, PyGObject deprecations

### DIFF
--- a/plugins/mainmenubutton/__init__.py
+++ b/plugins/mainmenubutton/__init__.py
@@ -90,15 +90,16 @@ class MainMenuButton(Gtk.ToggleButton, notebook.NotebookAction):
         builder = main.mainwindow().builder
 
         # Move menu items of the main menu to the internal menu
-        self.mainmenu = builder.get_object('mainmenu')
-        self.menu = Gtk.Menu()
-        self.menu.attach_to_widget(self, None)
-        self.menu.connect('deactivate', self.on_menu_deactivate)
+        self.mainmenu = mainmenu = builder.get_object('mainmenu')
+        self.menu = menu = Gtk.Menu()
+        menu.attach_to_widget(self, None)
+        menu.connect('deactivate', self.on_menu_deactivate)
 
-        for menuitem in self.mainmenu:
-            menuitem.reparent(self.menu)
+        for menuitem in mainmenu:
+            mainmenu.remove(menuitem)
+            menu.add(menuitem)
 
-        self.menu.show_all()
+        menu.show_all()
         self.show_all()
 
         self.connect('toggled', self.on_toggled)
@@ -114,8 +115,11 @@ class MainMenuButton(Gtk.ToggleButton, notebook.NotebookAction):
         """
         self.notebook.disconnect(self.notebook_page_removed_connection)
 
-        for menuitem in self.menu:
-            menuitem.reparent(self.mainmenu)
+        menu = self.menu
+        mainmenu = self.mainmenu
+        for menuitem in menu:
+            menu.remove(menuitem)
+            mainmenu.add(menuitem)
 
         self.unparent()
         Gtk.Button.destroy(self)

--- a/plugins/minimode/controls.py
+++ b/plugins/minimode/controls.py
@@ -43,7 +43,7 @@ def suppress(signal):
     def wrapper(function):
         def wrapped_function(self, *args, **kwargs):
             def on_event(sender, *args):
-                sender.stop_emission(signal)
+                sender.stop_emission_by_name(signal)
                 return True
 
             handler_id = self.connect(signal, on_event)

--- a/xl/migrations/database/__init__.py
+++ b/xl/migrations/database/__init__.py
@@ -24,17 +24,14 @@
 # do so. If you do not wish to do so, delete this exception statement
 # from your version.
 
-import imp
-import os
 from xl import common
 
 
 def handle_migration(db, pdata, oldversion, newversion):
     if oldversion == 1 and newversion == 2:
-        migrator = imp.load_source(
-            "from1to2", os.path.join(os.path.dirname(__file__), "from1to2.py")
-        )
-        migrator.migrate(db, pdata, oldversion, newversion)
+        from . import from1to2
+
+        from1to2.migrate(db, pdata, oldversion, newversion)
     else:
         raise common.VersionError(
             "Don't know how to handle upgrade from "

--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -395,10 +395,11 @@ class Track:
 
             # Retrieve file specific metadata
             gloc = Gio.File.new_for_uri(loc)
-            mtime = gloc.query_info(
-                "time::modified", Gio.FileQueryInfoFlags.NONE, None
-            ).get_modification_time()
-            mtime = mtime.tv_sec + (mtime.tv_usec / 100000.0)
+            mtime = (
+                gloc.query_info("time::modified", Gio.FileQueryInfoFlags.NONE, None)
+                .get_modification_date_time()
+                .to_unix()
+            )
 
             if not force and self.__tags.get('__modified', 0) >= mtime:
                 return f

--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -395,11 +395,17 @@ class Track:
 
             # Retrieve file specific metadata
             gloc = Gio.File.new_for_uri(loc)
-            mtime = (
-                gloc.query_info("time::modified", Gio.FileQueryInfoFlags.NONE, None)
-                .get_modification_date_time()
-                .to_unix()
-            )
+            if hasattr(Gio.FileInfo, 'get_modification_date_time'):  # GLib >=2.62
+                mtime = (
+                    gloc.query_info("time::modified", Gio.FileQueryInfoFlags.NONE, None)
+                    .get_modification_date_time()
+                    .to_unix()
+                )
+            else:  # Deprecated due to the Year 2038 problem
+                mtime = gloc.query_info(
+                    "time::modified", Gio.FileQueryInfoFlags.NONE, None
+                ).get_modification_time()
+                mtime = mtime.tv_sec + (mtime.tv_usec / 100000.0)
 
             if not force and self.__tags.get('__modified', 0) >= mtime:
                 return f

--- a/xlgui/widgets/common.py
+++ b/xlgui/widgets/common.py
@@ -267,7 +267,7 @@ class DragTreeView(AutoScrollTreeView):
 
         if source:
             self.connect('drag-data-get', self.container.drag_get_data)
-            self.drag_source_set_icon_stock(Gtk.STOCK_DND)
+            self.drag_source_set_icon_name('gtk-dnd')
 
     def get_selected_tracks(self):
         """

--- a/xlgui/widgets/dialogs.py
+++ b/xlgui/widgets/dialogs.py
@@ -51,14 +51,17 @@ from threading import Thread
 logger = logging.getLogger(__name__)
 
 
-def error(parent, message=None, markup=None, _flags=Gtk.DialogFlags.MODAL):
+def error(parent, message=None, markup=None):
     """
     Shows an error dialog
     """
     if message is markup is None:
         raise ValueError("message or markup must be specified")
     dialog = Gtk.MessageDialog(
-        parent, _flags, Gtk.MessageType.ERROR, Gtk.ButtonsType.CLOSE
+        buttons=Gtk.ButtonsType.CLOSE,
+        message_type=Gtk.MessageType.ERROR,
+        modal=True,
+        transient_for=parent,
     )
     if markup is None:
         dialog.props.text = message
@@ -75,7 +78,10 @@ def info(parent, message=None, markup=None):
     if message is markup is None:
         raise ValueError("message or markup must be specified")
     dialog = Gtk.MessageDialog(
-        parent, Gtk.DialogFlags.MODAL, Gtk.MessageType.INFO, Gtk.ButtonsType.OK
+        buttons=Gtk.ButtonsType.OK,
+        message_type=Gtk.MessageType.INFO,
+        modal=True,
+        transient_for=parent,
     )
     if markup is None:
         dialog.props.text = message
@@ -88,10 +94,10 @@ def info(parent, message=None, markup=None):
 def yesno(parent, message):
     '''Gets a Yes/No response from a user'''
     dlg = Gtk.MessageDialog(
-        parent=parent,
-        type=Gtk.MessageType.QUESTION,
         buttons=Gtk.ButtonsType.YES_NO,
-        message_format=message,
+        message_type=Gtk.MessageType.QUESTION,
+        text=message,
+        transient_for=parent,
     )
     response = dlg.run()
     dlg.destroy()
@@ -1098,10 +1104,10 @@ class ConfirmCloseDialog(Gtk.MessageDialog):
 
 class MessageBar(Gtk.InfoBar):
     type_map = {
-        Gtk.MessageType.INFO: Gtk.STOCK_DIALOG_INFO,
-        Gtk.MessageType.QUESTION: Gtk.STOCK_DIALOG_QUESTION,
-        Gtk.MessageType.WARNING: Gtk.STOCK_DIALOG_WARNING,
-        Gtk.MessageType.ERROR: Gtk.STOCK_DIALOG_ERROR,
+        Gtk.MessageType.INFO: 'dialog-information',
+        Gtk.MessageType.QUESTION: 'dialog-question',
+        Gtk.MessageType.WARNING: 'dialog-warning',
+        Gtk.MessageType.ERROR: 'dialog-error',
     }
     buttons_map = {
         Gtk.ButtonsType.OK: [(Gtk.STOCK_OK, Gtk.ResponseType.OK)],
@@ -1311,7 +1317,7 @@ class MessageBar(Gtk.InfoBar):
             Gtk.MessageType.ERROR.
         """
         if type != Gtk.MessageType.OTHER:
-            self.image.set_from_stock(self.type_map[type], Gtk.IconSize.DIALOG)
+            self.image.set_from_icon_name(self.type_map[type], Gtk.IconSize.DIALOG)
 
         Gtk.InfoBar.set_message_type(self, type)
 

--- a/xlgui/widgets/info.py
+++ b/xlgui/widgets/info.py
@@ -50,7 +50,8 @@ class TrackInfoPane(Gtk.Bin):
         builder.add_from_file(xdg.get_data_path('ui', 'widgets', 'track_info.ui'))
 
         info_box = builder.get_object('info_box')
-        info_box.reparent(self)
+        info_box.get_parent().remove(info_box)
+        self.add(info_box)
 
         self.__auto_update = False
         self.__display_progress = False

--- a/xlgui/widgets/notebook.py
+++ b/xlgui/widgets/notebook.py
@@ -232,7 +232,6 @@ class NotebookTab(Gtk.EventBox):
             border = Gtk.Border.new()
             border.left = 1
             border.right = 1
-            entry.set_inner_border(border)
             entry.connect('activate', self.on_entry_activate)
             entry.connect('focus-out-event', self.on_entry_focus_out_event)
             entry.connect('key-press-event', self.on_entry_key_press_event)

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -484,7 +484,8 @@ class PlaylistPage(PlaylistPageBase):
 
         for child in playlist_page.get_children():
             packing = playlist_page.query_child_packing(child)
-            child.reparent(self)
+            playlist_page.remove(child)
+            self.add(child)
             self.set_child_packing(child, *packing)
 
         self.shuffle_button = self.builder.get_object("shuffle_button")
@@ -855,7 +856,6 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
         self.dragdrop_copyonly = False
 
         self.set_fixed_height_mode(True)  # MASSIVE speedup - don't disable this!
-        self.set_rules_hint(True)
         self.set_enable_search(True)
         self.selection = self.get_selection()
         self.selection.set_mode(Gtk.SelectionMode.MULTIPLE)
@@ -1508,7 +1508,7 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
         Stops the default handler from running, all
         processing occurs in the drag-data-received handler
         """
-        self.stop_emission('drag-data-delete')
+        self.stop_emission_by_name('drag-data-delete')
 
     def on_drag_end(self, widget, context):
         """
@@ -1529,7 +1529,7 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
         external URIs and inserts or appends them to the playlist
         """
         # Stop default handler from running
-        self.stop_emission('drag-data-received')
+        self.stop_emission_by_name('drag-data-received')
 
         # Makes `self.on_row_inserted` to ignore inserted rows
         # see https://github.com/exaile/exaile/issues/487


### PR DESCRIPTION
Python:

* imp: Obsoleted by importlib, but let's just use normal import.

GTK:

* Entry.set_inner_border: We're supposed to use CSS, but things look fine
  on Adwaita so we'll do without it for now.
* TreeView.set_rules_hint: No replacement, seems to already do nothing.
* Widget.drag_source_set_icon_stock: Use ..._set_icon_name.
* Image.set_from_stock: Use set_from_icon_name.
* Widget.reparent: Use remove+add.

GIO:

* FileInfo.get_modification_time: Use get_modification_date_time.

PyGObject:

* Gtk.Widget.stop_emission: Use stop_emission_by_name,
* Gtk.MessageDialog constructor args: Use GObject property construction.