### PR TITLE
Remove shebangs from plugins installed without execute perms

### DIFF
--- a/plugins/bpm/bpmdetect.py
+++ b/plugins/bpm/bpmdetect.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 '''
     Simple program that uses the 'bpmdetect' GStreamer plugin to detect
     the BPM of a song, and outputs that to console.

--- a/plugins/ipconsole/ipython_view.py
+++ b/plugins/ipconsole/ipython_view.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 '''
 Provides IPython console widget.
 


### PR DESCRIPTION
These plugins are installed through the Makefile without execute permissions and so have redundant shebangs at the top of the file.  The shebangs may be useful during development but in that case the developer can explicitly call python to run the file anyway.