### PR TITLE
Use the correct address for the FSF

### DIFF
--- a/plugins/lyricsmania/__init__.py
+++ b/plugins/lyricsmania/__init__.py
@@ -11,7 +11,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 try:
     import lxml.html

--- a/plugins/somafm/__init__.py
+++ b/plugins/somafm/__init__.py
@@ -11,7 +11,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import logging
 import operator


### PR DESCRIPTION
A couple of plugins are using the wrong address for the FSF in their license text