### PR TITLE
Fix MetadataList insert metadata alignment

### DIFF
--- a/tests/xl/test_common.py
+++ b/tests/xl/test_common.py
@@ -1,0 +1,27 @@
+import pytest
+
+from xl.common import MetadataList
+
+
+@pytest.mark.parametrize(
+    ('index', 'inserted_at'),
+    [
+        (0, 0),
+        (2, 2),
+        (3, 3),
+        (100, 3),
+        (-1, 2),
+        (-100, 0),
+    ],
+)
+def test_metadata_list_insert_preserves_metadata(index, inserted_at):
+    items = MetadataList(['a', 'b', 'c'], ['A', 'B', 'C'])
+
+    items.insert(index, 'new', 'NEW')
+
+    expected_items = ['a', 'b', 'c']
+    expected_items.insert(inserted_at, 'new')
+    expected_metadata = ['A', 'B', 'C']
+    expected_metadata.insert(inserted_at, 'NEW')
+    assert list(items) == expected_items
+    assert items.metadata == expected_metadata

--- a/xl/common.py
+++ b/xl/common.py
@@ -701,13 +701,7 @@ class MetadataList:
         self[len(self) : len(self)] = other
 
     def insert(self, i, item, metadata=None):
-        if i >= len(self):
-            i = len(self)
-            e = len(self) + 1
-        else:
-            e = i
-        self[i:e] = [item]
-        self.metadata[i:e] = [metadata]
+        self[i:i] = MetadataList([item], [metadata])
 
     def pop(self, i=-1):
         item = self[i]


### PR DESCRIPTION
Note: AI generated, human reviewed

* Fixes issue #922 (alternative to https://github.com/exaile/exaile/pull/923)

The original implementation inserted placeholder metadata through `__setitem__`, then accidentally inserted the supplied metadata a second time. The suggested fix fails for negative indices because the list length changes before self.metadata[i] is evaluated