### PR TITLE
Fix typos

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -55,7 +55,7 @@ Environment variables that affect "make install":
     The full path to the lib directory.
     Default: ``EPREFIX/lib``
   DATADIR
-    The full path to non-arcitecture dependent data files.
+    The full path to non-architecture dependent data files.
     Default: ``PREFIX/share``
   MANPREFIX
     The full path to the parent of the man page installation directory (same
@@ -84,5 +84,3 @@ Environment variables that affect "make install":
 
 Additional Resources:
 1. `XDG Base Directory Specification <https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_
-
-

--- a/doc/dev/debugging.rst
+++ b/doc/dev/debugging.rst
@@ -175,7 +175,7 @@ Debugging segfaults (segmentation violations)
 3. Run ``gdb /usr/bin/python3``
 4. In gdb, run ``set logging on exaile-segfault.txt`` to enable logging to that file.
 5. In gdb, run ``run ./exaile.py --startgui``. You might append other arguments if you need them.
-6. Use Exaile as you did before and try to reproduce the problem. At some point, exaile might freeze. This is when gdb catched the segmentation fault.
+6. Use Exaile as you did before and try to reproduce the problem. At some point, exaile might freeze. This is when gdb caught the segmentation fault.
 7. In gdb, run ``t a a py-bt`` and ``t a a bt full``. The first one will get python backtraces from all threads, the second one will get native (C/C++) stacktraces. You might need to type the return key a few times after each of these two commands to make gdb print all lines of the stack traces. This might take a while.
 8. In gdb, type ``quit`` and press the enter key.
 9. Please attach the file ``exaile-segfault.txt`` to a bug report at `Github <https://github.com/exaile/exaile/issues/new>`_ after you checked that it does not contain any private data. If you prefer to send the data encrypted, please feel free to encrypt them to the PGP key ID 0x545B42FB8713DA3B and send it to one of its Email addresses.

--- a/doc/dev/plugin_guide.rst
+++ b/doc/dev/plugin_guide.rst
@@ -401,7 +401,7 @@ of trying to explain it:
     settings.set_option('plugin/pluginname/settingname', setting_value)
     
     #to get a setting
-    default_value = 'If the setting doesnt exist, I am the default value.'
+    default_value = 'If the setting doesn't exist, I am the default value.'
     retrieved_setting = settings.get_option('plugin/pluginname/settingname', default_value)
 
 That's all there is to it. There is a few restrictions as to the
@@ -410,7 +410,7 @@ datatypes you can save as settings, see ``xl/settings.py`` for more details.
 Searching the collection
 -------------------------
 
-The following method returns an list of similiar tracks to the current
+The following method returns an list of similar tracks to the current
 playing track:
 
 .. code-block:: python

--- a/plugins/bookmarks/__init__.py
+++ b/plugins/bookmarks/__init__.py
@@ -52,7 +52,7 @@ class Bookmark:
     ):
         """
         Creates a bookmark for current track/position if path or time are
-        None. Creates a bookmark for the given track/positon otherwise.
+        None. Creates a bookmark for the given track/position otherwise.
         """
         if not path:
             # get currently playing track

--- a/plugins/currentsong/PLUGININFO
+++ b/plugins/currentsong/PLUGININFO
@@ -1,6 +1,6 @@
 Version='4.1.2'
 Authors=['Aly Hirani <alyhirani@gmail.com>', 'Jorge Villaseñor <salinasv@gmail.com']
 Name=_('Current Song in Pidgin')
-Description=_('Sets the currently playing status in Pidgin. Check the Pidgin FAQ to find out the suppported services.')
+Description=_('Sets the currently playing status in Pidgin. Check the Pidgin FAQ to find out the supported services.')
 Category=_('Notifications')
 RequiredModules=['dbus']

--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -603,7 +603,7 @@ class DaapLibrary(collection.Library):
         self.scanning = False
         # return True
 
-    # Needed to be overriden for who knows why (exceptions)
+    # Needed to be overridden for who knows why (exceptions)
     def _count_files(self):
         count = 0
         if self.daap_share:

