### PR TITLE
Shutdown plugin - Add preferences for activation by default and timeout

### DIFF
--- a/plugins/shutdown/__init__.py
+++ b/plugins/shutdown/__init__.py
@@ -22,6 +22,8 @@ from xl import event, providers
 from xl.nls import gettext as _
 from xlgui.widgets import dialogs, menu
 
+from . import shutdown_preferences
+
 SHUTDOWN = None
 
 
@@ -65,6 +67,7 @@ class Shutdown:
             buttons=Gtk.ButtonsType.CLOSE,
         )
         self.message.connect('response', self.on_response)
+
 
     def on_toggle(self, menuitem, name):
         if menuitem.get_active() and name == 'close':
@@ -214,3 +217,6 @@ def _enable(eventname, exaile, nothing):
 def disable(exaile):
     global SHUTDOWN
     SHUTDOWN.destroy()
+
+def get_preferences_pane():
+    return shutdown_preferences

--- a/plugins/shutdown/__init__.py
+++ b/plugins/shutdown/__init__.py
@@ -18,7 +18,7 @@ import dbus
 from gi.repository import GLib
 from gi.repository import Gtk
 
-from xl import event, providers
+from xl import event, providers, settings
 from xl.nls import gettext as _
 from xlgui.widgets import dialogs, menu
 
@@ -31,7 +31,9 @@ class Shutdown:
     def __init__(self, exaile):
         self.exaile = exaile
         self.do_shutdown = False
-        self.do_close = False
+        self.do_close = settings.get_option(
+            "shutdown/activate_closing_by_default", False
+        )
 
         # add menuitem to tools menu
         providers.register(
@@ -48,6 +50,9 @@ class Shutdown:
             lambda w, n, p, c: self.on_toggle(w, n),
         )
         providers.register('menubar-tools-menu', item)
+
+        if self.do_close:
+            event.add_ui_callback(self.on_playback_player_end, 'playback_player_end')
 
         item = menu.check_menu_item(
             'shutdown',
@@ -67,7 +72,6 @@ class Shutdown:
             buttons=Gtk.ButtonsType.CLOSE,
         )
         self.message.connect('response', self.on_response)
-
 
     def on_toggle(self, menuitem, name):
         if menuitem.get_active() and name == 'close':
@@ -123,7 +127,7 @@ class Shutdown:
         if self.countdown is not None:
             GLib.source_remove(self.countdown)
 
-        self.counter = 10
+        self.counter = settings.get_option("shutdown/timeout", 10)
         self.countdown = GLib.timeout_add_seconds(1, self.on_timeout)
 
     def on_response(self, widget, response):
@@ -217,6 +221,7 @@ def _enable(eventname, exaile, nothing):
 def disable(exaile):
     global SHUTDOWN
     SHUTDOWN.destroy()
+
 
 def get_preferences_pane():
     return shutdown_preferences

--- a/plugins/shutdown/shutdown_preferences.py
+++ b/plugins/shutdown/shutdown_preferences.py
@@ -1,0 +1,17 @@
+import os
+from xlgui.preferences import widgets
+from xl.nls import gettext as _
+
+name = _("Shutdown")
+basedir = os.path.dirname(os.path.realpath(__file__))
+ui = os.path.join(basedir, "shutdown_preferences.ui")
+
+
+class ActivateClosingByDefault(widgets.CheckPreference):
+    default = True
+    name = "shutdown/activate_closing_by_default"
+
+
+class Timeout(widgets.SpinPreference):
+    default = 10
+    name = "shutdown/timeout"

--- a/plugins/shutdown/shutdown_preferences.py
+++ b/plugins/shutdown/shutdown_preferences.py
@@ -8,7 +8,7 @@ ui = os.path.join(basedir, "shutdown_preferences.ui")
 
 
 class ActivateClosingByDefault(widgets.CheckPreference):
-    default = True
+    default = False
     name = "shutdown/activate_closing_by_default"
 
 

--- a/plugins/shutdown/shutdown_preferences.ui
+++ b/plugins/shutdown/shutdown_preferences.ui
@@ -45,7 +45,7 @@
     </child>
     <child>
       <object class="GtkCheckButton" id="shutdown/activate_closing_by_default">
-        <property name="label" translatable="yes">Activate Closing by default each time Exaile starts</property>
+        <property name="label" translatable="yes">Activate "Close Exaile after Playback" automatically</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>

--- a/plugins/shutdown/shutdown_preferences.ui
+++ b/plugins/shutdown/shutdown_preferences.ui
@@ -13,33 +13,18 @@
     <property name="row_spacing">4</property>
     <property name="column_spacing">2</property>
     <child>
-      <object class="GtkCheckButton" id="shutdown/activate_closing_by_default">
-        <property name="label" translatable="yes">Activate Closing by default each time Exaile starts</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes"></property>
-        <property name="draw_indicator">True</property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">0</property>
-        <property name="width">3</property>
-      </packing>
-    </child>
-    <child>
       <object class="GtkLabel" id="label2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="halign">start</property>
-        <property name="label" translatable="yes">Fade duration (ms):</property>
+        <property name="label" translatable="yes">Timeout (in s):</property>
         <accessibility>
           <relation type="label-for" target="shutdown/timeout"/>
         </accessibility>
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">1</property>
+        <property name="top_attach">0</property>
       </packing>
     </child>
     <child>
@@ -54,6 +39,21 @@
       </object>
       <packing>
         <property name="left_attach">1</property>
+        <property name="top_attach">0</property>
+        <property name="width">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="shutdown/activate_closing_by_default">
+        <property name="label" translatable="yes">Activate Closing by default each time Exaile starts</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="tooltip_text" translatable="yes"></property>
+        <property name="draw_indicator">True</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
         <property name="top_attach">1</property>
         <property name="width">3</property>
       </packing>

--- a/plugins/shutdown/shutdown_preferences.ui
+++ b/plugins/shutdown/shutdown_preferences.ui
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.18.3 -->
+<interface>
+  <requires lib="gtk+" version="3.10"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">9999</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkGrid" id="preferences_pane">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="row_spacing">4</property>
+    <property name="column_spacing">2</property>
+    <child>
+      <object class="GtkCheckButton" id="shutdown/activate_closing_by_default">
+        <property name="label" translatable="yes">Activate Closing by default each time Exaile starts</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="tooltip_text" translatable="yes"></property>
+        <property name="draw_indicator">True</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+        <property name="width">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label2">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Fade duration (ms):</property>
+        <accessibility>
+          <relation type="label-for" target="shutdown/timeout"/>
+        </accessibility>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSpinButton" id="shutdown/timeout">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="xalign">1</property>
+        <property name="adjustment">adjustment1</property>
+        <accessibility>
+          <relation type="labelled-by" target="label2"/>
+        </accessibility>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">1</property>
+        <property name="width">3</property>
+      </packing>
+    </child>
+  </object>
+</interface>


### PR DESCRIPTION
This adds a plugin preference page to set the shutdown timeout and to activate the "Close Exaile after Playback" checkbox automatically each start of Exaile.