### PR TITLE
tests: remove mox3 dependency

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -112,6 +112,5 @@ BPM Counter plugin:
 
 Test dependencies:
 
-* mox3 (python3)
 * pytest (python3)
 

--- a/tests/xl/trax/test_util.py
+++ b/tests/xl/trax/test_util.py
@@ -1,7 +1,5 @@
 import unittest
 
-from mox3 import mox
-
 from gi.repository import Gio
 
 import xl.collection
@@ -34,12 +32,6 @@ class TestGetTracksFromUri:
 
         def get_file_type(self):
             return self.retval
-
-    def setup(self):
-        self.mox = mox.Mox()
-
-    def teardown(self):
-        self.mox.UnsetStubs()
 
     def get_anything(self, file_type):
         anything = self.mox.CreateMockAnything()


### PR DESCRIPTION
- Fixes #817

Note that the tests in test_util.py still use mox, but... they're all skipped because I never fixed them previously, so I guess it's ok to keep them skipped? Not 100% sure what the tests were supposed to do. 