### PR TITLE
Add plugin path to sys.path to allow dynamic loading of modules

### DIFF
--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -56,8 +56,11 @@ class CdPlugin:
 
     def __import_dependency(self, module_name):
         try:
-            full_name = 'plugins.cd.' + module_name + '_parser'
-            return importlib.import_module(full_name)
+            sys.path.append(os.path.dirname(__file__))
+            full_name = module_name + '_parser'
+            imported = importlib.import_module(full_name)
+            sys.path.pop()
+            return imported
         except ImportError:
             logger.warn(
                 'Cannot import optional dependency "%s" for plugin cd.', module_name


### PR DESCRIPTION
The cd-plugin loads the parser modules for discid and musicbrainzng dynamically to catch missing dependencies.

This works in case Exaile is run from source and plugins are in `{$exaile_dir}/plugins` because the `$exaile_dir` is in sys.path

If Exaile is installed to the system the exaile directory is /usr/lib/exaile and plugins are in /usr/share/exaile.
In this case the plugins directory is not in sys.path