### PR TITLE
Migrate metadata mapping

### DIFF
--- a/data/ui/preferences/collection.ui
+++ b/data/ui/preferences/collection.ui
@@ -167,7 +167,7 @@ This feature should work for MP3, MP4, FLAC and OGG. </property>
     <child>
       <object class="GtkLabel" id="collection/use_legacy_metadata_mapping_hint">
         <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Use legacy tag mapping as up to Exaile 4.1.2 for OGG and FLAC files for comment and bpm tags. From Exaile 4.1.3 the mapping is equivalent to Musicbrainz.
+        <property name="label" translatable="yes">Use legacy tag mapping for Ogg Vorbis and FLAC files for comment and bpm tags. From Exaile 4.1.3 the mapping is equivalent to MusicBrainz.
 Your can start migration here. After migration this feature will be disabled.</property>
         <property name="justify">fill</property>
         <property name="wrap">True</property>

--- a/data/ui/preferences/collection.ui
+++ b/data/ui/preferences/collection.ui
@@ -186,7 +186,7 @@ Your can start migration here. After migration this feature will be disabled.</p
 		<property name="width_request">150</property>
 		<property name="visible">True</property>
 		<property name="can_focus">True</property>
-		<property name="label" translatable="yes">Migrate existing tempo tags to bpm tag now</property>
+		<property name="label" translatable="yes">Migrate existing tempo and comment tags now</property>
 	  </object>
 	  <packing>
 		<property name="left_attach">0</property>

--- a/data/ui/preferences/collection.ui
+++ b/data/ui/preferences/collection.ui
@@ -152,7 +152,7 @@ This feature should work for MP3, MP4, FLAC and OGG. </property>
     </child>
     <child>
       <object class="GtkCheckButton" id="collection/use_legacy_metadata_mapping">
-        <property name="label" translatable="yes">FLAC: Read and write bpm to tempo tag</property>
+        <property name="label" translatable="yes">Use legacy tag mapping</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
@@ -167,8 +167,8 @@ This feature should work for MP3, MP4, FLAC and OGG. </property>
     <child>
       <object class="GtkLabel" id="collection/use_legacy_metadata_mapping_hint">
         <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Use this feature to read and write bpm instead to tempo tag in flac files.
-This is the old behaviour. To get rid of it, migrate using the button. After migration this feature will be disabled.</property>
+        <property name="label" translatable="yes">Use legacy tag mapping as up to Exaile 4.1.2 for OGG and FLAC files for comment and bpm tags. From Exaile 4.1.3 the mapping is equivalent to Musicbrainz.
+Your can start migration here. After migration this feature will be disabled.</property>
         <property name="justify">fill</property>
         <property name="wrap">True</property>
         <accessibility>

--- a/data/ui/preferences/collection.ui
+++ b/data/ui/preferences/collection.ui
@@ -150,5 +150,60 @@ This feature should work for MP3, MP4, FLAC and OGG. </property>
         <property name="width">2</property>
       </packing>
     </child>
+    <child>
+      <object class="GtkCheckButton" id="collection/use_legacy_metadata_mapping">
+        <property name="label" translatable="yes">FLAC: Read and write bpm to tempo tag</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="draw_indicator">True</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">9</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="collection/use_legacy_metadata_mapping_hint">
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Use this feature to read and write bpm instead to tempo tag in flac files.
+This is the old behaviour. To get rid of it, migrate using the button. After migration this feature will be disabled.</property>
+        <property name="justify">fill</property>
+        <property name="wrap">True</property>
+        <accessibility>
+          <relation type="label-for" target="collection/use_legacy_metadata_mapping"/>
+        </accessibility>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">10</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+	<child>
+	  <object class="GtkButton" id="collection/use_legacy_metadata_mapping_sync_now">
+		<property name="width_request">150</property>
+		<property name="visible">True</property>
+		<property name="can_focus">True</property>
+		<property name="label" translatable="yes">Migrate existing tempo tags to bpm tag now</property>
+	  </object>
+	  <packing>
+		<property name="left_attach">0</property>
+		<property name="top_attach">11</property>
+        <property name="width">2</property>
+	  </packing>
+	</child>
+    <child>
+      <object class="GtkBox" id="collection/use_legacy_metadata_mapping_progress">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">12</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
   </object>
 </interface>

