### PR TITLE
xl/plugins: fix plugin enumeration with PyGObject >= 3.52.0

### DIFF
--- a/xl/plugins.py
+++ b/xl/plugins.py
@@ -264,11 +264,19 @@ class PluginsManager:
         # https://github.com/exaile/exaile/issues/962
         try:
             gi.require_version('GIRepository', '3.0')
+            new_api = True
         except ValueError:
             gi.require_version('GIRepository', '2.0')
+            new_api = False
         from gi.repository import GIRepository
 
-        gir = GIRepository.Repository.get_default()
+        # The old API had `get_default` method to obtain global singleton
+        # object; it was removed in the new API, which requires creation
+        # of separate GIRepository instances.
+        if new_api:
+            gir = GIRepository.Repository()
+        else:
+            gir = GIRepository.Repository.get_default()
 
         modules = info.get('RequiredModules', [])
 


### PR DESCRIPTION
The old GIRepository API (exposed by PyGObject < 3.52.0) has a `Repository.get_default()` method to obtain global singleton object; this method was removed in the new API (exposed by PyGObject >= 3.52.0), which requires creation of separate `Repository` instances.

Properly handle both APIs, in order to fix plugin enumeration when PyGObject >= 3.52.0 is used; otherwise, trying to list plugins in Preferences dialog fails with "Could not load plugin info! Failed plugins: <list of all plugins>" message, which is caused by an `AttributeError` in `PluginsManager.is_potentially_broken()`.