### PR TITLE
Bugfix Unable to sort a playlist with rating value #758

### DIFF
--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -654,6 +654,8 @@ class Track:
         elif tag == '__basename':
             # TODO: Check if unicode() is required
             value = self.get_basename()
+        elif tag == '__rating':
+            value = self.get_rating()
         else:
             value = self.__tags.get(tag)
 


### PR DESCRIPTION
Hello Johannes,

this problem happens in case that there is a track with none rating.
In the case the get_tag_sort function returns None.
Instead the track function get_rating should be used, shouldn't it?