### PR TITLE
Wikipedia plugin: decode page content to string

### DIFF
--- a/plugins/wikipedia/__init__.py
+++ b/plugins/wikipedia/__init__.py
@@ -30,7 +30,10 @@ from . import preferences
 
 import gi
 
-gi.require_version('WebKit2', '4.0')
+try:
+    gi.require_version('WebKit2', '4.1')
+except:
+    gi.require_version('WebKit2', '4.0')
 from gi.repository import WebKit2
 
 
@@ -124,7 +127,7 @@ class BrowserPage(WebKit2.WebView):
         url = "https://%s.m.wikipedia.org/wiki/Special:Search/%s" % (language, artist)
 
         try:
-            html = common.get_url_contents(url, self.__user_agent)
+            html = common.get_url_contents(url, self.__user_agent).decode("utf-8")
         except urllib.error.URLError as e:
             log.error(e)
             log.error(

--- a/plugins/wikipedia/__init__.py
+++ b/plugins/wikipedia/__init__.py
@@ -127,7 +127,9 @@ class BrowserPage(WebKit2.WebView):
         url = "https://%s.m.wikipedia.org/wiki/Special:Search/%s" % (language, artist)
 
         try:
-            html = common.get_url_contents(url, self.__user_agent).decode("utf-8")
+            html = common.get_url_contents(url, self.__user_agent)
+            if not isinstance(html, str):
+                html = html.decode("utf-8")
         except urllib.error.URLError as e:
             log.error(e)
             log.error(


### PR DESCRIPTION
Currently the wikipedia plugin is not showing any web content, because the content retrieved by urllib needs to be decoded to string.

Additionally the enhancement from #875 is integrated.