### PR TITLE
Bugfix: Tag writing with "write_rating_to_audio_file_metadata"

### DIFF
--- a/xl/metadata/_base.py
+++ b/xl/metadata/_base.py
@@ -190,12 +190,7 @@ class BaseFormat:
             # __ is used to denote exaile's internal tags, so we skip
             # loading them to avoid conflicts. usually this shouldn't be
             # an issue.
-            if t.startswith("__") and (
-                t != '__rating'
-                or not settings.get_option(
-                    'collection/write_rating_to_audio_file_metadata', False
-                )
-            ):
+            if self._remove_internal_tag(t):
                 continue
             tags.append(t)
         alltags = self.read_tags(tags)
@@ -279,12 +274,7 @@ class BaseFormat:
             # tags starting with __ are internal and should not be written
             # -> this covers INFO_TAGS, which also shouldn't be written
             for tag in list(tagdict.keys()):
-                if tag.startswith("__") and (
-                    tag != '__rating'
-                    or not settings.get_option(
-                        'collection/write_rating_to_audio_file_metadata', False
-                    )
-                ):
+                if self._remove_internal_tag(tag):
                     del tagdict[tag]
 
             # Only modify the tags we were told to modify
@@ -362,6 +352,17 @@ class BaseFormat:
             # 5
             rating = 100
         return rating
+
+    def _remove_internal_tag(self, tag):
+        if tag.startswith("__") and (
+            tag != '__rating'
+            or not settings.get_option(
+                'collection/write_rating_to_audio_file_metadata', False
+            )
+        ):
+            return True
+
+        return False
 
 
 class CaseInsensitiveBaseFormat(BaseFormat):

--- a/xl/metadata/_base.py
+++ b/xl/metadata/_base.py
@@ -33,7 +33,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from xl import version
+from xl import version, settings
 import mutagen
 
 version.register('Mutagen', mutagen.version_string)
@@ -190,7 +190,12 @@ class BaseFormat:
             # __ is used to denote exaile's internal tags, so we skip
             # loading them to avoid conflicts. usually this shouldn't be
             # an issue.
-            if t.startswith("__") and t != '__rating':
+            if t.startswith("__") and (
+                t != '__rating'
+                or not settings.get_option(
+                    'collection/write_rating_to_audio_file_metadata', False
+                )
+            ):
                 continue
             tags.append(t)
         alltags = self.read_tags(tags)
@@ -274,7 +279,12 @@ class BaseFormat:
             # tags starting with __ are internal and should not be written
             # -> this covers INFO_TAGS, which also shouldn't be written
             for tag in list(tagdict.keys()):
-                if tag.startswith("__") and tag != '__rating':
+                if tag.startswith("__") and (
+                    tag != '__rating'
+                    or not settings.get_option(
+                        'collection/write_rating_to_audio_file_metadata', False
+                    )
+                ):
                     del tagdict[tag]
 
             # Only modify the tags we were told to modify

--- a/xl/metadata/_id3.py
+++ b/xl/metadata/_id3.py
@@ -153,7 +153,7 @@ class ID3Format(BaseFormat):
             frames = [id3.WOAR(encoding=3, url=d) for d in data]
         elif tag == 'POPM':
             # Rating Stars
-            data = int(data)
+            data = int(data[0])
             rating = self._stars_to_rating(data)
             email = settings.get_option(
                 'collection/write_rating_to_audio_file_metadata_popm_mail'

--- a/xl/metadata/flac.py
+++ b/xl/metadata/flac.py
@@ -81,7 +81,7 @@ class FlacFormat(CaseInsensitiveBaseFormat):
 
         elif tag == 'rating':
             # Rating Stars
-            value = [str(self._stars_to_rating(int(value)))]
+            value = [str(self._stars_to_rating(int(value[0])))]
 
         else:
             # flac has text based attributes, so convert everything to unicode

--- a/xl/metadata/ogg.py
+++ b/xl/metadata/ogg.py
@@ -75,7 +75,7 @@ class OggFormat(CaseInsensitiveBaseFormat):
                 new_value.append(tmp)
             value = new_value
         elif tag == 'rating':
-            rating = self._stars_to_rating(value)
+            rating = self._stars_to_rating(value[0])
             value = [str(rating)]
         else:
             # vorbis has text based attributes, so convert everything to unicode

--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -613,7 +613,7 @@ class Track:
         elif tag == '__rating' and self._write_rating_to_disk():
             try:
                 value = self.__tags.get(tag)[0]
-            except (TypeError) as e:
+            except TypeError as e:
                 value = self.__tags.get(tag)
         else:
             value = self.__tags.get(tag)

--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -611,7 +611,10 @@ class Track:
             # __startoffset don't check for None. Those need to be fixed.
             value = self.__tags.get(tag, 0)
         elif tag == '__rating' and self._write_rating_to_disk():
-            value = self.__tags.get(tag)[0]
+            try:
+                value = self.__tags.get(tag)[0]
+            except (TypeError) as e:
+                value = self.__tags.get(tag)
         else:
             value = self.__tags.get(tag)
 

--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -610,7 +610,7 @@ class Track:
             # TODO: This is only necessary because some places that deal with
             # __startoffset don't check for None. Those need to be fixed.
             value = self.__tags.get(tag, 0)
-        elif tag == '__rating' and self._write_rating_to_disk():
+        elif tag == '__rating':
             try:
                 value = self.__tags.get(tag)[0]
             except TypeError as e:


### PR DESCRIPTION
* Tags sometimes are not written to file metadata if "write_rating_to_audio_file_metadata" is active
* If tags are writable, rating was always written, regardless of write_rating_to_audio_file_metadata

Tested with properties and bpm plugin.
I.e. tried to store bpm to flac file either with "write_rating_to_audio_file_metadata" active or not