### PR TITLE
lyricsmania: Fix unexisting element lookup

### DIFF
--- a/plugins/lyricsmania/__init__.py
+++ b/plugins/lyricsmania/__init__.py
@@ -33,7 +33,6 @@ def enable(exaile):
         providers.register('lyrics', LyricsMania(exaile))
     else:
         raise NotImplementedError('LXML is not available.')
-        return False
 
 
 def disable(exaile):
@@ -76,12 +75,8 @@ class LyricsMania(LyricSearchMethod):
 
         try:
             lyrics_body = lyrics_html.find_class('lyrics-body')[0]
-            video_elem = lyrics_body.get_element_by_id('video-musictory')
-            first_line = video_elem.tail
-            lyrics_body.remove(video_elem)
             lyrics = lyrics_body.text_content()
             lyrics = re.sub(r'^\s+Lyrics to .+', '', lyrics)
-            lyrics = first_line + lyrics
             lyrics = lyrics.replace('\t', '')
             lyrics = self.remove_script(lyrics)
             lyrics = self.remove_html_tags(lyrics)


### PR DESCRIPTION
This is essentially a reversion of #861.

I received [a report](https://github.com/NixOS/nixpkgs/issues/442879) that the lyricsmania plugin wasn't working and found that it wasn't working for me either. When I dug into it, I found that it was caused by a KeyError on the #video-musictory element, which I'm not seeing in the browser either.

While it's possible that this element still exists in some situations, it strikes me as more likely that the html has changed for good and I'm just the first to notice and report. I could move this all to a `try` block if we think it's necessary but I'm erring on the side of deletion unless someone disagrees.

Also removing the unreachable `return` earlier in the file.