### PR TITLE
trax/util.is_valid_track: Change new_for_uri to new_for_commandline_arg

### DIFF
--- a/xl/trax/util.py
+++ b/xl/trax/util.py
@@ -45,7 +45,7 @@ def is_valid_track(location):
     :returns: whether the file is a valid track
     :rtype: boolean
     """
-    extension = Gio.File.new_for_uri(location).get_basename().split(".")[-1]
+    extension = Gio.File.new_for_commandline_arg(location).get_basename().split(".")[-1]
     return extension.lower() in metadata.formats
 
 


### PR DESCRIPTION
In Exaile core this is always called with a URI so it works, but the tests
call it with a local file path and we get test failures. (It must have
worked in earlier GIO versions, because our CI doesn't catch this.)

trax.Track uses new_for_commandline_arg for its location argument, so this
should be correct.

Fixes: https://github.com/exaile/exaile/issues/750