### PR TITLE
Upgrade Licensing to CC-BY-4.0 to be compatible with Debian FSG

### DIFF
--- a/data/images/scalable/exaile-noshadow.svg
+++ b/data/images/scalable/exaile-noshadow.svg
@@ -671,7 +671,7 @@
           </rdf:Bag>
         </dc:subject>
         <cc:license
-           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
         <dc:contributor>
           <cc:Agent>
             <dc:title>Jakub Steiner, Andreas Nilsson</dc:title>
@@ -680,7 +680,7 @@
         <dc:source>http://tigert.com</dc:source>
       </cc:Work>
       <cc:License
-         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
         <cc:permits
            rdf:resource="http://web.resource.org/cc/Reproduction" />
         <cc:permits

--- a/data/images/scalable/exaile-pause.svg
+++ b/data/images/scalable/exaile-pause.svg
@@ -750,7 +750,7 @@
           </rdf:Bag>
         </dc:subject>
         <cc:license
-           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
         <dc:contributor>
           <cc:Agent>
             <dc:title>Jakub Steiner, Andreas Nilsson</dc:title>
@@ -759,7 +759,7 @@
         <dc:source>http://tigert.com</dc:source>
       </cc:Work>
       <cc:License
-         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
         <cc:permits
            rdf:resource="http://web.resource.org/cc/Reproduction" />
         <cc:permits

--- a/data/images/scalable/exaile-play.svg
+++ b/data/images/scalable/exaile-play.svg
@@ -701,7 +701,7 @@
           </rdf:Bag>
         </dc:subject>
         <cc:license
-           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
         <dc:contributor>
           <cc:Agent>
             <dc:title>Jakub Steiner, Andreas Nilsson</dc:title>
@@ -710,7 +710,7 @@
         <dc:source>http://tigert.com</dc:source>
       </cc:Work>
       <cc:License
-         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
         <cc:permits
            rdf:resource="http://web.resource.org/cc/Reproduction" />
         <cc:permits

--- a/data/images/scalable/exaile.svg
+++ b/data/images/scalable/exaile.svg
@@ -691,7 +691,7 @@
           </rdf:Bag>
         </dc:subject>
         <cc:license
-           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
         <dc:contributor>
           <cc:Agent>
             <dc:title>Jakub Steiner, Andreas Nilsson</dc:title>
@@ -700,7 +700,7 @@
         <dc:source>http://tigert.com</dc:source>
       </cc:Work>
       <cc:License
-         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
         <cc:permits
            rdf:resource="http://web.resource.org/cc/Reproduction" />
         <cc:permits


### PR DESCRIPTION
To be compatible with Debian Free Software Guidelines CC-BY-2.0 needs to be upgraded to CC-BY-4.0
See https://wiki.debian.org/DFSGLicenses#Creative_Commons_Attribution-ShareAlike_3.0_Unported_.28CC_BY-SA_3.0.29

@mathbr Do you agree?