### PR TITLE
Don't add unsupported media files to library

### DIFF
--- a/xl/collection.py
+++ b/xl/collection.py
@@ -735,6 +735,10 @@ class Library:
             # on windows, unknown why fix isn't needed on linux.
             elif not tr._init:
                 self.collection.add(tr)
+
+        if not tr.is_supported():
+            return None
+
         return tr
 
     def rescan(
@@ -837,6 +841,9 @@ class Library:
                 continue
 
             if not gloc.query_exists(None):
+                removals.append(tr)
+
+            if not tr.is_supported():
                 removals.append(tr)
 
         for tr in removals:

--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -417,7 +417,7 @@ class Track:
                 ).get_modification_time()
                 mtime = mtime.tv_sec + (mtime.tv_usec / 100000.0)
 
-            f = self._get_format_obj()
+            f = metadata.get_format(loc)
             if not force and self.__tags.get('__modified', 0) >= mtime:
                 return f
 
@@ -474,7 +474,8 @@ class Track:
         Determines if a file has a supported media format
         """
         if self._is_supported is None:
-            f = self._get_format_obj()
+            loc = self.get_loc_for_io()
+            f = metadata.get_format(loc)
             if f is None:
                 self._is_supported = False
             else:

--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -155,7 +155,14 @@ class Track:
     """
 
     # save a little memory this way
-    __slots__ = ["__tags", "_scan_valid", "_dirty", "__weakref__", "_init", "_is_supported"]
+    __slots__ = [
+        "__tags",
+        "_scan_valid",
+        "_dirty",
+        "__weakref__",
+        "_init",
+        "_is_supported",
+    ]
     # this is used to enforce the one-track-per-uri rule
     __tracksdict = weakref.WeakValueDictionary()
     # store a copy of the settings values here - much faster (0.25 cpu
@@ -410,6 +417,7 @@ class Track:
                 ).get_modification_time()
                 mtime = mtime.tv_sec + (mtime.tv_usec / 100000.0)
 
+            f = metadata.get_format(loc)
             if not force and self.__tags.get('__modified', 0) >= mtime:
                 return f
 

--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -155,7 +155,7 @@ class Track:
     """
 
     # save a little memory this way
-    __slots__ = ["__tags", "_scan_valid", "_dirty", "__weakref__", "_init"]
+    __slots__ = ["__tags", "_scan_valid", "_dirty", "__weakref__", "_init", "_is_supported"]
     # this is used to enforce the one-track-per-uri rule
     __tracksdict = weakref.WeakValueDictionary()
     # store a copy of the settings values here - much faster (0.25 cpu
@@ -249,6 +249,7 @@ class Track:
 
         self.__tags = {}
         self._scan_valid = None  # whether our last tag read attempt worked
+        self._is_supported = None
 
         # This is not used by write_tags, this is used by the collection to
         # indicate that the tags haven't been written to the collection
@@ -388,13 +389,13 @@ class Track:
         Returns False if unsuccessful, and a Format object from
         `xl.metadata` otherwise.
         """
+
+        if not self.is_supported():
+            self._scan_valid = False
+            return False
+
         loc = self.get_loc_for_io()
         try:
-            f = metadata.get_format(loc)
-            if f is None:
-                self._scan_valid = False
-                return False  # not a supported type
-
             # Retrieve file specific metadata
             gloc = Gio.File.new_for_uri(loc)
             if hasattr(Gio.FileInfo, 'get_modification_date_time'):  # GLib >=2.62
@@ -459,6 +460,20 @@ class Track:
         if self.get_local_path():
             return True
         return False
+
+    def is_supported(self):
+        """
+        Determines if a file has a supported media format
+        """
+        if self._is_supported is None:
+            loc = self.get_loc_for_io()
+            f = metadata.get_format(loc)
+            if f is None:
+                self._is_supported = False
+            else:
+                self._is_supported = True
+
+        return self._is_supported
 
     def get_size(self):
         """

--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -417,7 +417,7 @@ class Track:
                 ).get_modification_time()
                 mtime = mtime.tv_sec + (mtime.tv_usec / 100000.0)
 
-            f = metadata.get_format(loc)
+            f = self._get_format_obj()
             if not force and self.__tags.get('__modified', 0) >= mtime:
                 return f
 
@@ -474,8 +474,7 @@ class Track:
         Determines if a file has a supported media format
         """
         if self._is_supported is None:
-            loc = self.get_loc_for_io()
-            f = metadata.get_format(loc)
+            f = self._get_format_obj()
             if f is None:
                 self._is_supported = False
             else:

--- a/xl/trax/trackdb.py
+++ b/xl/trax/trackdb.py
@@ -337,6 +337,9 @@ class TrackDB:
             # Don't add duplicates -- track URLs are unique
             if location in self.tracks:
                 continue
+            # Don't add unsupported media files
+            if not tr.is_supported():
+                continue
             locations += [location]
             self.tracks[location] = TrackHolder(tr, self._key)
             self._key += 1


### PR DESCRIPTION
Fixes #883

Reproduction:
* Add a folder with cover.png (or any other unsupported file) to the library
* Mark the folder as monitored
* Change the name of cover.png

After this cover.png is imported to the library.

With this pull request there will be a test if a file is supported.
Also the accidentally imported files will be removed.