--- a/xl/main.py
+++ b/xl/main.py
@@ -646,6 +646,7 @@ class Exaile:
 
         # Activate new flac/ogg metadata handling for new installations
         from xl.migrations.settings import flac_tempo
+
         flac_tempo.migrate()
 
         # TODO: enable audio plugins separately from normal

--- a/xl/main.py
+++ b/xl/main.py
@@ -644,6 +644,11 @@ class Exaile:
 
         engine.migrate()
 
+        # Migrate flac tempo tag
+        from xl.migrations.settings import flac_tempo
+
+        flac_tempo.migrate()
+
         # TODO: enable audio plugins separately from normal
         #       plugins? What about plugins that use the player?
 

--- a/xl/main.py
+++ b/xl/main.py
@@ -644,9 +644,8 @@ class Exaile:
 
         engine.migrate()
 
-        # Migrate flac tempo tag
+        # Activate new flac/ogg metadata handling for new installations
         from xl.migrations.settings import flac_tempo
-
         flac_tempo.migrate()
 
         # TODO: enable audio plugins separately from normal

--- a/xl/metadata/flac.py
+++ b/xl/metadata/flac.py
@@ -34,9 +34,7 @@ from mutagen.flac import Picture
 class FlacFormat(CaseInsensitiveBaseFormat):
     MutagenType = flac.FLAC
     tag_mapping = {
-        # 'bpm': 'bpm',
         'cover': '__cover',
-        # 'comment': 'description',
         'language': "Language",
         '__rating': 'rating',
     }

--- a/xl/metadata/flac.py
+++ b/xl/metadata/flac.py
@@ -26,6 +26,7 @@
 
 import xl.unicode
 from xl.metadata._base import CaseInsensitiveBaseFormat, CoverImage
+from xl import settings
 from mutagen import flac
 from mutagen.flac import Picture
 
@@ -33,9 +34,9 @@ from mutagen.flac import Picture
 class FlacFormat(CaseInsensitiveBaseFormat):
     MutagenType = flac.FLAC
     tag_mapping = {
-        'bpm': 'tempo',
+        # 'bpm': 'bpm',
         'cover': '__cover',
-        'comment': 'description',
+        # 'comment': 'description',
         'language': "Language",
         '__rating': 'rating',
     }
@@ -65,6 +66,20 @@ class FlacFormat(CaseInsensitiveBaseFormat):
             data = int(raw['rating'][0])
             return [str(self._rating_to_stars(data))]
 
+        elif tag == 'bpm':
+            if (
+                settings.get_option('collection/use_legacy_metadata_mapping', False)
+                and 'tempo' in raw
+            ):
+                tag = 'tempo'
+
+        elif tag == 'comment':
+            if (
+                settings.get_option('collection/use_legacy_metadata_mapping', False)
+                and 'description' in raw
+            ):
+                tag = 'description'
+
         return CaseInsensitiveBaseFormat._get_tag(self, raw, tag)
 
     def _set_tag(self, raw, tag, value):
@@ -82,6 +97,16 @@ class FlacFormat(CaseInsensitiveBaseFormat):
         elif tag == 'rating':
             # Rating Stars
             value = [str(self._stars_to_rating(int(value[0])))]
+
+        elif tag == 'bpm':
+            if settings.get_option('collection/use_legacy_metadata_mapping', False):
+                tag = 'tempo'
+            value = [xl.unicode.to_unicode(v) for v in value]
+
+        elif tag == 'comment':
+            if settings.get_option('collection/use_legacy_metadata_mapping', False):
+                tag = 'description'
+            value = [xl.unicode.to_unicode(v) for v in value]
 
         else:
             # flac has text based attributes, so convert everything to unicode

