### PR TITLE
Set LC_ALL=C on `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ test_compile:
 	$(MAKE) -C $(BUILD_DIR) all
 
 test:
-	EXAILE_DIR=$(shell pwd) PYTHONPATH=$(shell pwd) $(PYTEST) tests
+	EXAILE_DIR=$(shell pwd) LC_ALL=C PYTHONPATH=$(shell pwd) $(PYTEST) tests
 
 test_coverage:
 	rm -rf coverage/


### PR DESCRIPTION
This prevents having the tests use / rely on translated strings.

Fixes: https://github.com/exaile/exaile/issues/735