--- a/plugins/daapclient/client.py
+++ b/plugins/daapclient/client.py
@@ -252,7 +252,7 @@ class DAAPTrack:
 
     def request(self):
         """returns a 'response' object for the track's mp3 data.
-        presumably you can strem from this or something"""
+        presumably you can stream from this or something"""
 
         # gotta bump this every track download
         self.database.session.connection.request_id += 1

--- a/plugins/grouptagger/__init__.py
+++ b/plugins/grouptagger/__init__.py
@@ -120,7 +120,7 @@ class GroupTaggerPlugin:
             menu.simple_menu_item(
                 'gt_export',
                 [],
-                _('E_xport collecton tags to JSON'),
+                _('E_xport collection tags to JSON'),
                 callback=self.on_export_tags,
             )
         )

--- a/plugins/helloworld/__init__.py
+++ b/plugins/helloworld/__init__.py
@@ -30,7 +30,7 @@
 
         def enable(exaile):
             print("Hello, world!")
-            testlib.sucess()
+            testlib.success()
 
         def disable(exaile):
             print("Goodbye. :(")
@@ -82,7 +82,7 @@ class HelloWorld:
 
     def enable(self, exaile):
         print("Hello, world!")
-        testlib.sucess()
+        testlib.success()
 
     def disable(self, exaile):
         print("Goodbye. :(")

--- a/plugins/helloworld/testlib.py
+++ b/plugins/helloworld/testlib.py
@@ -25,5 +25,5 @@
 # from your version.
 
 
-def sucess():
+def success():
     print("w00t!")

--- a/plugins/inhibitsuspend/__init__.py
+++ b/plugins/inhibitsuspend/__init__.py
@@ -229,7 +229,7 @@ class PowerManagerAdapter(DbusSuspendAdapter):
     """
     Default Adapter, implemented by most desktop sessions
     Adapter for org.freedesktop.PowerManagement.Inhibit Interface
-    Some desktop sesssions use different bus names for this interface
+    Some desktop sessions use different bus names for this interface
     and have other small variances
     """
 
@@ -266,7 +266,7 @@ class GnomeAdapter(DbusSuspendAdapter):
 
     def _dbus_inhibit_call(self):
         """
-        Gnome Interface has more paramters
+        Gnome Interface has more parameters
         """
         self.cookie = self.iface.Inhibit(
             self.PROGRAM, 1, self.ACTIVITY, self.SUSPEND_FLAG

--- a/plugins/ipconsole/ipython_view.py
+++ b/plugins/ipconsole/ipython_view.py
@@ -290,7 +290,7 @@ class IterableIPShell:
 
     def _getHistory(self):
         """
-        Get's the command string of the current history level.
+        Gets the command string of the current history level.
 
         @return: Historic command string.
         @rtype: string
@@ -652,7 +652,7 @@ class IPythonView(ConsoleView, IterableIPShell):
 
     def raw_input(self, prompt=''):
         """
-        Custom raw_input() replacement. Get's current line from console buffer.
+        Custom raw_input() replacement. Gets current line from console buffer.
 
         @param prompt: Prompt to print. Here for compatibility as replacement.
         @type prompt: string

--- a/plugins/jamendo/__init__.py
+++ b/plugins/jamendo/__init__.py
@@ -89,7 +89,7 @@ class JamendoPanel(panel.Panel):
 
         self.setup_widgets()
 
-    # find out whats selected and add the tracks under it to the playlist
+    # find out what's selected and add the tracks under it to the playlist
     def add_to_playlist(self):
         sel = self.get_selected_item()
         if isinstance(sel, jamtree.Artist):
@@ -440,7 +440,7 @@ class JamendoCoverSearch(CoverSearchMethod):
     name = 'jamendo'
     use_cache = False  # do this since the tracks dont stay on local.
     fixed = True
-    fixed_priority = 5  # take precendence, since we know we are 'right'
+    fixed_priority = 5  # take precedence, since we know we are 'right'
     # for matching tracks.
 
     def __init__(self, user_agent):

--- a/plugins/lastfmlove/lastfmlove_preferences.py
+++ b/plugins/lastfmlove/lastfmlove_preferences.py
@@ -39,7 +39,7 @@ class APIKeyPreference(widgets.Preference):
     name = 'plugin/lastfmlove/api_key'
 
 
-class APISecretPrefence(widgets.Preference):
+class APISecretPreference(widgets.Preference):
     name = 'plugin/lastfmlove/api_secret'
 
 

--- a/plugins/minimode/__init__.py
+++ b/plugins/minimode/__init__.py
@@ -271,7 +271,7 @@ class MiniMode(Gtk.Window):
 
     def on_main_visible_toggle(self, main):
         """
