### PR TITLE
chore: fix some pytest warnings

### DIFF
--- a/tests/xl/trax/test_search.py
+++ b/tests/xl/trax/test_search.py
@@ -19,7 +19,7 @@ def get_search_result_track():
 
 
 class TestMatcher:
-    def setup(self):
+    def setup_method(self):
         self.strack = get_search_result_track()
         self.strack.track.set_tag_raw('artist', ['foo', 'bar'])
 
@@ -54,7 +54,7 @@ class TestMatcher:
 
 
 class TestExactMatcher:
-    def setup(self):
+    def setup_method(self):
         self.str = get_search_result_track()
 
     def test_exact_matcher_true(self):
@@ -69,7 +69,7 @@ class TestExactMatcher:
 
 
 class TestInMatcher:
-    def setup(self):
+    def setup_method(self):
         self.str = get_search_result_track()
 
     def test_in_matcher_none(self):
@@ -94,7 +94,7 @@ class TestInMatcher:
 
 
 class TestGtLtMatchers:
-    def setup(self):
+    def setup_method(self):
         self.str = get_search_result_track()
 
     def test_gt_bitrate_matcher_true(self):
@@ -197,7 +197,7 @@ class TestManyMultiMetaMatcher(TestMetaMatcherClasses):
 
 
 class TestTracksMatcher:
-    def setup(self):
+    def setup_method(self):
         self.str = get_search_result_track()
 
     def test_in_matcher(self):

--- a/tests/xl/trax/test_track.py
+++ b/tests/xl/trax/test_track.py
@@ -21,7 +21,7 @@ class Test_MetadataCacher:
     TIMEOUT = 2000
     MAX_ENTRIES = 2
 
-    def setup(self):
+    def setup_method(self):
         self.mc: track._MetadataCacher[str, str] = track._MetadataCacher(
             self.TIMEOUT, self.MAX_ENTRIES
         )

--- a/tests/xl/trax/test_util.py
+++ b/tests/xl/trax/test_util.py
@@ -41,7 +41,7 @@ class TestGetTracksFromUri:
 
 
 class TestSortTracks:
-    def setup(self):
+    def setup_method(self):
         self.tracks = [
             xl.trax.track.Track(url) for url in ('/tmp/foo', '/tmp/bar', '/tmp/baz')
         ]
@@ -62,7 +62,7 @@ class TestSortTracks:
 
 
 class TestSortResultTracks:
-    def setup(self):
+    def setup_method(self):
         tracks = [
             xl.trax.track.Track(url) for url in ('/tmp/foo', '/tmp/bar', '/tmp/baz')
         ]


### PR DESCRIPTION
See also: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose