### PR TITLE
Small trifles with cd plugin

### DIFF
--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -165,7 +165,7 @@ class CDPlaylist(playlist.Playlist):
             self.__device = "/dev/cdrom"
         else:
             self.__device = device
-        self.__read_disc_index_async(device)
+        GLib.idle_add(self.__read_disc_index_async, device)
 
     @common.threaded
     def __read_disc_index_async(self, device):

--- a/plugins/cd/__init__.py
+++ b/plugins/cd/__init__.py
@@ -165,7 +165,7 @@ class CDPlaylist(playlist.Playlist):
             self.__device = "/dev/cdrom"
         else:
             self.__device = device
-        GLib.idle_add(self.__read_disc_index_async, device)
+        self.__read_disc_index_async(device)
 
     @common.threaded
     def __read_disc_index_async(self, device):

--- a/plugins/cd/_cdguipanel.py
+++ b/plugins/cd/_cdguipanel.py
@@ -138,7 +138,7 @@ class CDImporter:
 
     def __prepare_transcoder(self):
         formats = transcoder.get_formats()
-        default_format = next(formats.keys())
+        default_format = next(iter(formats))
         self.format = settings.get_option("cd_import/format", default_format)
         default_quality = formats[default_format]['default']
         self.quality = settings.get_option("cd_import/quality", default_quality)
@@ -184,7 +184,7 @@ class CDImporter:
 
     def _end_cb(self):
         self.cont.set()
-        xlgui.main.mainwindow().message.show_info("Finished transcoding files")
+        xlgui.main.mainwindow().message.show_info(_("Finished transcoding files"))
 
     def _error_cb(self, gerror, message_string):
         self.running = False

--- a/xl/transcoder.py
+++ b/xl/transcoder.py
@@ -85,7 +85,7 @@ FORMATS = {
         "default"   : 160,
         "raw_steps" : [32, 48, 64, 96, 128, 160, 192, 224, 256, 320],
         "kbs_steps" : [32, 48, 64, 96, 128, 160, 192, 224, 256, 320],
-        "command"   : "lame vbr=4 vbr-mean-bitrate=%i",
+        "command"   : "lamemp3enc vbr=4 vbr-mean-bitrate=%i",
         "extension" : "mp3",
         "plugins"   : ["lamemp3enc"],
         "desc"      : _("A proprietary and older, but also popular, lossy "
@@ -96,7 +96,7 @@ FORMATS = {
         "default"   : 160,
         "raw_steps" : [32, 48, 64, 96, 128, 160, 192, 224, 256, 320],
         "kbs_steps" : [32, 48, 64, 96, 128, 160, 192, 224, 256, 320],
-        "command"   : "lame bitrate=%i",
+        "command"   : "lamemp3enc bitrate=%i",
         "extension" : "mp3",
         "plugins"   : ["lamemp3enc"],
         "desc"      : _("A proprietary and older, but also popular, "


### PR DESCRIPTION
Some small fixes:
* Missing gettext
* Retrieving default format from formats list
* encode as mp3 needs to use lamemp3enc now

FWIW reading the disc index (https://github.com/exaile/exaile/blob/master/plugins/cd/__init__.py#L174) is seems not to be running on its own thread.
At least here Exaile gui is blocked during reading the index.
@ryneeverett Do you know of this?