### PR TITLE
Fix python 3.7 compatibility

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,6 +12,7 @@ Core dependencies
 Essential:
 
 * python3 >= 3.6
+* python3-typing-extensions (python3 <= 3.7 only)
 * python3-bsddb3
 * gtk+ >= 3.22
 * gstreamer (>= 1.14)

--- a/xlgui/widgets/info.py
+++ b/xlgui/widgets/info.py
@@ -25,7 +25,16 @@
 # do so. If you do not wish to do so, delete this exception statement
 # from your version.
 
-from typing import Literal
+try:
+    from typing import Literal  # python >= 3.8
+except ImportError:
+    # python <= 3.7 requires typing_extensions package
+    try:
+        from typing_extensions import Literal
+    except ModuleNotFoundError as e:
+        raise RuntimeError(
+            "Please install typing-extensions package to run exaile under python <= 3.7."
+        ) from e
 
 from gi.repository import GLib
 from gi.repository import Gtk


### PR DESCRIPTION
The `typing` package from python 3.7 stdlib does not provide `Literal` type, so external `typing-extensions` package must be used instead.

Alternatively, we should drop official support for python <= 3.7.