### PR TITLE
Add metadata handler for aac files

### DIFF
--- a/xl/metadata/__init__.py
+++ b/xl/metadata/__init__.py
@@ -34,6 +34,7 @@ from gi.repository import Gio
 from xl.metadata._base import BaseFormat, CoverImage, NotWritable, NotReadable
 
 from xl.metadata import (
+    aac,
     aiff,
     ape,
     asf,
@@ -55,7 +56,7 @@ from xl.metadata import (
 formats = {
     # fmt: off
     '669'   : mod.ModFormat,
-    'aac'   : mp4.MP4Format,
+    'aac'   : [mp4.MP4Format, aac.AACFormat],
     'ac3'   : None,
     'aif'   : aiff.AIFFFormat,
     'aifc'  : aiff.AIFFFormat,
@@ -133,6 +134,16 @@ def get_format(loc: str) -> Optional[BaseFormat]:
 
     if formatclass is None:
         formatclass = DummyFormat
+
+    # Some file types can be more than one format
+    # So check each possible format
+    if type(formatclass) is list:
+        for klass in formatclass:
+            try:
+                return klass(loc)
+            except:
+                continue
+        return None
 
     try:
         return formatclass(loc)

--- a/xl/metadata/aac.py
+++ b/xl/metadata/aac.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2023 luzip665
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#
+# The developers of the Exaile media player hereby grant permission
+# for non-GPL compatible GStreamer and Exaile plugins to be used and
+# distributed together with GStreamer and Exaile. This permission is
+# above and beyond the permissions granted by the GPL license by which
+# Exaile is covered. If you modify this code, you may extend this
+# exception to your version of the code, but you are not obligated to
+# do so. If you do not wish to do so, delete this exception statement
+# from your version.
+import logging
+
+logger = logging.getLogger(__name__)
+
+from xl.metadata._id3 import ID3Format
+from mutagen import id3
+
+
+class AACFormat(ID3Format):
+    MutagenType = id3.ID3FileType
+    pass


### PR DESCRIPTION
According to https://mutagen.readthedocs.io/en/latest/api/aac.html ID3 tags can be used with aac.

Checked with kid3.