### PR TITLE
desktopcover: Re-add preferences

### DIFF
--- a/plugins/desktopcover/__init__.py
+++ b/plugins/desktopcover/__init__.py
@@ -71,9 +71,8 @@ class DesktopCoverPlugin:
 
             settings.set_option('plugin/desktopcover/anchor', gravity)
 
-
-def get_preferences_pane():
-    return desktopcover_preferences
+    def get_preferences_pane(self):
+        return desktopcover_preferences
 
 
 plugin_class = DesktopCoverPlugin

--- a/plugins/desktopcover/desktopcover_preferences.ui
+++ b/plugins/desktopcover/desktopcover_preferences.ui
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="upper">9999</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment2">
     <property name="upper">9999</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment3">
     <property name="upper">9999</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment4">
     <property name="upper">9999</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkListStore" id="anchor_liststore">
     <columns>
@@ -48,28 +48,41 @@
       </row>
     </data>
   </object>
+  <!-- n-columns=3 n-rows=8 -->
   <object class="GtkGrid" id="preferences_pane">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="row_spacing">4</property>
-    <property name="column_spacing">2</property>
+    <property name="can-focus">False</property>
+    <property name="row-spacing">4</property>
+    <property name="column-spacing">2</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">Note: Desktop Cover positioning is not supported on Wayland.</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">0</property>
+        <property name="width">3</property>
+      </packing>
+    </child>
     <child>
       <object class="GtkLabel" id="label1">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="halign">start</property>
         <property name="label" translatable="yes">Anchor:</property>
-        <property name="single_line_mode">True</property>
+        <property name="single-line-mode">True</property>
       </object>
       <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">0</property>
+        <property name="left-attach">0</property>
+        <property name="top-attach">1</property>
       </packing>
     </child>
     <child>
       <object class="GtkComboBox" id="plugin/desktopcover/anchor">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
+        <property name="can-focus">True</property>
         <property name="model">anchor_liststore</property>
         <property name="active">0</property>
         <child>
@@ -80,199 +93,195 @@
         </child>
       </object>
       <packing>
-        <property name="left_attach">1</property>
-        <property name="top_attach">0</property>
+        <property name="left-attach">1</property>
+        <property name="top-attach">1</property>
         <property name="width">2</property>
       </packing>
     </child>
     <child>
       <object class="GtkLabel" id="label2">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="halign">start</property>
         <property name="label" translatable="yes">X offset:</property>
-        <property name="single_line_mode">True</property>
+        <property name="single-line-mode">True</property>
       </object>
       <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">1</property>
+        <property name="left-attach">0</property>
+        <property name="top-attach">2</property>
       </packing>
     </child>
     <child>
       <object class="GtkSpinButton" id="plugin/desktopcover/x">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="invisible_char">●</property>
-        <property name="width_chars">5</property>
+        <property name="can-focus">True</property>
+        <property name="width-chars">5</property>
         <property name="adjustment">adjustment1</property>
-        <property name="snap_to_ticks">True</property>
+        <property name="snap-to-ticks">True</property>
         <property name="numeric">True</property>
       </object>
       <packing>
-        <property name="left_attach">1</property>
-        <property name="top_attach">1</property>
+        <property name="left-attach">1</property>
+        <property name="top-attach">2</property>
       </packing>
     </child>
     <child>
       <object class="GtkLabel" id="label3">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="halign">start</property>
         <property name="hexpand">True</property>
         <property name="label" translatable="yes">pixels</property>
-        <property name="single_line_mode">True</property>
+        <property name="single-line-mode">True</property>
       </object>
       <packing>
-        <property name="left_attach">2</property>
-        <property name="top_attach">1</property>
+        <property name="left-attach">2</property>
+        <property name="top-attach">2</property>
       </packing>
     </child>
     <child>
       <object class="GtkLabel" id="label4">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="halign">start</property>
         <property name="label" translatable="yes">Y offset:</property>
-        <property name="single_line_mode">True</property>
+        <property name="single-line-mode">True</property>
       </object>
       <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">2</property>
+        <property name="left-attach">0</property>
+        <property name="top-attach">3</property>
       </packing>
     </child>
     <child>
       <object class="GtkSpinButton" id="plugin/desktopcover/y">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="invisible_char">●</property>
+        <property name="can-focus">True</property>
         <property name="adjustment">adjustment2</property>
-        <property name="snap_to_ticks">True</property>
+        <property name="snap-to-ticks">True</property>
         <property name="numeric">True</property>
       </object>
       <packing>
