### PR TITLE
xl/trax: search_tracks: remove time.sleep(0)

### DIFF
--- a/xl/trax/search.py
+++ b/xl/trax/search.py
@@ -24,7 +24,6 @@
 # do so. If you do not wish to do so, delete this exception statement
 # from your version.
 
-import time
 import re
 from typing import Collection
 
@@ -536,14 +535,6 @@ def search_tracks(trackiter, trackmatchers: Collection[TracksMatcher]):
             srtr = SearchResultTrack(srtr)
         if all(tma.match(srtr) for tma in trackmatchers):
             yield srtr
-
-        # On large collections, searching can take a while. Due to
-        # peculiarities in python's GIL that means the now-cpu-bound
-        # thread running the search can end up blocking other threads.
-        # Calling out to time.sleep forces a release of the GIL and
-        # allows other threads to run. Benchmarks show this has no
-        # noticeable effect on search speed.
-        time.sleep(0)
 
 
 def search_tracks_from_string(


### PR DESCRIPTION
~When processing the tracks in `search_tracks` generator, yield the current thread's timeslice only when running in the secondary (non-main) thread. This prevents unnecessary slow-downs in the main thread, where we want to finish the operation as fast as possible (especially under python 3.11 on linux, where `time.sleep(0)` introduced additional overhead).~

When processing the tracks in `search_tracks` generator, do not explicitly yield the current thread's time-slice via `time.sleep(0)`.
    
Removal of sleep call prevents unnecessary slow-downs in the main thread, where we want to finish the operation as fast as possible (especially under python 3.11 on linux, where `time.sleep(0)` introduced additional overhead).
    
The comment accompanying the sleep call refers to GIL behavior, which might have been applicable in python2-era, but does not seem to be applicable to python3 anymore.

Fixes #832.