-        Handles visiblity toggles in
+        Handles visibility toggles in
         Exaile's main window stead
         """
         if self.__active:

--- a/plugins/multialarmclock/__init__.py
+++ b/plugins/multialarmclock/__init__.py
@@ -47,7 +47,7 @@ def _init(prefsdialog, builder):
     logger.debug('_init() called')
     global MY_BUILDER, ALARM_CLOCK_MAIN
 
-    # note that we get a new builder everytime the prefs dialog is closed and re-opened
+    # note that we get a new builder every time the prefs dialog is closed and re-opened
     MY_BUILDER = builder
     if ALARM_CLOCK_MAIN is not None:
         ALARM_CLOCK_MAIN.init_ui(builder)

--- a/plugins/multialarmclock/cellrenderers.py
+++ b/plugins/multialarmclock/cellrenderers.py
@@ -133,7 +133,7 @@ class CellRendererDays(Gtk.CellRendererText):
 
     def _key_pressed(self, view, event):
         '''Key pressed event handler, finish editing on Return'''
-        # event == None for day selected via doubleclick
+        # event == None for day selected via double-click
         if (
             not event
             or event.type == Gdk.EventType.KEY_PRESS

--- a/plugins/osd/__init__.py
+++ b/plugins/osd/__init__.py
@@ -384,7 +384,7 @@ class OSDWindow(Gtk.Window):
         # Without decorations, the window cannot be resized on some desktops
         # this especially effects GNOME/Wayland and is probably caused by
         # missing client-side decorations (CSD). This code might break when
-        # using client side decorations. In this case, we probably shoud hide
+        # using client side decorations. In this case, we probably should hide
         # the titlebar instead of removing the decorations.
         # Removing decorations is ignored on some platforms to enable
         # the resize grid.

--- a/plugins/playlistanalyzer/extending.txt
+++ b/plugins/playlistanalyzer/extending.txt
@@ -43,7 +43,7 @@ The plugin treats the template as a giant string, and uses python format
 string functionality to substitute data into the template. 
 
 - Anything with a % in it should be %%
-- The following special strings will be subsituted
+- The following special strings will be substituted
 
     - %(data)s              - The data as JSON (see above for format)
     - %(title)s             - User defined title

--- a/plugins/replaygain/__init__.py
+++ b/plugins/replaygain/__init__.py
@@ -35,7 +35,7 @@ try:
     def get_preferences_pane():
         return replaygainprefs
 
-except Exception:  # fail gracefully if we cant set up the UI
+except Exception:  # fail gracefully if we can't set up the UI
     pass
 
 NEEDED_ELEMS = ["rgvolume", "rglimiter"]

--- a/plugins/shutdown/__init__.py
+++ b/plugins/shutdown/__init__.py
@@ -57,7 +57,7 @@ class Shutdown:
 
     def on_toggled(self, menuitem):
         """
