### PR TITLE
Fix metadata reading on SID files

### DIFF
--- a/xl/metadata/sid.py
+++ b/xl/metadata/sid.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2008-2010 Adam Olsen
+# Copyright (C) 2025 Johannes Sasongko <johannes sasongko org>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,17 +33,13 @@ class SidFormat(BaseFormat):
     writable = False
 
     def load(self):
-        f = open(self.loc, "rb")
-        f.seek(22)
-        data = {}
-        data['title'] = f.read(32).replace(chr(0), "")
-        data['artist'] = f.read(32).replace(chr(0), "")
-        data['copyright'] = f.read(32).replace(chr(0), "")
-        f.close()
-        self.mutagen = data
-
-    def get_length(self):
-        return -1
-
-    def get_bitrate(self):
-        return -1
+        with open(self.loc, 'rb') as f:
+            # Search for "+16" in
+            # https://www.hvsc.c64.org/download/C64Music/DOCUMENTS/SID_file_format.txt
+            f.seek(0x16)
+            read = lambda: f.read(32).split(b'\0', 1)[0].decode('cp1252', 'replace')
+            self.mutagen = {
+                'title': read(),
+                'artist': read(),
+                'copyright': read(),
+            }


### PR DESCRIPTION
Currently we can't add SID files because the metadata reader throws an exception.

In the code, `f.read(32).replace(chr(0), "")` currently fails: the file is opened in binary mode, `read` returns bytes, and that's not compatible with the str args in the `replace` call.

Extra fixes:

* Accommodate the possibility of there being junk after the terminating nul character in a field.
* Decode with cp1252, matching what the documentation I found says.
* Remove the get_length and get_bitrate methods; the parent implementations are good enough (actually better because they return None instead of -1).