### PR TITLE
makefile: append directory to existing PYTHONPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ test_compile:
 	$(MAKE) -C $(BUILD_DIR) all
 
 test:
-	EXAILE_DIR=$(shell pwd) LC_ALL=C PYTHONPATH=$(shell pwd) $(PYTEST) tests
+	EXAILE_DIR=$(shell pwd) LC_ALL=C PYTHONPATH=$(shell pwd):$(PYTHONPATH) $(PYTEST) tests
 
 test_coverage:
 	rm -rf coverage/


### PR DESCRIPTION
Without doing this I get:

    ImportError while loading conftest '/path/to/exaile/tests/conftest.py'.
    tests/conftest.py:7: in <module>
        from gi.repository import Gio
    E   ModuleNotFoundError: No module named 'gi'