-        Enables or disables defered shutdown
+        Enables or disables deferred shutdown
         """
         if menuitem.get_active():
             self.do_shutdown = True

--- a/tests/xl/trax/test_track.py
+++ b/tests/xl/trax/test_track.py
@@ -517,7 +517,7 @@ class TestTrack:
         tr.set_tag_raw('__bitrate', 48000)
         assert tr.get_tag_display('__bitrate') == '48k'
 
-    def test_get_display_tag_bitrate_bitrateless_formate(self, test_tracks):
+    def test_get_display_tag_bitrate_bitrateless_format(self, test_tracks):
         td = test_tracks.get('.flac')
         tr = track.Track(td.filename)
         assert tr.get_tag_display('__bitrate') == ''

--- a/tools/installer/exaile_installer.nsi
+++ b/tools/installer/exaile_installer.nsi
@@ -191,13 +191,13 @@ Function .onInit
             ; if it returns success proceede, otherwise abort the installer
             ; (uninstall aborted by user for example)
             ExecWait '"$INSTDIR\uninstall.exe" _?=$INSTDIR' $R1
-            ; uninstall suceeded, since the uninstall.exe is still there
+            ; uninstall succeeded, since the uninstall.exe is still there
             ; goto rm_instdir as well
             StrCmp $R1 0 rm_instdir
             ; uninstall failed
             Abort
         rm_instdir:
-            ; either the uninstaller was sucessfull or
+            ; either the uninstaller was successful or
             ; the uninstaller.exe wasn't found
             RMDir /r "$INSTDIR"
     do_continue:

--- a/tools/pylint.cfg
+++ b/tools/pylint.cfg
@@ -70,12 +70,12 @@ include-ids=yes
 # written in a file name "pylint_global.[txt|html]".
 files-output=no
 
-# Tells wether to display a full report or only the messages
+# Tells whether to display a full report or only the messages
 reports=no
 
 # Python expression which should return a note less than 10 (10 is the highest
 # note). You have access to the variables errors warning, statement which
-# respectivly contain the number of errors / warnings messages and the total
+# respectively contain the number of errors / warnings messages and the total
 # number of statements analyzed. This is used by the global evaluation report
 # (R0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
@@ -94,7 +94,7 @@ comment=no
 # checks for :
 # * doc strings
 # * modules / classes / functions / methods / arguments / variables name
-# * number of arguments, local variables, branchs, returns and statements in
+# * number of arguments, local variables, branches, returns and statements in
 # functions, methods
 # * required module attributes
 # * dangerous default values as arguments
@@ -152,11 +152,11 @@ bad-functions=map,filter,apply,input
 # * unused variables / imports
 # * undefined variables
 # * redefinition of variable from builtins or from an outer scope
-# * use of variable before assigment
+# * use of variable before assignment
 # 
 [VARIABLES]
 
-# Tells wether we should check for unused import in __init__ files.
+# Tells whether we should check for unused import in __init__ files.
 init-import=no
 
 # A regular expression matching names used for dummy variables (i.e. not used).
@@ -171,12 +171,12 @@ additional-builtins=
 # 
 [TYPECHECK]
 
-# Tells wether missing members accessed in mixin class should be ignored. A
+# Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).
 ignore-mixin-members=yes
 
 # List of classes names for which member attributes should not be checked
-# (useful for classes with attributes dynamicaly set).
+# (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
 
 # When zope mode is activated, add a predefined set of Zope acquired attributes
@@ -225,7 +225,7 @@ max-public-methods=20
 # checks for :
 # * methods without self as first argument
 # * overridden methods signature
-# * access only to existant members via self
+# * access only to existent members via self
 # * attributes not defined in the __init__ method
 # * supported interfaces implementation
 # * unreachable code

--- a/xl/collection.py
+++ b/xl/collection.py
@@ -261,7 +261,7 @@ class Collection(trax.TrackDB):
             self._running_total_count += self._running_count
             if self._scan_stopped:
                 break
-        else:  # didnt break
+        else:  # didn't break
             try:
                 if self.location is not None:
                     self.save_to_location()
@@ -734,7 +734,7 @@ class Library:
                 self.collection.add(tr)
 
             # Track already existed. This fixes trax.get_tracks_from_uri
-            # on windows, unknown why fix isnt needed on linux.
+            # on windows, unknown why fix isn't needed on linux.
             elif not tr._init:
                 self.collection.add(tr)
         return tr
@@ -801,7 +801,7 @@ class Library:
                     # for compilation detection. Most albums have far fewer
                     # than 110 tracks anyway, so it is unlikely that this
                     # restriction will affect the heuristic's accuracy.
-                    # 110 was chosen to accomodate "top 100"-style
+                    # 110 was chosen to accommodate "top 100"-style
                     # compilations.
                     if len(dirtracks) > 110:
                         logger.debug(
@@ -909,7 +909,7 @@ class TransferQueue:
 
     def transfer(self) -> None:
         """
