### PR TITLE
Extend multitextentrydialog with values and hints

### DIFF
--- a/xlgui/widgets/dialogs.py
+++ b/xlgui/widgets/dialogs.py
@@ -203,7 +203,7 @@ class MultiTextEntryDialog(Gtk.Dialog):
 
         self.fields = []
 
-    def add_field(self, label):
+    def add_field(self, label, value = None):
         """
         Adds a field and corresponding label
 
@@ -221,6 +221,10 @@ class MultiTextEntryDialog(Gtk.Dialog):
         entry.set_width_chars(30)
         entry.set_icon_activatable(Gtk.EntryIconPosition.SECONDARY, False)
         entry.connect('activate', lambda *e: self.response(Gtk.ResponseType.OK))
+
+        if value is not None:
+            entry.set_text(value)
+
         self.__entry_area.attach(entry, 1, line_number, 1, 1)
         label.show()
         entry.show()

--- a/xlgui/widgets/dialogs.py
+++ b/xlgui/widgets/dialogs.py
@@ -203,7 +203,7 @@ class MultiTextEntryDialog(Gtk.Dialog):
 
         self.fields = []
 
-    def add_field(self, label, value = None, tooltip = None):
+    def add_field(self, label, value=None, tooltip=None):
         """
         Adds a field and corresponding label
 
@@ -226,7 +226,9 @@ class MultiTextEntryDialog(Gtk.Dialog):
             entry.set_text(value)
 
         if tooltip is not None:
-            entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, 'dialog-information')
+            entry.set_icon_from_icon_name(
+                Gtk.EntryIconPosition.SECONDARY, 'dialog-information'
+            )
             entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, tooltip)
 
         self.__entry_area.attach(entry, 1, line_number, 1, 1)

--- a/xlgui/widgets/dialogs.py
+++ b/xlgui/widgets/dialogs.py
@@ -203,11 +203,13 @@ class MultiTextEntryDialog(Gtk.Dialog):
 
         self.fields = []
 
-    def add_field(self, label, value=None, tooltip=None):
+    def add_field(self, label: str, value: str = None, tooltip: str = None):
         """
         Adds a field and corresponding label
 
         :param label: the label to display
+        :param value: the text in entry field
+        :param tooltip: a tooltip to show
         :returns: the newly created entry
         :rtype: :class:`Gtk.Entry`
         """

--- a/xlgui/widgets/dialogs.py
+++ b/xlgui/widgets/dialogs.py
@@ -203,7 +203,7 @@ class MultiTextEntryDialog(Gtk.Dialog):
 
         self.fields = []
 
-    def add_field(self, label, value = None):
+    def add_field(self, label, value = None, tooltip = None):
         """
         Adds a field and corresponding label
 
@@ -224,6 +224,10 @@ class MultiTextEntryDialog(Gtk.Dialog):
 
         if value is not None:
             entry.set_text(value)
+
+        if tooltip is not None:
+            entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, 'dialog-information')
+            entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, tooltip)
 
         self.__entry_area.attach(entry, 1, line_number, 1, 1)
         label.show()


### PR DESCRIPTION
With this the MultiTextEntryDialog widget is able to show text entries with preset value and an optional hint.