### PR TITLE
Pylint cleanup in docs Python files

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Exaile documentation build configuration file, created by
 # sphinx-quickstart on Mon Jul 31 17:15:07 2017.
 #
@@ -12,10 +10,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
-
-from os.path import abspath, join, dirname
+import sys
+from os.path import abspath, dirname, join
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -41,7 +38,7 @@ EXAILE_AUTHORS = [
 #
 
 sys.path.append(abspath(dirname(__file__)))
-import mocks
+import mocks  # noqa: E402  # pylint: disable=wrong-import-position
 mocks.import_fake_modules()
 mocks.fake_xl_settings()
 sys.path.pop()
@@ -71,7 +68,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Exaile'
-copyright = '2009-2025 Exaile Development Team'
+copyright = '2009-2025 Exaile Development Team'  # noqa  # pylint: disable=redefined-builtin
 author = ''.join(EXAILE_AUTHORS)
 
 # The version info for the project you're documenting, acts as replacement for
@@ -79,7 +76,7 @@ author = ''.join(EXAILE_AUTHORS)
 # built documents.
 #
 
-import xl.version
+import xl.version  # noqa: E402  # pylint: disable=wrong-import-position
 version = xl.version.__version__
 release = xl.version.__version__
 

--- a/doc/mocks.py
+++ b/doc/mocks.py
@@ -1,9 +1,9 @@
-'''
-    Provided so that we can build docs without needing to have any
-    dependencies installed (such as for RTFD).
+"""
+Provided so that we can build docs without needing to have any
+dependencies installed (such as for RTFD).
 
-    Derived from https://read-the-docs.readthedocs.org/en/latest/faq.html
-'''
+Derived from https://read-the-docs.readthedocs.org/en/latest/faq.html
+"""
 
 import sys
 
@@ -57,6 +57,7 @@ class MockGiModule:
     def accelerator_parse(cls, *args):
         return [0, 0]
 
+
 class Mock:
     __all__ = []
 
@@ -106,13 +107,12 @@ def import_fake_modules():
 
 def fake_xl_settings():
     # player hack
-    import xl.settings
+    import xl.settings  # pylint: disable=import-outside-toplevel
 
     def option_hack(name, default):
         if name == 'player/engine':
             return 'rtfd_hack'
-        else:
-            return orig_get_option(name, default)
+        return orig_get_option(name, default)
 
     orig_get_option = xl.settings.get_option
     xl.settings.get_option = option_hack


### PR DESCRIPTION
This PR performs a pylint cleanup of documentation-related Python files.

Changes:
- Cleaned lint issues in doc/conf.py
- Cleaned lint issues in doc/mocks.py

Validation:
- python3 -m py_compile doc/conf.py doc/mocks.py