-        Tranfer the queued tracks to the library.
+        Transfer the queued tracks to the library.
 
         This is NOT asynchronous
         """

--- a/xl/common.py
+++ b/xl/common.py
@@ -276,7 +276,7 @@ def glib_wait_seconds(timeout):
     """
     Same as glib_wait, but uses GLib.timeout_add_seconds instead
     of GLib.timeout_add and takes its timeout in seconds. See the
-    glib documention for why you might want to use one over the
+    glib documentation for why you might want to use one over the
     other.
     """
     return _glib_wait_inner(timeout, GLib.timeout_add_seconds)
@@ -571,7 +571,7 @@ def walk(root: Gio.File) -> Iterable[Gio.File]:
                     queue.append(fil)
                 elif type == Gio.FileType.REGULAR:
                     yield fil
-        except GLib.Error:  # why doesnt gio offer more-specific errors?
+        except GLib.Error:  # why doesn't gio offer more-specific errors?
             logger.exception("Unhandled exception while walking on %s.", dir)
 
 

--- a/xl/covers.py
+++ b/xl/covers.py
@@ -73,7 +73,7 @@ class Cacher:
 
         :param data: The data to store, as a bytestring.
         """
-        # FIXME: this doesnt handle hash collisions at all. with
+        # FIXME: this doesn't handle hash collisions at all. with
         # 2^256 possible keys its unlikely that we'll have a collision,
         # but we should handle it anyway.
         h = hashlib.sha256()
@@ -484,7 +484,7 @@ class CoverSearchMethod:
 
     #: If true, cover results will be cached for faster lookup
     use_cache = True
-    #: A name uniquely identifing the search method.
+    #: A name uniquely identifying the search method.
     name = "base"
     #: Whether the backend should have a fixed priority instead of being
     #  configurable.

--- a/xl/formatter.py
+++ b/xl/formatter.py
@@ -272,7 +272,7 @@ class Formatter(GObject.GObject):
 
                 identifier_parts += [groups['parameters']]
 
-            # Required to make multiple occurences of the same
+            # Required to make multiple occurrences of the same
             # identifier with different parameters work
             extractions[':'.join(identifier_parts)] = (identifier, parameters)
 

--- a/xl/lyrics.py
+++ b/xl/lyrics.py
@@ -41,7 +41,7 @@ class LyricsNotFoundException(Exception):
 
 class LyricsCache:
     """
-    Basically just a thread-safe shelf for convinience.
+    Basically just a thread-safe shelf for convenience.
     Supports container syntax.
     """
 

--- a/xl/main.py
+++ b/xl/main.py
@@ -689,7 +689,7 @@ class Exaile:
 
         event.log_event("player_loaded", player.PLAYER, None)
 
-        # Initalize playlist manager
+        # Initialize playlist manager
         from xl import playlist
 
         self.playlists = playlist.PlaylistManager()
@@ -705,7 +705,7 @@ class Exaile:
 
         dynamic.MANAGER.collection = self.collection
 
-        # Initalize device manager
+        # Initialize device manager
         logger.info("Loading devices...")
         from xl import devices
 

--- a/xl/metadata/_apev2.py
+++ b/xl/metadata/_apev2.py
@@ -25,11 +25,11 @@
 # from your version.
 
 
-from xl.metadata._base import CaseInsensitveBaseFormat
+from xl.metadata._base import CaseInsensitiveBaseFormat
 from mutagen import apev2
 
 
