### PR TITLE
win installer: manually collect libsoup-2.4-1.dll and its dependencies

### DIFF
--- a/tools/installer/exaile.spec
+++ b/tools/installer/exaile.spec
@@ -1,6 +1,7 @@
 # -*- mode: python -*-
 
 import sys
+import pathlib
 from PyInstaller.utils.hooks import collect_submodules
 
 if sys.platform == 'win32':
@@ -22,6 +23,26 @@ hiddenimports = (
 )
 
 binaries = []
+
+if sys.platform == 'win32':
+    # In msys2/mingw32 GStreamer 1.22.1, the `soup` plugin (used for playing
+    # radio streams) is not linked against the `libsoup-*.dll` DLL, so
+    # PyInstaller's dependency analysis fails to pick up the DLL, and we need
+    # to manually pass it via `binaries`.
+    # Due to an oversight in PyInstaller, manually-passed `binaries` are not
+    # subjected to dependency analysis, so we also need to ensure that missing
+    # dependencies of `libsoup-*.dll` are collected. One such dependency is
+    # `libsqlite3-*.dll`.
+    dll_dir = pathlib.Path('_build_root/mingw32/bin')
+    dll_patterns = [
+        # match `libsoup-2.4-1.dll` but not `libsoup-gnome-2.4-1.dll`
+        'libsoup-[0-9]*.dll',
+        # dependency of `libsoup`
+        'libsqlite3-[0-9]*.dll',
+    ]
+    for dll_pattern in dll_patterns:
+        for dll_name in dll_dir.glob(dll_pattern):
+            binaries += [(str(dll_name), '.')]
 
 # We don't use packaging directly, but this is required because something else
 # uses it and PyInstaller (tested with v3.4) fails to detect some of


### PR DESCRIPTION
In GStreamer 1.22.1 used by our SDK 39, the `soup` GStreamer plugin, which is used for radio streams, is not linked against the `soup` shared library (DLL) anymore, so PyInstaller fails to pick up the DLL and some of its dependencies. Failing to load the `soup` plugin causes fall-back to `curl` one, which seems to fail to load any radio stream.

Therefore, ensure that `libsoup-2.4-1.dll` is collected, by passing it to PyInstaller via `binaries` in the spec file.

Fixes #867.