### PR TITLE
Fix gone track-properties menu item references

### DIFF
--- a/plugins/audioscrobbler/__init__.py
+++ b/plugins/audioscrobbler/__init__.py
@@ -138,7 +138,7 @@ class ExaileScrobbler:
 
         providers.register(
             'menubar-tools-menu',
-            menu.simple_separator('plugin-sep', ['track-properties']),
+            menu.simple_separator('plugin-sep', ['slow-scan-collection']),
         )
 
         def factory(menu_, parent, context):

--- a/plugins/bookmarks/__init__.py
+++ b/plugins/bookmarks/__init__.py
@@ -325,7 +325,7 @@ class BookmarksPlugin:
 
         # add tools menu items
         providers.register(
-            'menubar-tools-menu', _sep('plugin-sep', ['track-properties'])
+            'menubar-tools-menu', _sep('plugin-sep', ['slow-scan-collection'])
         )
         item = _smi(
             'bookmarks',

--- a/plugins/daapclient/__init__.py
+++ b/plugins/daapclient/__init__.py
@@ -735,7 +735,7 @@ class DaapClientPlugin:
         menu_ = menu.Menu(None)
 
         providers.register(
-            'menubar-tools-menu', _sep('plugin-sep', ['track-properties'])
+            'menubar-tools-menu', _sep('plugin-sep', ['slow-scan-collection'])
         )
 
         item = _smi('daap', ['plugin-sep'], _('Connect to DAAP...'), submenu=menu_)

--- a/plugins/shutdown/__init__.py
+++ b/plugins/shutdown/__init__.py
@@ -33,7 +33,7 @@ class Shutdown:
         # add menuitem to tools menu
         providers.register(
             'menubar-tools-menu',
-            menu.simple_separator('plugin-sep', ['track-properties']),
+            menu.simple_separator('plugin-sep', ['slow-scan-collection']),
         )
 
         item = menu.check_menu_item(


### PR DESCRIPTION
Fixes #901 by replacing the reference to track-properties menu item with slow-scan-collection menu item