### PR TITLE
Support GIRepository-3.0

### DIFF
--- a/xl/main.py
+++ b/xl/main.py
@@ -54,7 +54,6 @@ def _do_heavy_imports():
     gi.require_version('Gdk', '3.0')
     gi.require_version('Gtk', '3.0')
     gi.require_version('Gst', '1.0')
-    gi.require_version('GIRepository', '2.0')
     gi.require_version('GstPbutils', '1.0')
 
     from gi.repository import GLib, Gio, Gtk

--- a/xl/plugins.py
+++ b/xl/plugins.py
@@ -259,6 +259,13 @@ class PluginsManager:
         :param info: The data returned from get_plugin_info()
         """
         import pkgutil
+        import gi
+
+        # https://github.com/exaile/exaile/issues/962
+        try:
+            gi.require_version('GIRepository', '3.0')
+        except ValueError:
+            gi.require_version('GIRepository', '2.0')
         from gi.repository import GIRepository
 
         gir = GIRepository.Repository.get_default()


### PR DESCRIPTION
GLib 2.84 integrates GIRepository (as `-3.0`), and that broke Exaile (even though the `-2.0` typelib & gir files still exist; I guess they're not usable anymore?).

There are a few ways we can fix this; in this commit I simply use a try-except, which seems the cleanest to me. The alternative is to import GLib then check `GLib.glib_version`, which I'd be fine with as well.

This commit also moves the `require_version` call from main.py to plugins.py, where the GIRepository import actually is.

Fixes: https://github.com/exaile/exaile/issues/962