### PR TITLE
Track-Fader: Return None if track length is unknown

### DIFF
--- a/xl/player/track_fader.py
+++ b/xl/player/track_fader.py
@@ -83,6 +83,9 @@ class TrackFader:
         stop_offset = track.get_tag_raw('__stopoffset') or 0
         tracklen = track.get_tag_raw('__length') or 0
 
+        if tracklen == 0:
+            return (None,) * 4
+
         if stop_offset < 1:
             stop_offset = tracklen
 


### PR DESCRIPTION
Seen while testing #940 

In case of playing a file that's not readable by mutagen the track length is unknown.

This causes the fader to stop immediately. 

Return None in this case instead diables the fader for this track.