### PR TITLE
CI: Update to testing with Fedora 34

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         imgtag:
           - debian-10
           - debian-stable
-          - fedora-33
+          - fedora-34
           - fedora-latest
           - ubuntu-18.04
           - ubuntu-rolling


### PR DESCRIPTION
Fedora 33 is EOL, see the Fedora 35 schedule:
https://fedorapeople.org/groups/schedule/f-35/f-35-key-tasks.html