### PR TITLE
Select correct playlist and track if starting with option resume_playback and gui

### DIFF
--- a/xl/main.py
+++ b/xl/main.py
@@ -767,10 +767,15 @@ class Exaile:
             # -> don't do it in command line mode, since that isn't expected
             self.gui.rescan_collection_with_progress(True)
 
-        if restore:
+        restore_play_state = settings.get_option("player/resume_playback", True)
+
+        if restore and restore_play_state:
             player.QUEUE._restore_player_state(
                 os.path.join(xdg.get_data_dir(), 'player.state')
             )
+
+            if self.gui:
+                self.gui.get_playlist_container().show_current_track()
 
         # pylint: enable-msg=W0201
 

--- a/xl/player/queue.py
+++ b/xl/player/queue.py
@@ -344,4 +344,6 @@ class PlayQueue(playlist.Playlist):
                 "%s/resume_paused" % self.player._name, False
             )
 
-            self.player.play(self.get_current(), start_at=start_at, paused=paused)
+            self.player.play(
+                self.current_playlist.get_current(), start_at=start_at, paused=paused
+            )

--- a/xlgui/__init__.py
+++ b/xlgui/__init__.py
@@ -347,6 +347,9 @@ class Main:
         """
         return self.panel_notebook.panels[panel_name].panel
 
+    def get_playlist_container(self):
+        return self.main.playlist_container
+
     def quit(self):
         """
         Quits the gui, saving anything that needs to be saved


### PR DESCRIPTION
I have the option resume_playback enabled and use queue and playlist

If I play a track in the playlist and close Exaile, after a restart the track in the playlist is neither selected nor played.
Instead the last selected track in queue is played.