### PR TITLE
Inhibitsuspend: systemd-inhibit, elogind-inhibit, and logind dbus support and fix xfce/gnome

### DIFF
--- a/plugins/inhibitsuspend/__init__.py
+++ b/plugins/inhibitsuspend/__init__.py
@@ -68,6 +68,13 @@ class SuspendInhibit:
         # see https://askubuntu.com/questions/72549/how-to-determine-which-window-manager-is-running
         xdg_session = os.getenv('XDG_CURRENT_DESKTOP', '').lower()
 
+        # Attempt to get logind bus
+        try:
+            bus = dbus.SystemBus()
+            logind = bus.get_object('org.freedesktop.login1', '/org/freedesktop/login1')
+        except dbus.exceptions.DBusException:
+            logind = None
+
         # Attempt to find an adaptor that works
         if 'gnome' in session or 'gnome' in xdg_session:
             self.adapter = GnomeAdapter()
@@ -79,6 +86,8 @@ class SuspendInhibit:
                 self.adapter = KdeAdapter()
         elif 'xfce' in session or 'xfce' in xdg_session:
             self.adapter = XfceAdapter()
+        elif logind:
+            self.adapter = LogindAdapter(logind)
         elif shutil.which(SystemdAdapter.cmd) is not None:
             self.adapter = SystemdAdapter()
         elif shutil.which(ElogindAdapter.cmd) is not None:
@@ -95,7 +104,7 @@ class SuspendInhibit:
                 self.adapter = GnomeAdapter()
         else:
             raise NotImplementedError(xdg_session)
-        logger.debug(f"Inhibiting suspend with {self.adapter.__qualname__}")
+        logger.debug(f"Inhibiting suspend with {self.adapter.__class__.__name__}")
 
     def destroy(self):
         self.adapter.destroy()
@@ -193,6 +202,31 @@ class SuspendAdapter(adapters.PlaybackAdapter):
         Must not block
         """
         raise NotImplementedError('Method not Overridden')
+
+
+class LogindAdapter(SuspendAdapter):
+    """
+    Adapter for logind interface.
+
+    See https://systemd.io/INHIBITOR_LOCKS/
+    """
+
+    def __init__(self, logind_obj):
+        interface = 'org.freedesktop.login1.Manager'
+        self.iface = dbus.Interface(logind_obj, interface)
+        super().__init__()
+
+    def _inhibit_call(self):
+        lock = self.iface.Inhibit(
+            'shutdown:sleep:idle',  # what
+            'Exaile',  # who
+            'Playing Music',  # why
+            'block',  # mode
+        )
+        self.lock_file_descriptor = lock.take()
+
+    def _uninhibit_call(self):
+        os.close(self.lock_file_descriptor)
 
 
 class DbusSuspendAdapter(SuspendAdapter):

--- a/plugins/inhibitsuspend/__init__.py
+++ b/plugins/inhibitsuspend/__init__.py
@@ -11,6 +11,7 @@ except ImportError:
     import _dummy_thread as _thread
 import logging
 import os
+import shutil
 
 import dbus
 import subprocess
@@ -78,9 +79,12 @@ class SuspendInhibit:
                 self.adapter = KdeAdapter()
         elif 'xfce' in session or 'xfce' in xdg_session:
             self.adapter = XfceAdapter()
+        elif shutil.which(SystemdAdapter.cmd) is not None:
+            self.adapter = SystemdAdapter()
+        elif shutil.which(ElogindAdapter.cmd) is not None:
+            self.adapter = ElogindAdapter()
         elif 'sway' in session or 'sway' in xdg_session:
             self.adapter = SwayAdapter()
-        # TODO implement for LXDE, X-Cinnamon, Unity; systemd-inhibit
         elif session == '' and xdg_session == '':
             logger.warning('Could not detect Desktop Session, will try default \
                     Power Manager then Gnome')
@@ -91,6 +95,7 @@ class SuspendInhibit:
                 self.adapter = GnomeAdapter()
         else:
             raise NotImplementedError(xdg_session)
+        logger.debug(f"Inhibiting suspend with {self.adapter.__qualname__}")
 
     def destroy(self):
         self.adapter.destroy()
@@ -303,6 +308,36 @@ class XfceAdapter(PowerManagerAdapter):
         except EnvironmentError:
             # Fall back to other bus name
             super().__init__(bus_name='org.xfce.PowerManager')
+
+
+class InhibitorProcessAdapter(SuspendAdapter):
+    """
+    Adapter for running an inhibition locking process.
+    """
+
+    cmd = ''
+
+    def _inhibit_call(self):
+        self.inhibitor = subprocess.Popen([self.cmd, 'sleep', 'infinity'])
+
+    def _uninhibit_call(self):
+        self.inhibitor.kill()
+
+
+class SystemdAdapter(InhibitorProcessAdapter):
+    """
+    Adapter for systems using systemd.
+    """
+
+    cmd = 'systemd-inhibit'
+
+
+class ElogindAdapter(InhibitorProcessAdapter):
+    """
+    Adapter for systems using elogind.
+    """
+
+    cmd = 'elogind-inhibit'
 
 
 class SwayAdapter(SuspendAdapter):


### PR DESCRIPTION
I don't know if there are actually any systems which support systemd-inhibit but not the logind bus. I also don't understand the ecosystem enough to know why all these desktop environments have their own dbus interfaces to handle suspend inhibitors and wonder if the logind bus would also work for them. I'm happy to rework or break this into separate PR's if somebody knows better.