### PR TITLE
Disable fuzzy matching for msgmerge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ pot:
 	  xgettext -j -o messages.pot --keyword=X-GNOME-FullName '../data/exaile.desktop.in' && \
 	  xgettext -j -o messages.pot '../data/exaile.appdata.xml.in' )
 	find po -name '*.po' -exec \
-	  msgmerge --previous --update {} po/messages.pot \;
+	  msgmerge --previous --no-fuzzy-matching --update {} po/messages.pot \;
 	echo $(LINGUAS) > po/LINGUAS
 
 potball: builddir


### PR DESCRIPTION
In this PR I would like to disable fuzzy matching for msgmerge.

While generating po files for #877 I saw that `msgmerge` fuzzy matching wants to use the translation of `Disc metadata` as the translation of `Migrating metadata`, which would be wrong. This happens even with the current master

If using the `--no-fuzzy-matching` switch it won't happen.

Example without `--no-fuzzy-matching`
```
#: ../xlgui/preferences/collection.py:195
#, fuzzy
#| msgid "Disc metadata"
msgid "Migrating metadata"
msgstr "CD-Metadaten"
```

Example with `--no-fuzzy-matching`
```
#: ../xlgui/preferences/collection.py:195
msgid "Migrating metadata"
msgstr ""
```