-class ApeFormat(CaseInsensitveBaseFormat):
+class ApeFormat(CaseInsensitiveBaseFormat):
     MutagenType = apev2.APEv2
     # TODO: this mapping is incomplete
     tag_mapping = {

--- a/xl/metadata/_base.py
+++ b/xl/metadata/_base.py
@@ -322,7 +322,7 @@ class BaseFormat:
                 return None
 
 
-class CaseInsensitveBaseFormat(BaseFormat):
+class CaseInsensitiveBaseFormat(BaseFormat):
     case_sensitive = False
 
     def get_keys_disk(self):

--- a/xl/metadata/flac.py
+++ b/xl/metadata/flac.py
@@ -25,12 +25,12 @@
 # from your version.
 
 import xl.unicode
-from xl.metadata._base import CaseInsensitveBaseFormat, CoverImage
+from xl.metadata._base import CaseInsensitiveBaseFormat, CoverImage
 from mutagen import flac
 from mutagen.flac import Picture
 
 
-class FlacFormat(CaseInsensitveBaseFormat):
+class FlacFormat(CaseInsensitiveBaseFormat):
     MutagenType = flac.FLAC
     tag_mapping = {
         'bpm': 'tempo',
@@ -45,7 +45,7 @@ class FlacFormat(CaseInsensitveBaseFormat):
         return -1
 
     def get_keys_disk(self):
-        keys = CaseInsensitveBaseFormat.get_keys_disk(self)
+        keys = CaseInsensitiveBaseFormat.get_keys_disk(self)
         if self.mutagen.pictures:
             keys.append('cover')
         return keys
@@ -57,7 +57,7 @@ class FlacFormat(CaseInsensitveBaseFormat):
                 for p in raw.pictures
             ]
 
-        return CaseInsensitveBaseFormat._get_tag(self, raw, tag)
+        return CaseInsensitiveBaseFormat._get_tag(self, raw, tag)
 
     def _set_tag(self, raw, tag, value):
         if tag == '__cover':
@@ -73,7 +73,7 @@ class FlacFormat(CaseInsensitveBaseFormat):
 
         # flac has text based attributes, so convert everything to unicode
         value = [xl.unicode.to_unicode(v) for v in value]
-        CaseInsensitveBaseFormat._set_tag(self, raw, tag, value)
+        CaseInsensitiveBaseFormat._set_tag(self, raw, tag, value)
 
     def _del_tag(self, raw, tag):
         if tag == '__cover':

--- a/xl/metadata/ogg.py
+++ b/xl/metadata/ogg.py
@@ -25,13 +25,13 @@
 # from your version.
 
 import xl.unicode
-from xl.metadata._base import CaseInsensitveBaseFormat, CoverImage
+from xl.metadata._base import CaseInsensitiveBaseFormat, CoverImage
 from mutagen import oggvorbis, oggopus
 from mutagen.flac import Picture
 import base64
 
 
-class OggFormat(CaseInsensitveBaseFormat):
+class OggFormat(CaseInsensitiveBaseFormat):
     MutagenType = oggvorbis.OggVorbis
     tag_mapping = {
         'bpm': 'tempo',
@@ -41,7 +41,7 @@ class OggFormat(CaseInsensitveBaseFormat):
     writable = True
 
     def _get_tag(self, raw, tag):
-        value = CaseInsensitveBaseFormat._get_tag(self, raw, tag)
+        value = CaseInsensitiveBaseFormat._get_tag(self, raw, tag)
         if value and tag == 'metadata_block_picture':
             new_value = []
             for v in value:
@@ -73,7 +73,7 @@ class OggFormat(CaseInsensitveBaseFormat):
         else:
             # vorbis has text based attributes, so convert everything to unicode
             value = [xl.unicode.to_unicode(v) for v in value]
-        CaseInsensitveBaseFormat._set_tag(self, raw, tag, value)
+        CaseInsensitiveBaseFormat._set_tag(self, raw, tag, value)
 
 
 class OggOpusFormat(OggFormat):

--- a/xl/metadata/speex.py
+++ b/xl/metadata/speex.py
@@ -25,11 +25,11 @@
 # from your version.
 
 
-from xl.metadata._base import CaseInsensitveBaseFormat
+from xl.metadata._base import CaseInsensitiveBaseFormat
 from mutagen import oggspeex
 
 
-class SpeexFormat(CaseInsensitveBaseFormat):
+class SpeexFormat(CaseInsensitiveBaseFormat):
     MutagenType = oggspeex.OggSpeex
     writable = True
 

--- a/xl/migrations/database/covers_1to2.py
+++ b/xl/migrations/database/covers_1to2.py
@@ -54,7 +54,7 @@ def old_get_track_key(track):
         tag = 'album'
         value = album
     else:
-        # no album info, cant store it
+        # no album info, can't store it
         return None
     return (tag, tuple(value))
 

--- a/xl/playlist.py
+++ b/xl/playlist.py
@@ -1530,7 +1530,7 @@ class Playlist:
             track = None
             track = trax.Track(uri=loc)
 
-            # readd meta
+            # re-add meta
             if not track:
                 continue
             if not track.is_local() and meta is not None:
@@ -1877,7 +1877,7 @@ class SmartPlaylist:
 
     def remove_param(self, index):
         """
-        Removes a parameter at the speficied index
+        Removes a parameter at the specified index
 
         index:  the index of the parameter to remove
         """
@@ -1894,7 +1894,7 @@ class SmartPlaylist:
         pl = Playlist(name=self.name)
         if not collection:
             collection = self.collection
-        if not collection:  # if there wasnt one set we might not have one
+        if not collection:  # if there wasn't one set we might not have one
             return pl
 
         search_string, matchers = self._create_search_data(collection)
@@ -2149,7 +2149,7 @@ class PlaylistManager:
         # collect the names of all playlists in playlist_dir
         existing = []
         for f in os.listdir(self.playlist_dir):
-            # everything except the order file shold be a playlist, but
+            # everything except the order file should be a playlist, but
             # check against hidden files since some editors put
             # temporary stuff in the same dir.
             if f != os.path.basename(self.order_file) and not f.startswith("."):

--- a/xl/plugins.py
+++ b/xl/plugins.py
@@ -229,7 +229,7 @@ class PluginsManager:
             for line in f:
                 try:
                     key, val = line.split("=", 1)
-                    # restricted eval - no bult-in funcs. marginally more secure.
+                    # restricted eval - no built-in funcs. marginally more secure.
                     infodict[key] = eval(val, {'__builtins__': None, '_': _}, {})
                 except ValueError:
                     pass  # this happens on blank lines

--- a/xl/radio.py
+++ b/xl/radio.py
@@ -66,7 +66,7 @@ class RadioManager(providers.ProviderHandler):
         """
         Removes a station from the manager
 
-        @param station: The station to remvoe
+        @param station: The station to remove
         """
         providers.unregister(self.servicename, station)
 

--- a/xl/trax/search.py
+++ b/xl/trax/search.py
@@ -542,7 +542,7 @@ def search_tracks(trackiter, trackmatchers: Collection[TracksMatcher]):
         # thread running the search can end up blocking other threads.
         # Calling out to time.sleep forces a release of the GIL and
         # allows other threads to run. Benchmarks show this has no
-        # noticable effect on search speed.
+        # noticeable effect on search speed.
         time.sleep(0)
 
 

--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -50,7 +50,7 @@ _K = TypeVar('_K')
 _V = TypeVar('_V')
 _V1 = TypeVar('_V1')
 
-# map chars to appropriate subsitutes for sorting
+# map chars to appropriate substitutes for sorting
 _sortcharmap = {
     'ß': 'ss',  # U+00DF
     'æ': 'ae',  # U+00E6
@@ -1026,7 +1026,7 @@ class Track:
         turns characters like æ into values suitable for sorting,
         like 'ae'. see _sortcharmap for the mapping.
 
-        value must be a unicode object or this wont replace anything.
+        value must be a unicode object or this won't replace anything.
 
         value must be in lower-case
         """

--- a/xl/trax/trackdb.py
+++ b/xl/trax/trackdb.py
@@ -120,7 +120,7 @@ class TrackDB:
         Provide the ability to iterate over a TrackDB.
         Just as with a dictionary, if tracks are added
         or removed during iteration, iteration will halt
-        wuth a RuntimeError.
+        with a RuntimeError.
         """
         track_iterator = iter(self.tracks.items())
         iterator = TrackDBIterator(track_iterator)

--- a/xl/xldbus.py
+++ b/xl/xldbus.py
@@ -213,7 +213,7 @@ class DbusManager(dbus.service.Object):
 
     def __init__(self, exaile):
         """
-        Initilializes the interface
+        Initializes the interface
         """
         self.exaile = exaile
         self.bus = dbus.SessionBus()

--- a/xlgui/guiutil.py
+++ b/xlgui/guiutil.py
@@ -225,7 +225,7 @@ def pixbuf_from_data(data, size=None, keep_ratio=True, upscale=False):
 
 class ScalableImageWidget(Gtk.Image):
     """
-    Custom resizeable image widget
+    Custom resizable image widget
     """
 
     def __init__(self):

--- a/xlgui/panel/__init__.py
+++ b/xlgui/panel/__init__.py
@@ -50,7 +50,7 @@ class Panel(GObject.GObject):
 
     def __init__(self, parent, name, label=None):
         """
-        Intializes the panel
+        Initializes the panel
 
         @param parent: the main window
         @type parent: Gtk.Window

--- a/xlgui/panel/playlists.py
+++ b/xlgui/panel/playlists.py
@@ -173,7 +173,7 @@ class BasePlaylistPanelMixin(GObject.GObject):
         (model, iter) = selection.get_selected()
         model.set_value(iter, 1, name)
 
-        # Update the manager aswell
+        # Update the manager as well
         self.playlist_manager.rename_playlist(playlist, name)
 
     def open_selected_playlist(self):
@@ -382,7 +382,7 @@ class PlaylistsPanel(panel.Panel, BasePlaylistPanelMixin):
 
     def __init__(self, parent, playlist_manager, smart_manager, collection, name):
         """
-        Intializes the playlists panel
+        Initializes the playlists panel
 
         @param playlist_manager:  The playlist manager
         """

--- a/xlgui/preferences/plugin.py
+++ b/xlgui/preferences/plugin.py
@@ -314,7 +314,7 @@ class PluginManager:
                         self.window,
                         "\n".join(
                             [
-                                _('Plugin allready exists!'),
+                                _('Plugin already exists!'),
                                 _('Do you want to override it?'),
                             ]
                         ),

--- a/xlgui/widgets/common.py
+++ b/xlgui/widgets/common.py
@@ -508,7 +508,7 @@ class DragTreeView(AutoScrollTreeView):
 
     def _handle_unknown_drag_data(self, loc):
         """
-        Handles unknown drag data that has been recieved by
+        Handles unknown drag data that has been received by
         drag_data_received.  Unknown drag data is classified as
         any loc (location) that is not in the collection of tracks
         (i.e. a new song, or a new playlist)

--- a/xlgui/widgets/dialogs.py
+++ b/xlgui/widgets/dialogs.py
@@ -599,7 +599,7 @@ class ListBox:
 class FileOperationDialog(Gtk.FileChooserDialog):
     """
     An extension of the Gtk.FileChooserDialog that
-    adds a collapsable panel to the bottom listing
+    adds a collapsible panel to the bottom listing
     valid file extensions that the file can be
     saved in. (similar to the one in GIMP)
     """

--- a/xlgui/widgets/notebook.py
+++ b/xlgui/widgets/notebook.py
@@ -415,13 +415,13 @@ class NotebookPage(Gtk.Box):
 
     def focus(self):
         """
-        Grabs focus for this page. Should be overriden in subclasses.
+        Grabs focus for this page. Should be overridden in subclasses.
         """
         self.grab_focus()
 
     def get_page_name(self):
         """
-        Returns the name of this tab. Should be overriden in subclasses.
+        Returns the name of this tab. Should be overridden in subclasses.
 
         Subclasses can also implement set_page_name(self, name) to allow
         renaming, but this is not mandatory.

--- a/xlgui/widgets/rating.py
+++ b/xlgui/widgets/rating.py
@@ -415,7 +415,7 @@ class RatingCellRenderer(Gtk.CellRendererPixbuf):
                   cell_area, flags):
         """
             Renders the rating images
-            (Overriden since Gtk.CellRendererPixbuf
+            (Overridden since Gtk.CellRendererPixbuf
              fails at vertical padding)
         """
         cell_area.width *= self.props.xalign


### PR DESCRIPTION
Found via:
- `codespell -S po,*.js -L strack,ro,daa,datas,splitted,gir,minuts,fo,nd,te,setts`
- `typos --format brief`