--- a/xl/metadata/ogg.py
+++ b/xl/metadata/ogg.py
@@ -35,8 +35,6 @@ import base64
 class OggFormat(CaseInsensitiveBaseFormat):
     MutagenType = oggvorbis.OggVorbis
     tag_mapping = {
-        # 'bpm': 'bpm',
-        # 'comment': 'description',
         'cover': 'metadata_block_picture',
         '__rating': 'rating',
     }

--- a/xl/migrations/settings/flac_tempo.py
+++ b/xl/migrations/settings/flac_tempo.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 luzip665
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from xl import settings
+
+
+def migrate():
+    """
+    Migration for flac bpm tag.
+    In case it's a new instance disable the old behaviour.
+    Otherwise leave it disabled
+    """
+    firstrun = settings.get_option("general/first_run", True)
+    migrated = settings.get_option('collection/flac_write_bpm_to_tempo', None)
+    if not firstrun and migrated == None:
+        settings.set_option('collection/flac_write_bpm_to_tempo', True)
+    elif firstrun:
+        settings.set_option('collection/flac_write_bpm_to_tempo', False)

--- a/xl/migrations/settings/flac_tempo.py
+++ b/xl/migrations/settings/flac_tempo.py
@@ -19,7 +19,7 @@ from xl import settings
 
 def migrate():
     """
-    Migration for flac bpm tag.
+    Migration for flac bpm and tempo tag setting.
     In case it's a new instance disable the old behaviour.
     Otherwise leave it disabled
     """

--- a/xl/migrations/settings/flac_tempo.py
+++ b/xl/migrations/settings/flac_tempo.py
@@ -24,8 +24,8 @@ def migrate():
     Otherwise leave it disabled
     """
     firstrun = settings.get_option("general/first_run", True)
-    migrated = settings.get_option('collection/flac_write_bpm_to_tempo', None)
+    migrated = settings.get_option('collection/use_legacy_metadata_mapping', None)
     if not firstrun and migrated == None:
-        settings.set_option('collection/flac_write_bpm_to_tempo', True)
+        settings.set_option('collection/use_legacy_metadata_mapping', True)
     elif firstrun:
-        settings.set_option('collection/flac_write_bpm_to_tempo', False)
+        settings.set_option('collection/use_legacy_metadata_mapping', False)

--- a/xlgui/preferences/collection.py
+++ b/xlgui/preferences/collection.py
@@ -192,7 +192,7 @@ class UseLegacyMetadataMappingSyncNow(widgets.Button, widgets.Conditional):
         self.scan_thread.connect('done', self.on_done)
         self.monitor = self.progress.add_monitor(
             self.scan_thread,
-            _("Migrating ratings to audio file metadata"),
+            _("Migrating metadata"),
             'document-open',
         )
 

--- a/xlgui/preferences/collection.py
+++ b/xlgui/preferences/collection.py
@@ -217,9 +217,11 @@ class UseLegacyMetadataMappingSyncNow(widgets.Button, widgets.Conditional):
 
             settings.set_option('collection/use_legacy_metadata_mapping', True)
             bpm = trax.get_tag_disk('tempo')
+            comment = trax.get_tag_disk('description')
 
             settings.set_option('collection/use_legacy_metadata_mapping', False)
             trax.set_tag_disk('bpm', bpm)
+            trax.set_tag_disk('comment', comment)
 
             i += 1
             yield i, total


### PR DESCRIPTION
Some metadata mappings are not like the standard.
Sources:
https://picard-docs.musicbrainz.org/en/appendices/tag_mapping.html
https://wiki.hydrogenaud.io/index.php?title=Tag_Mapping
https://docs.kde.org/trunk5/en/kid3/kid3/commands.html#frame-list

See also discussion at #682 

For flac and ogg there is new mapping and migration for bpm and comment.