-        <property name="left_attach">1</property>
-        <property name="top_attach">2</property>
+        <property name="left-attach">1</property>
+        <property name="top-attach">3</property>
       </packing>
     </child>
     <child>
       <object class="GtkLabel" id="label5">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="halign">start</property>
         <property name="label" translatable="yes">pixels</property>
-        <property name="single_line_mode">True</property>
+        <property name="single-line-mode">True</property>
       </object>
       <packing>
-        <property name="left_attach">2</property>
-        <property name="top_attach">2</property>
+        <property name="left-attach">2</property>
+        <property name="top-attach">3</property>
       </packing>
     </child>
     <child>
       <object class="GtkCheckButton" id="plugin/desktopcover/override_size">
         <property name="label" translatable="yes">Override cover size</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">False</property>
         <property name="halign">start</property>
-        <property name="draw_indicator">True</property>
+        <property name="draw-indicator">True</property>
       </object>
       <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">3</property>
+        <property name="left-attach">0</property>
+        <property name="top-attach">4</property>
         <property name="width">3</property>
       </packing>
     </child>
     <child>
       <object class="GtkLabel" id="label6">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="halign">start</property>
         <property name="label" translatable="yes">Size:</property>
-        <property name="single_line_mode">True</property>
+        <property name="single-line-mode">True</property>
       </object>
       <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">4</property>
+        <property name="left-attach">0</property>
+        <property name="top-attach">5</property>
       </packing>
     </child>
     <child>
       <object class="GtkSpinButton" id="plugin/desktopcover/size">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="invisible_char">●</property>
+        <property name="can-focus">True</property>
         <property name="adjustment">adjustment3</property>
-        <property name="snap_to_ticks">True</property>
+        <property name="snap-to-ticks">True</property>
         <property name="numeric">True</property>
       </object>
       <packing>
-        <property name="left_attach">1</property>
-        <property name="top_attach">4</property>
+        <property name="left-attach">1</property>
+        <property name="top-attach">5</property>
       </packing>
     </child>
     <child>
       <object class="GtkLabel" id="label7">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="halign">start</property>
         <property name="label" translatable="yes">pixels</property>
-        <property name="single_line_mode">True</property>
+        <property name="single-line-mode">True</property>
       </object>
       <packing>
-        <property name="left_attach">2</property>
-        <property name="top_attach">4</property>
+        <property name="left-attach">2</property>
+        <property name="top-attach">5</property>
       </packing>
     </child>
     <child>
       <object class="GtkCheckButton" id="plugin/desktopcover/fading">
         <property name="label" translatable="yes">Use fading</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">False</property>
         <property name="halign">start</property>
-        <property name="draw_indicator">True</property>
+        <property name="draw-indicator">True</property>
       </object>
       <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">5</property>
+        <property name="left-attach">0</property>
+        <property name="top-attach">6</property>
         <property name="width">3</property>
       </packing>
     </child>
     <child>
       <object class="GtkLabel" id="label8">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="halign">start</property>
         <property name="label" translatable="yes">Fading duration:</property>
       </object>
       <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">6</property>
+        <property name="left-attach">0</property>
+        <property name="top-attach">7</property>
       </packing>
     </child>
     <child>
       <object class="GtkSpinButton" id="plugin/desktopcover/fading_duration">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="invisible_char">●</property>
+        <property name="can-focus">True</property>
         <property name="adjustment">adjustment4</property>
-        <property name="snap_to_ticks">True</property>
+        <property name="snap-to-ticks">True</property>
         <property name="numeric">True</property>
       </object>
       <packing>
-        <property name="left_attach">1</property>
-        <property name="top_attach">6</property>
+        <property name="left-attach">1</property>
+        <property name="top-attach">7</property>
       </packing>
     </child>
     <child>
       <object class="GtkLabel" id="label9">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="halign">start</property>
         <property name="label" translatable="yes">ms</property>
       </object>
       <packing>
-        <property name="left_attach">2</property>
-        <property name="top_attach">6</property>
+        <property name="left-attach">2</property>
+        <property name="top-attach">7</property>
       </packing>
     </child>
   </object>


### PR DESCRIPTION
The desktopcover plugin had a Preferences pane... until we broke it almost 9 years ago and nobody noticed :-D.

Meanwhile, Wayland appeared and made things difficult for the plugin, so I've also added a note:

> Note: Desktop cover positioning is not supported on Wayland.