### PR TITLE
Don't remove tracks twice during scan.

### DIFF
--- a/xl/collection.py
+++ b/xl/collection.py
@@ -840,10 +840,7 @@ class Library:
                 logger.exception("Error decoding file location")
                 continue
 
-            if not gloc.query_exists(None):
-                removals.append(tr)
-
-            if not tr.is_supported():
+            if not (gloc.query_exists(None) or tr.is_supported()):
                 removals.append(tr)
 
         for tr in removals:


### PR DESCRIPTION
A bug was introduced in #885 by potentially adding tracks to `removals` twice if both conditions are true. This results in a KeyError when removal of the second track is attempted because the `location` has already been deleted from `self.tracks`:

    File "./xl/trax/trackdb.py", line 369, in remove_tracks
      self._deleted_keys.append(self.tracks[location]._key)
    KeyError: 'file:///...'