### PR TITLE
Windows launcher: provide dummy sys.stderr and sys.stdout

### DIFF
--- a/exaile_win.py
+++ b/exaile_win.py
@@ -8,7 +8,16 @@
 import builtins
 import msvcrt
 import sys
+import os
 from ctypes import windll
+
+
+# Provide dummy sys.stdout and sys.stderr, which are None in noconsole/windowed
+# mode (launched using pythonw.exe, or PyInstaller build).
+if sys.stdout is None:
+    sys.stdout = open(os.devnull, "w")
+if sys.stderr is None:
+    sys.stderr = open(os.devnull, "w")
 
 
 __builtin__open = __builtins__.open


### PR DESCRIPTION
Recent versions of PyInstaller do not provide dummy `sys.stderr` and `sys.stdout` in noconsole/windowed mode anymore. Instead, they are left at `None`, same as when script is ran using `pythonw.exe`.

Provide dummy file-like objects for `sys.stderr` and `sys.stdout` to prevent errors in parts of the code that blindly assume that the streams are available.