### PR TITLE
Update tested distribution versions and dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
     strategy:
       matrix:
         imgtag:
-          - debian-10
+          - debian-11
           - debian-stable
-          - fedora-34
+          - fedora-37
           - fedora-latest
-          - ubuntu-18.04
+          - ubuntu-20.04
           - ubuntu-rolling
     timeout-minutes: 4
     runs-on: ubuntu-latest
@@ -37,12 +37,10 @@ jobs:
         # we de-escalate manually here.
         # This requires the image to already have a user named `exaile`, created
         # using e.g. `useradd -MN exaile`.
-        # The GST_REGISTRY_FORK=no works around <https://github.com/exaile/exaile/issues/783>
-        # until it's supposedly fixed in GLib 2.70.3.
         run: |
           chown -R exaile .
           export HOME=/tmp/home
-          su -m exaile -c "GST_REGISTRY_FORK=no make BUILDDIR=/tmp/build test test_compile check-doc"
+          su -m exaile -c "make BUILDDIR=/tmp/build test test_compile check-doc"
 
   deploy:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')

--- a/DEPS
+++ b/DEPS
@@ -11,20 +11,19 @@ Core dependencies
 
 Essential:
 
-* python3 >= 3.6
-* python3-typing-extensions (python3 <= 3.7 only)
+* python3 >= 3.8
 * python3-bsddb3
-* gtk+ >= 3.22
-* gstreamer (>= 1.14)
-* gstreamer-plugins-base (>= 1.14)
-* gstreamer-plugins-good (>= 1.14)
-* python3-mutagen (>= 1.38)
+* gtk+ >= 3.24
+* gstreamer (>= 1.16)
+* gstreamer-plugins-base (>= 1.16)
+* gstreamer-plugins-good (>= 1.16)
+* python3-mutagen (>= 1.44)
 * python3-dbus
 * GI typelib files for GTK+, GStreamer (including gstreamer-plugins-base) and cairo and their python bindings
 
   * Packages on Debian and Ubuntu:
 
-    * python3-gi >= 3.22
+    * python3-gi >= 3.36
     * python3-gi-cairo
     * gir1.2-gtk-3.0
     * gir1.2-gstreamer-1.0
@@ -33,7 +32,7 @@ Essential:
   * Packages on Fedora:
 
     * python3-cairo
-    * python3-gobject >= 3.22
+    * python3-gobject >= 3.24
     * python3-gstreamer1
 
 Optional dependencies
@@ -53,7 +52,7 @@ Device detection:
 
 * udisks2
 
-CD info: (TODO: This is currently broken on python3, see #608 and #652)
+CD info:
 
 * python-libdiscid or python-discid (optional on linux, required to use musicbrainz)
 * python-musicbrainzngs (optional)


### PR DESCRIPTION
Update tested distribution versions, reflecting [exaile/exaile-testimg!2](https://github.com/exaile/exaile-testimg2/pull/1).

Update dependencies based on the package version shipped by our oldest supported distribution, Ubuntu 20.04 (old LTS) with help of Ubuntu's package list https://packages.ubuntu.com/