### PR TITLE
[py312] replace deprecated RawConfigParser.readp

### DIFF
--- a/xl/playlist.py
+++ b/xl/playlist.py
@@ -534,7 +534,7 @@ class PLSConverter(FormatConverter):
 
         try:
             with GioFileInputStream(gfile) as stream:
-                pls_playlist.readfp(stream)
+                pls_playlist.read_file(stream)
         except MissingSectionHeaderError:
             # Most likely version 1, thus only a list of URIs
             playlist = Playlist(self.name_from_path(path))


### PR DESCRIPTION
Fix SomaFM streams by replacing the deprecated RawConfigParser.readfp (removed in py312) with [ConfigParser.read_file](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file) (available since py32)

https://github.com/exaile/exaile/blob/6bb6c4a84c8b5496c75fc984e35ad9bd59b837f4/xl/playlist.py#L537

```
INFO    : Playing http://radio.hearme.fm:9950/stream
ERROR   : Playback error: Internal data stream error
INFO    : Reconfiguring crossfading
INFO    : Crossfade: disabled
INFO    : Playing http://live.myradio.yt:1220/stream
INFO    : Buffering complete
ERROR   : Error importing playlist
Traceback (most recent call last):
  File "/usr/share/exaile/plugins/somafm/__init__.py", line 178, in _get_playlist
    self.playlists[playlist_id] = playlist.import_playlist(url)
                                  ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/usr/lib/exaile/xl/playlist.py", line 130, in import_playlist
    return provider.import_from_file(path)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/lib/exaile/xl/playlist.py", line 516, in import_from_file
    pls_playlist.readfp(stream)
    ^^^^^^^^^^^^^^^^^^^
AttributeError: 'RawConfigParser' object has no attribute 'readfp'. Did you mean: 'read'?
Traceback (most recent call last):
  File "/usr/lib/exaile/xlgui/panel/radio.py", line 291, in on_row_activated
    self.emit('playlist-selected', item.get_playlist())
                                   ~~~~~~~~~~~~~~~~~^^
  File "/usr/share/exaile/plugins/somafm/__init__.py", line 204, in <lambda>
    lambda url=url, playlist_id=self.playlist_id: self._get_playlist(
                                                  ~~~~~~~~~~~~~~~~~~^
        url, playlist_id
        ^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/share/exaile/plugins/somafm/__init__.py", line 184, in _get_playlist
    return self.playlists[playlist_id]
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^
KeyError: 3
```