### PR TITLE
Allow tools/plugin_tool.py run without PyGObject/GLib

### DIFF
--- a/tools/plugin_tool.py
+++ b/tools/plugin_tool.py
@@ -53,8 +53,6 @@ if __name__ == '__main__':
     os.environ['EXAILE_DIR'] = exaile_dir
     sys.path.insert(0, exaile_dir)
 
-    import xl.xdg
-    xl.xdg.local_hack = False
     import xl.version
     v = '%s' % (xl.version.__version__.split("-")[0])
 

--- a/xl/version.py
+++ b/xl/version.py
@@ -28,11 +28,15 @@ import logging
 import os
 from typing import Dict
 
-from . import xdg
-
 logger = logging.getLogger(__name__)
 
 __version__ = "devel"
+
+# We need the local hack for OSX bundled apps, so we depend on the main script
+# to set the environment variable correctly instead of trying to infer an
+# absolute path
+# exaile_dir = os.path.split(os.path.dirname(os.path.realpath(__file__)))[0]
+exaile_dir = os.environ['EXAILE_DIR']
 
 
 def get_current_version():
@@ -77,7 +81,7 @@ def get_current_revision():
 
 if "DIST_VERSION" in os.environ:
     __version__ = os.environ['DIST_VERSION']
-elif os.path.exists(os.path.join(xdg.exaile_dir, ".git")):
+elif os.path.exists(os.path.join(exaile_dir, ".git")):
     version = get_current_version()
     if version is not None:
         __version__ = version

--- a/xl/xdg.py
+++ b/xl/xdg.py
@@ -28,11 +28,9 @@ import os
 import sys
 from gi.repository import GLib
 
-# We need the local hack for OSX bundled apps, so we depend on the main script
-# to set the environment variable correctly instead of trying to infer an
-# absolute path
-# exaile_dir = os.path.split(os.path.dirname(os.path.realpath(__file__)))[0]
-exaile_dir = os.environ['EXAILE_DIR']
+# exaile_dir is now defined in xl.version, but most of the codebase
+# still accessed it via xl.xdg.exaile_dir
+from .version import exaile_dir
 
 homedir = os.path.expanduser("~")
 lastdir = homedir


### PR DESCRIPTION
Allows `plugin_tool.py` to import `xl.xdg`, which enables creation of distribution tarball in an environment that does not have `PyGObject` installed.