### PR TITLE
trackdb: make get_tracks synchronized

### DIFF
--- a/xl/trax/trackdb.py
+++ b/xl/trax/trackdb.py
@@ -373,5 +373,6 @@ class TrackDB:
 
         self._dirty = True
 
+    @common.synchronized
     def get_tracks(self) -> List[Track]:
         return list(self)


### PR DESCRIPTION
- Other things are already synchronized, this prevents RuntimeErrors when retrieving a collection snapshot