### PR TITLE
Fix marker props

### DIFF
--- a/xlgui/widgets/playback.py
+++ b/xlgui/widgets/playback.py
@@ -278,7 +278,7 @@ class Marker(GObject.GObject):
         try:
             return self.__values[gproperty.name]
         except KeyError:
-            raise AttributeError('unknown property %s' % property.name)
+            raise AttributeError('unknown property %s' % gproperty.name)
 
     def do_set_property(self, gproperty, value):
         """

--- a/xlgui/widgets/playback.py
+++ b/xlgui/widgets/playback.py
@@ -284,10 +284,9 @@ class Marker(GObject.GObject):
         """
         Sets a GObject property
         """
-        try:
-            self.__values[gproperty.name] = value
-        except KeyError:
-            raise AttributeError('unknown property %s' % property.name)
+        if gproperty.name not in self.__values:
+            raise AttributeError('unknown property %s' % gproperty.name)
+        self.__values[gproperty.name] = value
 
 
 class MarkerManager(providers.ProviderHandler):


### PR DESCRIPTION
I don't know if the issues can actually be triggered, but the existing code was definitely wrong.

1. `property` is a typo; should be `gproperty`.

2. In this code, KeyError is never raised; it will just write to a new key in `self.__values` (which is a normal dict):
  ```py
  try:
      self.__values[gproperty.name] = value
  except KeyError:
      ...
  ```