### PR TITLE
chore: Drop some outdated backward compatibility code

### DIFF
--- a/plugins/daapclient/client.py
+++ b/plugins/daapclient/client.py
@@ -13,8 +13,6 @@ class DAAPClient:
         self.socket = None
         self.request_id = 0
 
-    #        self._old_itunes = 0
-
     def connect(self, hostname, port=3689, password=None, user_agent=None):
         if self.socket is not None:
             raise DAAPError("DAAPClient: already connected.")
@@ -61,10 +59,7 @@ class DAAPClient:
         if self.request_id > 0:
             headers['Client-DAAP-Request-ID'] = self.request_id
 
-        #        if (self._old_itunes):
-        #            headers[ 'Client-DAAP-Validation' ] = hash_v2(r, 2)
-        #        else:
-        #            headers[ 'Client-DAAP-Validation' ] = hash_v3(r, 2, self.request_id)
+        # headers[ 'Client-DAAP-Validation' ] = hash_v3(r, 2, self.request_id)
 
         # there are servers that don't allow >1 download from a single HTTP
         # session, or something. Reset the connection each time. Thanks to
@@ -131,15 +126,6 @@ class DAAPClient:
 
     def getInfo(self):
         self.request('/server-info')
-
-        # detect the 'old' iTunes 4.2 servers, and set a flag, so we use
-        # the real MD5 hash algo to verify requests.
-
-    #        version = response.getAtom("apro") or response.getAtom("ppro")
-    #        if int(version) == 2:
-    #            self._old_itunes = 1
-
-    # response.printTree()
 
     def login(self):
         response = self.request("/login")

--- a/plugins/keybinder/__init__.py
+++ b/plugins/keybinder/__init__.py
@@ -44,15 +44,7 @@ class KeybinderPlugin:
         self.__exaile = None
 
     def enable(self, exaile):
-        broken = False
-        if hasattr(Keybinder, 'supported'):
-            # introduced in Keybinder-3.0 0.3.2, see
-            # https://github.com/kupferlauncher/keybinder/blob/master/NEWS
-            if not Keybinder.supported():
-                broken = True
-        elif not guiutil.platform_is_x11():
-            broken = True
-        if broken:
+        if not Keybinder.supported():
             raise Exception(
                 _(
                     'Keybinder is not supported on this platform! '

--- a/xl/externals/gi_composites.py
+++ b/xl/externals/gi_composites.py
@@ -72,9 +72,6 @@ def _register_template(cls, template_bytes):
     # This implementation won't work if there are nested templates, but
     # we can't do that anyways due to PyGObject limitations so it's ok
 
-    if not hasattr(cls, 'set_template'):
-        raise TypeError("Requires PyGObject 3.13.2 or greater")
-
     cls.set_template(template_bytes)
 
     bound_methods = set()

--- a/xl/player/gst/__init__.py
+++ b/xl/player/gst/__init__.py
@@ -16,17 +16,11 @@ from gi.repository import Gst
 
 Gst.init(None)
 
-try:
-    __gst_version__ = '%s.%s.%s' % (
-        Gst.VERSION_MAJOR,
-        Gst.VERSION_MINOR,
-        Gst.VERSION_MICRO,
-    )
-except AttributeError:
-    # Old version of GStreamer < 1.3.3
-    # https://bugzilla.gnome.org/show_bug.cgi?id=703021
-    __gst_version__ = '**unknown version < 1.3.3**'
-
+__gst_version__ = '%s.%s.%s' % (
+    Gst.VERSION_MAJOR,
+    Gst.VERSION_MINOR,
+    Gst.VERSION_MICRO,
+)
 
 from xl.version import register
 

--- a/xl/trax/track.py
+++ b/xl/trax/track.py
@@ -405,18 +405,11 @@ class Track:
         try:
             # Retrieve file specific metadata
             gloc = Gio.File.new_for_uri(loc)
-            if hasattr(Gio.FileInfo, 'get_modification_date_time'):  # GLib >=2.62
-                mtime = (
-                    gloc.query_info("time::modified", Gio.FileQueryInfoFlags.NONE, None)
-                    .get_modification_date_time()
-                    .to_unix()
-                )
-            else:  # Deprecated due to the Year 2038 problem
-                mtime = gloc.query_info(
-                    "time::modified", Gio.FileQueryInfoFlags.NONE, None
-                ).get_modification_time()
-                mtime = mtime.tv_sec + (mtime.tv_usec / 100000.0)
-
+            mtime = (
+                gloc.query_info("time::modified", Gio.FileQueryInfoFlags.NONE, None)
+                .get_modification_date_time()
+                .to_unix()
+            )
             f = metadata.get_format(loc)
             if not force and self.__tags.get('__modified', 0) >= mtime:
                 return f

--- a/xlgui/guiutil.py
+++ b/xlgui/guiutil.py
@@ -115,18 +115,9 @@ def get_workarea_dimensions(window=None):
         screen = Gdk.Screen.get_default()
         default_monitor = screen.get_primary_monitor()
         return screen.get_monitor_workarea(default_monitor)
-    elif (
-        Gtk.get_major_version() > 3
-        or Gtk.get_major_version() == 3
-        and Gtk.get_minor_version() >= 22
-    ):
-        # Gdk.Monitor was introduced in Gtk+ 3.22
+    else:
         display = window.get_window().get_display()
         work_area = display.get_monitor_at_window(window.get_window()).get_workarea()
-    else:
-        screen = window.get_screen()
-        monitor_nr = screen.get_monitor_at_window(window.get_window())
-        work_area = screen.get_monitor_workarea(monitor_nr)
     return work_area
 
 

--- a/xlgui/widgets/info.py
+++ b/xlgui/widgets/info.py
@@ -25,16 +25,7 @@
 # do so. If you do not wish to do so, delete this exception statement
 # from your version.
 
-try:
-    from typing import Literal  # python >= 3.8
-except ImportError:
-    # python <= 3.7 requires typing_extensions package
-    try:
-        from typing_extensions import Literal
-    except ModuleNotFoundError as e:
-        raise RuntimeError(
-            "Please install typing-extensions package to run exaile under python <= 3.7."
-        ) from e
+from typing import Literal
 
 from gi.repository import GLib
 from gi.repository import Gtk


### PR DESCRIPTION
This code is no longer needed because support for the software versions it refers to has been removed.