### PR TITLE
Plugin reload fails and remove crashes

### DIFF
--- a/xl/plugins.py
+++ b/xl/plugins.py
@@ -80,7 +80,7 @@ class PluginsManager:
         )
         plugin = importlib.util.module_from_spec(spec)
         # We need to temporarily add the plugin to sys.modules because otherwise the loader will fail to exec_module() if the plugin uses relative imports.
-        if pluginname in sys.modules:
+        if pluginname in sys.modules and sys.modules[pluginname] != None:
             raise InvalidPluginError(
                 _('Plugin is already loaded or has a conflicting name.')
             )

--- a/xlgui/preferences/plugin.py
+++ b/xlgui/preferences/plugin.py
@@ -230,7 +230,7 @@ class PluginManager:
 
         GLib.idle_add(self.ask_for_remove, plugin_name)
 
-    def ask_for_remove(self,  plugin_name: str):
+    def ask_for_remove(self, plugin_name: str):
         response = dialogs.yesno(
             self.window,
             "\n".join(

--- a/xlgui/preferences/plugin.py
+++ b/xlgui/preferences/plugin.py
@@ -228,6 +228,9 @@ class PluginManager:
         if not user_installed:
             return
 
+        GLib.idle_add(self.ask_for_remove, plugin_name)
+
+    def ask_for_remove(self,  plugin_name: str):
         response = dialogs.yesno(
             self.window,
             "\n".join(


### PR DESCRIPTION
1. Plugin reload fails 
Setting the entry in `sys.modules`to none does not remove the key from the dict (at least in Python 3.12

2. Plugin remove crashes Exaile
The confirmation dialog on removing an user installed plugin causes a SIGSEV