### PR TITLE
wikipedia: use WebKit2 4.1(and libsoup 3)

### DIFF
--- a/plugins/wikipedia/__init__.py
+++ b/plugins/wikipedia/__init__.py
@@ -30,7 +30,7 @@ from . import preferences
 
 import gi
 
-gi.require_version('WebKit2', '4.0')
+gi.require_version('WebKit2', '4.1')
 from gi.repository import WebKit2
 
 


### PR DESCRIPTION
The only difference between 4.0 and 4.1 is the libsoup version (2.4 vs 3.0) used by each.  libsoup 2.4, and hence WebKit2 4.0, are unmaintained and are being dropped by distributions.  Nothing else here uses libsoup directly, so no further porting is required.