### PR TITLE
Fix race condition for exaile.desktop build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ format:
 check_format:
 	$(BLACK) --check --diff -S *.py plugins/ xl/ xlgui/ tests/ tools/installer/exaile.spec
 
-desktop_files: builddir
+desktop_files: builddir pot
 	msgfmt --desktop --template=data/exaile.desktop.in -d po -o build/exaile.desktop
 	msgfmt --xml --template=data/exaile.appdata.xml.in -d po -o build/exaile.appdata.xml
 


### PR DESCRIPTION
Without this patch, `make -j4` would create the `exaile.desktop` file at the very beginning of the build and complain about missing `po/LINGUAS` input. That means it missed translations when compared to the -j1 build.

This patch was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).