### PR TITLE
makefile: make the `dekstop_files` target depend on `locale` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ format:
 check_format:
 	$(BLACK) --check --diff -S *.py plugins/ xl/ xlgui/ tests/ tools/installer/exaile.spec
 
-desktop_files: builddir
+desktop_files: builddir locale
 	echo $(LINGUAS) > po/LINGUAS
 	msgfmt --desktop --template=data/exaile.desktop.in -d po -o build/exaile.desktop
 	msgfmt --xml --template=data/exaile.appdata.xml.in -d po -o build/org.exaile.exaile.appdata.xml


### PR DESCRIPTION
Make `desktop_files` target depend on the `locale` target, to ensure that in a parallel build (`make -jN`), modifications to .po files (part of `locale` target) are finished before `desktop_files` target tries to use the .po files.

Fixes #982.