### PR TITLE
SPAT: leave next track ready to play. Fix #767.

### DIFF
--- a/xl/playlist.py
+++ b/xl/playlist.py
@@ -1170,9 +1170,11 @@ class Playlist:
         repeat_mode = self.repeat_mode
         shuffle_mode = self.shuffle_mode
         next_index = -1
-        if current_position == self.spat_position and current_position != -1:
-            self.__next_data = (True, None, None)
-            return None
+        spat = (
+            True
+            if current_position == self.spat_position and current_position != -1
+            else False
+        )
 
         if repeat_mode == 'track':
             next_index = None
@@ -1203,7 +1205,7 @@ class Playlist:
                 if len(self) > 1:
                     return self.__get_next(-1)
 
-        self.__next_data = (False, next_index, next)
+        self.__next_data = (spat, next_index, next)
         return next
 
     def get_next(self):
@@ -1234,16 +1236,16 @@ class Playlist:
 
         spat, index, next = self.__next_data
 
-        if spat:
-            self.spat_position = -1
-            return None
-        elif index is not None:
+        if index is not None:
             try:
                 self.current_position = index
             except IndexError:
                 self.current_position = -1
         else:
             self.__next_data = None
+        if spat:
+            self.spat_position = -1
+            return None
 
         return self.current
 

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -904,6 +904,12 @@ class PlaylistView(AutoScrollTreeView, providers.ProviderHandler):
             self.player,
             destroy_with=self,
         )
+        event.add_ui_callback(
+            self.on_playback_start,
+            "playlist_track_next",
+            self.player,
+            destroy_with=self,
+        )
         self._cursor_changed = self.connect("cursor-changed", self.on_cursor_changed)
         self.connect("row-activated", self.on_row_activated)
         self.connect("key-press-event", self.on_key_press_event)


### PR DESCRIPTION
This branch is based on #820.

<s>With these changes the behavior is as I would expect, except the play/pause button gets left with the pause symbol showing when it is in a stopped state and the button actually behaves as a play button.</s> (fixed)

I do not believe there is any way to accomplish proper SPAT behavior
from within the playlist/queue, so we need to add the ability to
propagate a command to stop up to the engine.