### PR TITLE
Check conditional preferences conditions on show

### DIFF
--- a/xlgui/preferences/__init__.py
+++ b/xlgui/preferences/__init__.py
@@ -225,6 +225,11 @@ class PreferencesDialog:
         self.last_child = child
         self.box.show_all()
 
+        childs = self.fields[page]
+        for c in childs:
+            if hasattr(c, 'check_condition'):
+                c.check_condition()
+
     def _populate_fields(self, page, builder):
         """
         Populates field pages

--- a/xlgui/preferences/widgets.py
+++ b/xlgui/preferences/widgets.py
@@ -225,6 +225,11 @@ class Conditional:
             else:
                 self.on_condition_failed()
 
+    def check_condition(self):
+        if self.on_check_condition():
+            self.on_condition_met()
+        else:
+            self.on_condition_failed()
 
 class CheckConditional(Conditional):
     """
@@ -301,6 +306,12 @@ class MultiConditional:
                 self.on_condition_met()
             else:
                 self.on_condition_failed()
+
+    def check_condition(self):
+        if self.on_check_condition():
+            self.on_condition_met()
+        else:
+            self.on_condition_failed()
 
 
 class Button(Preference):


### PR DESCRIPTION
Old behavior in case the AudioSink is set to automatic:
* Open settings
* Go to Playback settings, only AudioSink and AudioSinkDevice are show on top, CustomSinkPipe is hidden
* Go to Collections settings
* Come back to Playback settings
=> Resulted in showing the preferences AudioSink, AudioSinkDevice and CustomSinkPipe

Now only  AudioSink and AudioSinkDevice are shown as expected.