### PR TITLE
Fix and clarify queue behaviors

### DIFF
--- a/data/ui/preferences/playback.ui
+++ b/data/ui/preferences/playback.ui
@@ -218,7 +218,7 @@
     </child>
     <child>
       <object class="GtkCheckButton" id="queue/remove_item_after_played">
-        <property name="label" translatable="yes">Remove after playback</property>
+        <property name="label" translatable="yes">Remove track from queue after playback</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>

--- a/xl/player/queue.py
+++ b/xl/player/queue.py
@@ -171,7 +171,9 @@ class PlayQueue(playlist.Playlist):
                         return self[0]
             else:
                 # if queue isn't removing items, it's just a normal playlist
-                return playlist.Playlist.get_next(self)
+                next = playlist.Playlist.get_next(self)
+                if next is not None:
+                    return next
         if self.current_playlist is not self:
             return self.current_playlist.get_next()
         elif self.last_playlist is not None:


### PR DESCRIPTION
@luzip665 I think this retains your desired queue behaviors and also retains mine as well. In particular, if there is no removal from the queue during playback, I expect the queue to behave like a normal playlist

- Clearly separate remove before/after playback flags
- If not removing from queue, restore normal playlist behavior

I should probably write some queue tests (#945).

Fixes #946