### PR TITLE
chore: Use HTTPS for icecast access

### DIFF
--- a/plugins/icecast/__init__.py
+++ b/plugins/icecast/__init__.py
@@ -69,7 +69,7 @@ class IcecastRadioStation(RadioStation):
         """
         self.exaile = exaile
         self.user_agent = exaile.get_user_agent_string('icecast')
-        self.icecast_url = 'http://dir.xiph.org'
+        self.icecast_url = 'https://dir.xiph.org'
 
         self.xml_url = self.icecast_url + '/yp.xml'
         self.genres_url = self.icecast_url + '/genres'


### PR DESCRIPTION
HTTP is not private and allows man-in-the-middle attacks. HTTPS provides some privacy and protects against simple man-in-the-middle attacks.