### PR TITLE
Track predictor plugin

### DIFF
--- a/plugins/queuetrackpredictor/PLUGININFO
+++ b/plugins/queuetrackpredictor/PLUGININFO
@@ -1,0 +1,5 @@
+Version='4.2.2'
+Authors=['Exaile contributors']
+Name=_("Queue Track Predictor")
+Description=_("Suggests next queue tracks from playlist ordering, GroupTagger groups, and BPM.")
+Category=_('Utility')

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -9,9 +9,10 @@ import os
 from gi.repository import Gtk
 
 from xl import player, providers, settings, xdg
+from xl.playlist import Playlist
 from xl.nls import gettext as _
 from xlgui import main
-from xlgui.widgets import dialogs, menu, notebook
+from xlgui.widgets import dialogs, menu, notebook, playlist as playlist_widget
 
 from . import model as predictor_model
 from . import model_store
@@ -28,7 +29,9 @@ class QueueTrackPredictorPlugin:
         self.playlist_menu_item = None
         self.train_dialog = None
         self.model_manager_dialog = None
-        self.suggestion_dialog = None
+        self.suggestions_playlist = None
+        self.suggestions_page = None
+        self.suggestions_tab = None
         self.button_registered = False
 
     def enable(self, exaile):
@@ -64,9 +67,11 @@ class QueueTrackPredictorPlugin:
         if self.model_manager_dialog is not None:
             self.model_manager_dialog.destroy()
             self.model_manager_dialog = None
-        if self.suggestion_dialog is not None:
-            self.suggestion_dialog.destroy()
-            self.suggestion_dialog = None
+        if self.suggestions_page is not None:
+            playlist_notebook = self._get_suggestions_notebook()
+            if playlist_notebook is not None:
+                playlist_notebook.remove_tab(self.suggestions_tab)
+            self._clear_suggestions_tab_references()
 
         if self.menu_item is not None:
             self.menu_item.unregister()
@@ -209,14 +214,51 @@ class QueueTrackPredictorPlugin:
             dialogs.info(parent_window, _("No suggestions found for the queue tail."))
             return
 
-        if self.suggestion_dialog is not None:
-            self.suggestion_dialog.destroy()
+        self.show_suggestions_playlist(tracks)
 
-        self.suggestion_dialog = SuggestionsDialog(self, parent_window, tracks)
-        self.suggestion_dialog.present()
+    def show_suggestions_playlist(self, tracks):
+        playlist_notebook = self._get_suggestions_notebook()
+        if playlist_notebook is None:
+            playlist_notebook = main.get_playlist_notebook()
+            self.suggestions_playlist = SuggestionsPlaylist(tracks)
+            self.suggestions_page = SuggestionsPlaylistPage(
+                self.suggestions_playlist, player.PLAYER
+            )
+            self.suggestions_page.connect(
+                'destroy', self.on_suggestions_page_destroyed
+            )
+            self.suggestions_tab = notebook.NotebookTab(
+                playlist_notebook, self.suggestions_page
+            )
+            playlist_notebook.add_tab(
+                self.suggestions_tab, self.suggestions_page
+            )
+        else:
+            self.suggestions_playlist.replace_tracks(tracks)
+            playlist_notebook.set_current_page(
+                playlist_notebook.page_num(self.suggestions_page)
+            )
+            self.suggestions_page.focus()
 
-    def append_to_queue(self, track):
-        player.QUEUE.append(track)
+    def _get_suggestions_notebook(self):
+        if self.suggestions_tab is None or self.suggestions_page is None:
+            return None
+        playlist_notebook = self.suggestions_tab.notebook
+        if (
+            playlist_notebook is None
+            or playlist_notebook.page_num(self.suggestions_page) == -1
+        ):
+            return None
+        return playlist_notebook
+
+    def on_suggestions_page_destroyed(self, page):
+        if page is self.suggestions_page:
+            self._clear_suggestions_tab_references()
+
+    def _clear_suggestions_tab_references(self):
+        self.suggestions_playlist = None
+        self.suggestions_page = None
+        self.suggestions_tab = None
 
 
 class SuggestNextTrackButton(Gtk.Button, notebook.NotebookAction):
@@ -238,6 +280,70 @@ class SuggestNextTrackButton(Gtk.Button, notebook.NotebookAction):
     def on_clicked(self, button):
         if self.plugin is not None:
             self.plugin.suggest_next_track()
+
+
+class SuggestionsPlaylist(Playlist):
+    def __init__(self, tracks):
+        Playlist.__init__(self, _('Track Suggestions'), list(tracks))
+
+    def replace_tracks(self, tracks):
+        Playlist.__setitem__(self, slice(None, None, None), list(tracks))
+
+    # The plugin can replace the result set, but user-facing playlist
+    # operations must not mutate it.
+    def set_shuffle_mode(self, mode):
+        pass
+
+    def set_repeat_mode(self, mode):
+        pass
+
+    def set_dynamic_mode(self, mode):
+        pass
+
+    def randomize(self, positions=None):
+        pass
+
+    def sort(self, tags, reverse=False):
+        pass
+
+    def clear(self):
+        pass
+
+    def __setitem__(self, index, value):
+        pass
+
+    def __delitem__(self, index):
+        pass
+
+    def append(self, track):
+        pass
+
+    def extend(self, tracks):
+        pass
+
+
+class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
+    reorderable = False
+
+    def __init__(self, suggestions_playlist, playlist_player):
+        playlist_widget.PlaylistPageBase.__init__(
+            self, suggestions_playlist, playlist_player
+        )
+        self.swindow = Gtk.ScrolledWindow()
+        self.swindow.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        self.view = playlist_widget.PlaylistView(
+            suggestions_playlist, playlist_player
+        )
+        self.view.drag_dest_unset()
+        self.swindow.add(self.view)
+        self.pack_start(self.swindow, True, True, 0)
+        self.show_all()
+
+    def focus(self):
+        self.view.grab_focus()
+
+    def get_page_name(self):
+        return _('Track Suggestions')
 
 
 class ModelManagerDialog(Gtk.Dialog):
@@ -591,102 +697,6 @@ class TrainingDialog(Gtk.Dialog):
     def destroy(self):
         self.plugin.train_dialog = None
         Gtk.Dialog.destroy(self)
-
-
-class SuggestionsDialog(Gtk.Dialog):
-    def __init__(self, plugin, parent, tracks):
-        Gtk.Dialog.__init__(
-            self,
-            title=_('Suggested Next Tracks'),
-            transient_for=parent,
-            modal=True,
-        )
-        self.plugin = plugin
-        self.set_default_size(720, 420)
-        self.add_buttons(
-            Gtk.STOCK_CANCEL,
-            Gtk.ResponseType.CANCEL,
-            _('Add to Queue'),
-            Gtk.ResponseType.OK,
-        )
-        self.connect('response', self.on_response)
-        self.connect('delete-event', self.on_delete_event)
-
-        self.store = Gtk.ListStore(str, str, str, str, object)
-        for track in tracks:
-            self.store.append(
-                (
-                    track.get_tag_display('title'),
-                    track.get_tag_display('artist'),
-                    _display_bpm(track),
-                    _display_groups(plugin, track),
-                    track,
-                )
-            )
-
-        self.tree = Gtk.TreeView(model=self.store)
-        self.tree.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
-        self.tree.get_selection().select_path(0)
-        self.tree.connect('row-activated', self.on_row_activated)
-        self._add_text_column(_('Title'), 0, True)
-        self._add_text_column(_('Artist'), 1, True)
-        self._add_text_column(_('BPM'), 2, False)
-        self._add_text_column(_('Groups'), 3, True)
-
-        scroller = Gtk.ScrolledWindow()
-        scroller.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-        scroller.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
-        scroller.add(self.tree)
-
-        content = self.get_content_area()
-        content.set_border_width(6)
-        content.pack_start(scroller, True, True, 0)
-        self.show_all()
-
-    def _add_text_column(self, title, column_id, expand):
-        renderer = Gtk.CellRendererText()
-        renderer.set_property('ellipsize', 3)
-        column = Gtk.TreeViewColumn(title, renderer, text=column_id)
-        column.set_expand(expand)
-        self.tree.append_column(column)
-
-    def get_selected_track(self):
-        model, tree_iter = self.tree.get_selection().get_selected()
-        if tree_iter is None:
-            return None
-        return model[tree_iter][4]
-
-    def on_response(self, dialog, response):
-        if response == Gtk.ResponseType.OK:
-            self.add_selected_track()
-        self.destroy()
-
-    def on_row_activated(self, tree, path, column):
-        self.tree.get_selection().select_path(path)
-        self.add_selected_track()
-        self.destroy()
-
-    def add_selected_track(self):
-        track = self.get_selected_track()
-        if track is not None:
-            self.plugin.append_to_queue(track)
-
-    def on_delete_event(self, widget, event):
-        self.plugin.suggestion_dialog = None
-
-    def destroy(self):
-        self.plugin.suggestion_dialog = None
-        Gtk.Dialog.destroy(self)
-
-
-def _display_bpm(track):
-    bpm = track.get_tag_raw('bpm', True)
-    return '' if bpm is None else str(bpm)
-
-
-def _display_groups(plugin, track):
-    groups = plugin.get_track_groups(track)
-    return ', '.join(sorted(groups))
 
 
 plugin_class = QueueTrackPredictorPlugin

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -11,7 +11,7 @@ from gi.repository import GLib, Gtk
 
 from xl import player, providers, settings, xdg
 from xl.playlist import Playlist
-from xl.nls import gettext as _
+from xl.nls import gettext as _, ngettext
 from xlgui import guiutil, main
 from xlgui.widgets import dialogs, menu, notebook, playlist as playlist_widget
 
@@ -25,6 +25,14 @@ MODEL_FILE = 'models.pickle'
 RECENT_TRACK_COUNT = 15
 CANDIDATE_POOL_MULTIPLIER = 5
 DIVERSITY_REBUILD_DELAY_MS = 200
+TAG_BIAS_REBUILD_DELAY_MS = 250
+TAG_BIAS_LABELS = {
+    -2: _('Strongly away'),
+    -1: _('Away'),
+    0: _('Neutral'),
+    1: _('Toward'),
+    2: _('Strongly toward'),
+}
 
 
 class QueueTrackPredictorPlugin:
@@ -193,10 +201,25 @@ class QueueTrackPredictorPlugin:
     def create_model_from_playlists(
         self, name, playlists, playlist_names, included_tags, replace=False
     ):
+        existing_biases = {}
+        if replace:
+            try:
+                existing_biases = self.load_model(name).get('tag_biases', {})
+            except (IOError, KeyError, ValueError):
+                pass
         model = predictor_model.build_model(
             playlists, self.get_track_groups, included_tags=included_tags
         )
         model['playlist_names'] = sorted(playlist_names)
+        included_tag_set = (
+            None if included_tags is None else set(included_tags)
+        )
+        model['tag_biases'] = {
+            tag: bias
+            for tag, bias in existing_biases.items()
+            if (included_tag_set is None or tag in included_tag_set)
+            and bias in predictor_model.TAG_BIAS_FACTORS
+        }
         catalog = self.load_model_catalog()
         if replace:
             model_store.replace_model(catalog, name, model)
@@ -204,6 +227,19 @@ class QueueTrackPredictorPlugin:
             model_store.add_model(catalog, name, model)
         self.save_model_catalog(catalog)
         return model
+
+    def set_model_tag_biases(self, model_name, tag_biases):
+        catalog = self.load_model_catalog()
+        model = catalog['models'][model_name]
+        included_tags = model.get('included_tags')
+        model['tag_biases'] = {
+            tag: int(bias)
+            for tag, bias in tag_biases.items()
+            if bias in predictor_model.TAG_BIAS_FACTORS
+            and bias != 0
+            and (included_tags is None or tag in included_tags)
+        }
+        self.save_model_catalog(catalog)
 
     def load_model(self, model_name=None):
         return self.load_model_entry(model_name)[1]
@@ -376,6 +412,16 @@ class QueueTrackPredictorPlugin:
         if not scored_tracks:
             dialogs.info(parent_window, _("No suggestions found for the queue tail."))
             return False
+        if self.suggestion_request is not None:
+            previous_tracks, request_parent, excluded_locations, _ = (
+                self.suggestion_request
+            )
+            self.suggestion_request = (
+                previous_tracks,
+                request_parent,
+                excluded_locations,
+                model_name,
+            )
         self.show_suggestions_playlist(scored_tracks, diversity, model_name)
         return False
 
@@ -583,7 +629,13 @@ class SuggestionsPlaylistView(playlist_widget.PlaylistView):
     def render_score(self, column, renderer, tree_model, tree_iter, data=None):
         track = tree_model.get_value(tree_iter, 0)
         score = self.playlist.get_score(track)
-        renderer.set_property('text', '' if score is None else str(score))
+        if score is None:
+            text = ''
+        elif float(score).is_integer():
+            text = str(int(score))
+        else:
+            text = '%.1f' % score
+        renderer.set_property('text', text)
 
 
 class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
@@ -602,6 +654,8 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         )
         self.plugin = plugin
         self.diversity_rebuild_source = None
+        self.tag_rebuild_source = None
+        self.model_name = None
         self.swindow = Gtk.ScrolledWindow()
         self.swindow.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         self.view = SuggestionsPlaylistView(
@@ -631,14 +685,26 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         )
         self.view.drag_dest_unset()
         self.swindow.add(self.view)
-        self.pack_start(self.swindow, True, True, 0)
+
+        self.content_stack = Gtk.Stack()
+        self.content_stack.set_transition_type(
+            Gtk.StackTransitionType.CROSSFADE
+        )
+        self.content_stack.add_named(self.swindow, 'suggestions')
+        self._build_tag_tuning_panel()
+        self.pack_start(self.content_stack, True, True, 0)
 
         diversity_box = Gtk.Box(spacing=8)
         diversity_box.set_border_width(6)
         self.model_label = Gtk.Label()
         self.model_label.set_xalign(0)
-        self.set_model_name(model_name)
         diversity_box.pack_start(self.model_label, False, False, 0)
+        self.tuning_toggle = Gtk.ToggleButton(label=_('Tune Tags'))
+        self.tuning_toggle.set_tooltip_text(
+            _('Tune tag preferences for this prediction model')
+        )
+        self.tuning_toggle.connect('toggled', self.on_tuning_toggled)
+        diversity_box.pack_start(self.tuning_toggle, False, False, 0)
         separator = Gtk.Separator(orientation=Gtk.Orientation.VERTICAL)
         diversity_box.pack_start(separator, False, False, 0)
         diversity_label = Gtk.Label(label=_('Diversity:'))
@@ -655,10 +721,303 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         diversity_box.pack_start(self.diversity_scale, True, True, 0)
         diversity_box.pack_end(self.search_entry.entry, False, True, 0)
         self.pack_start(diversity_box, False, False, 0)
+        self.set_model_name(model_name)
+        self.content_stack.set_visible_child_name('suggestions')
         self.show_all()
 
+    def _build_tag_tuning_panel(self):
+        panel = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        panel.set_border_width(8)
+
+        tools = Gtk.Box(spacing=6)
+        self.tag_search = Gtk.SearchEntry()
+        self.tag_search.set_placeholder_text(_('Search tags'))
+        self.tag_search.set_hexpand(True)
+        self.tag_search.connect('search-changed', self.on_tag_filter_changed)
+        tools.pack_start(self.tag_search, True, True, 0)
+
+        self.tag_filter_choice = Gtk.ComboBoxText()
+        self.tag_filter_choice.append('all', _('All'))
+        self.tag_filter_choice.append('adjusted', _('Adjusted'))
+        self.tag_filter_choice.append('neutral', _('Neutral'))
+        self.tag_filter_choice.set_active_id('all')
+        self.tag_filter_choice.connect('changed', self.on_tag_filter_changed)
+        tools.pack_start(self.tag_filter_choice, False, False, 0)
+
+        self.tag_sort_choice = Gtk.ComboBoxText()
+        self.tag_sort_choice.append('adjusted', _('Adjusted First'))
+        self.tag_sort_choice.append('name', _('Name'))
+        self.tag_sort_choice.append('bias', _('Bias'))
+        self.tag_sort_choice.set_active_id('adjusted')
+        self.tag_sort_choice.set_tooltip_text(_('Sort tags'))
+        self.tag_sort_choice.connect('changed', self.on_tag_sort_changed)
+        tools.pack_start(self.tag_sort_choice, False, False, 0)
+
+        self.reset_all_tags_button = Gtk.Button(label=_('Reset All'))
+        self.reset_all_tags_button.connect('clicked', self.on_reset_all_tags)
+        tools.pack_start(self.reset_all_tags_button, False, False, 0)
+        panel.pack_start(tools, False, False, 0)
+
+        self.tag_biases = {}
+        self.tag_children = {}
+        self.tag_bias_labels = {}
+        self.tag_tuning_flow = Gtk.FlowBox()
+        self.tag_tuning_flow.set_selection_mode(Gtk.SelectionMode.MULTIPLE)
+        self.tag_tuning_flow.set_activate_on_single_click(False)
+        self.tag_tuning_flow.set_column_spacing(6)
+        self.tag_tuning_flow.set_row_spacing(6)
+        self.tag_tuning_flow.set_homogeneous(False)
+        self.tag_tuning_flow.set_min_children_per_line(1)
+        self.tag_tuning_flow.set_max_children_per_line(20)
+        self.tag_tuning_flow.set_valign(Gtk.Align.START)
+        self.tag_tuning_flow.set_filter_func(self.is_tag_child_visible)
+        self.tag_tuning_flow.set_sort_func(self.compare_tag_children)
+        self.tag_tuning_flow.connect(
+            'selected-children-changed', self.on_tag_selection_changed
+        )
+        self.tag_tuning_flow.connect(
+            'child-activated', self.on_tag_child_activated
+        )
+        self.tag_tuning_flow.connect('key-press-event', self.on_tag_key_pressed)
+
+        tag_scroller = Gtk.ScrolledWindow()
+        tag_scroller.set_policy(
+            Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC
+        )
+        tag_scroller.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
+        tag_scroller.add(self.tag_tuning_flow)
+        panel.pack_start(tag_scroller, True, True, 0)
+
+        self.tag_selection_label = Gtk.Label(label=_('Select one or more tags.'))
+        self.tag_selection_label.set_xalign(0)
+        panel.pack_start(self.tag_selection_label, False, False, 0)
+
+        self.bias_buttons = Gtk.Box(spacing=4)
+        for shortcut, bias in enumerate((-2, -1, 0, 1, 2), 1):
+            button = Gtk.Button(label=TAG_BIAS_LABELS[bias])
+            button.set_tooltip_text(
+                _('Apply to selected tags (keyboard shortcut: %d)') % shortcut
+            )
+            button.connect(
+                'clicked',
+                lambda widget, value=bias: self.set_selected_tag_bias(value),
+            )
+            self.bias_buttons.pack_start(button, True, True, 0)
+        self.bias_buttons.set_sensitive(False)
+        panel.pack_start(self.bias_buttons, False, False, 0)
+
+        self.content_stack.add_named(panel, 'tuning')
+
     def focus(self):
-        self.view.grab_focus()
+        if not self.tuning_toggle.get_active():
+            self.view.grab_focus()
+
+    def on_tuning_toggled(self, button):
+        tuning = button.get_active()
+        self.content_stack.set_visible_child_name(
+            'tuning' if tuning else 'suggestions'
+        )
+        self.search_entry.entry.set_visible(not tuning)
+        if tuning:
+            button.set_label(_('Show Suggestions'))
+            self.tag_search.grab_focus()
+        else:
+            self._update_tuning_button_label()
+            self.view.grab_focus()
+
+    def _populate_tag_tuning(self, model):
+        included_tags = model.get('included_tags')
+        if included_tags is None:
+            included_tags = {
+                tag
+                for summary in model.get('candidate_features', {}).values()
+                for tag in summary.get('groups', ())
+            }
+        else:
+            included_tags = set(included_tags)
+        self.tag_biases = {
+            tag: int(bias)
+            for tag, bias in model.get('tag_biases', {}).items()
+            if tag in included_tags
+            and bias in predictor_model.TAG_BIAS_FACTORS
+            and bias != 0
+        }
+        for child in self.tag_tuning_flow.get_children():
+            self.tag_tuning_flow.remove(child)
+        self.tag_children.clear()
+        self.tag_bias_labels.clear()
+        for tag in included_tags:
+            child = Gtk.FlowBoxChild()
+            tile = Gtk.Box(spacing=8)
+            tile.set_border_width(8)
+            tile.set_size_request(180, -1)
+            tag_label = Gtk.Label(label=tag)
+            tag_label.set_xalign(0)
+            tag_label.set_hexpand(True)
+            bias_label = Gtk.Label(
+                label=TAG_BIAS_LABELS[self.tag_biases.get(tag, 0)]
+            )
+            bias_label.set_xalign(1)
+            self._set_tag_bias_label(bias_label, self.tag_biases.get(tag, 0))
+            tile.pack_start(tag_label, True, True, 0)
+            tile.pack_end(bias_label, False, False, 0)
+            child.add(tile)
+            self.tag_children[child] = tag
+            self.tag_bias_labels[tag] = bias_label
+            self.tag_tuning_flow.insert(child, -1)
+            child.show_all()
+        self.tag_tuning_flow.invalidate_filter()
+        self.tag_tuning_flow.invalidate_sort()
+        has_tags = bool(self.tag_children)
+        if not has_tags and self.tuning_toggle.get_active():
+            self.tuning_toggle.set_active(False)
+        self.tuning_toggle.set_sensitive(has_tags)
+        self.reset_all_tags_button.set_sensitive(bool(self.tag_biases))
+        self.tag_selection_label.set_text(
+            _('Select one or more tags.')
+            if has_tags
+            else _('This model does not include any tags.')
+        )
+        self._update_tuning_button_label()
+
+    def is_tag_child_visible(self, child, data=None):
+        tag = self.tag_children[child]
+        bias = self.tag_biases.get(tag, 0)
+        query = self.tag_search.get_text().strip().casefold()
+        if query and query not in tag.casefold():
+            return False
+        mode = self.tag_filter_choice.get_active_id() or 'all'
+        if mode == 'adjusted':
+            return bias != 0
+        if mode == 'neutral':
+            return bias == 0
+        return True
+
+    def on_tag_filter_changed(self, widget):
+        self.tag_tuning_flow.unselect_all()
+        self.tag_tuning_flow.invalidate_filter()
+
+    def compare_tag_children(self, first, second, data=None):
+        first_tag = self.tag_children[first]
+        second_tag = self.tag_children[second]
+        first_bias = self.tag_biases.get(first_tag, 0)
+        second_bias = self.tag_biases.get(second_tag, 0)
+        mode = self.tag_sort_choice.get_active_id() or 'adjusted'
+        if mode == 'name':
+            first_key = (first_tag.casefold(), first_tag)
+            second_key = (second_tag.casefold(), second_tag)
+        elif mode == 'bias':
+            first_key = (-first_bias, first_tag.casefold(), first_tag)
+            second_key = (-second_bias, second_tag.casefold(), second_tag)
+        else:
+            first_key = (
+                first_bias == 0,
+                first_tag.casefold(),
+                first_tag,
+            )
+            second_key = (
+                second_bias == 0,
+                second_tag.casefold(),
+                second_tag,
+            )
+        return (first_key > second_key) - (first_key < second_key)
+
+    def on_tag_sort_changed(self, widget):
+        self.tag_tuning_flow.invalidate_sort()
+
+    def on_tag_selection_changed(self, flowbox):
+        count = len(flowbox.get_selected_children())
+        self.bias_buttons.set_sensitive(count > 0)
+        self.tag_selection_label.set_text(
+            ngettext('%d tag selected.', '%d tags selected.', count) % count
+            if count
+            else _('Select one or more tags.')
+        )
+
+    def _selected_tag_names(self):
+        return [
+            self.tag_children[child]
+            for child in self.tag_tuning_flow.get_selected_children()
+        ]
+
+    def _set_tag_bias_label(self, label, bias):
+        label.set_text(TAG_BIAS_LABELS[bias])
+        context = label.get_style_context()
+        if bias == 0:
+            context.add_class('dim-label')
+        else:
+            context.remove_class('dim-label')
+
+    def set_selected_tag_bias(self, bias):
+        selected = set(self._selected_tag_names())
+        if not selected:
+            return
+        for tag in selected:
+            if bias == 0:
+                self.tag_biases.pop(tag, None)
+            else:
+                self.tag_biases[tag] = bias
+            self._set_tag_bias_label(self.tag_bias_labels[tag], bias)
+        self._tag_biases_changed()
+
+    def on_tag_child_activated(self, flowbox, child):
+        tag = self.tag_children[child]
+        bias = self.tag_biases.get(tag, 0)
+        levels = (-2, -1, 0, 1, 2)
+        next_bias = levels[(levels.index(bias) + 1) % len(levels)]
+        self.set_selected_tag_bias(next_bias)
+
+    def on_tag_key_pressed(self, flowbox, event):
+        bias_for_key = {'1': -2, '2': -1, '3': 0, '4': 1, '5': 2, '0': 0}
+        bias = bias_for_key.get(event.string)
+        if bias is None:
+            return False
+        self.set_selected_tag_bias(bias)
+        return True
+
+    def on_reset_all_tags(self, button):
+        if self.tag_biases:
+            self.tag_biases.clear()
+            for label in self.tag_bias_labels.values():
+                self._set_tag_bias_label(label, 0)
+            self._tag_biases_changed()
+
+    def _tag_biases_changed(self):
+        try:
+            self.plugin.set_model_tag_biases(self.model_name, self.tag_biases)
+        except Exception as exc:
+            dialogs.error(
+                self.plugin._get_parent_window(),
+                _('Could not save tag tuning: %s') % exc,
+            )
+            self._populate_tag_tuning(self.plugin.load_model(self.model_name))
+            return
+        self.tag_tuning_flow.invalidate_filter()
+        self.tag_tuning_flow.invalidate_sort()
+        self.reset_all_tags_button.set_sensitive(bool(self.tag_biases))
+        self._update_tuning_button_label()
+        if self.tag_rebuild_source is not None:
+            GLib.source_remove(self.tag_rebuild_source)
+        self.tag_rebuild_source = GLib.timeout_add(
+            TAG_BIAS_REBUILD_DELAY_MS, self.regenerate_tag_suggestions
+        )
+
+    def _update_tuning_button_label(self):
+        if not hasattr(self, 'tuning_toggle'):
+            return
+        if self.tuning_toggle.get_active():
+            self.tuning_toggle.set_label(_('Show Suggestions'))
+            return
+        adjusted = len(self.tag_biases)
+        self.tuning_toggle.set_label(
+            _('Tune Tags (%d)') % adjusted if adjusted else _('Tune Tags')
+        )
+
+    def regenerate_tag_suggestions(self):
+        self.tag_rebuild_source = None
+        if self.plugin.suggestion_request is not None:
+            self.plugin.suggest_from_tracks(*self.plugin.suggestion_request)
+        return False
 
     def get_page_name(self):
         return _('Track Suggestions')
@@ -669,6 +1028,22 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
 
     def set_model_name(self, model_name):
         self.model_label.set_text(_('Model: %s') % model_name)
+        if model_name == self.model_name:
+            return
+        self.model_name = model_name
+        try:
+            model = self.plugin.load_model(model_name)
+        except Exception:
+            self.tag_biases.clear()
+            for child in self.tag_tuning_flow.get_children():
+                self.tag_tuning_flow.remove(child)
+            self.tag_children.clear()
+            self.tag_bias_labels.clear()
+            self.tuning_toggle.set_sensitive(False)
+            self.reset_all_tags_button.set_sensitive(False)
+            self._update_tuning_button_label()
+            return
+        self._populate_tag_tuning(model)
 
     def on_search_entry_activate(self, entry):
         self.view.filter_tracks(entry.get_text() or None)
@@ -689,6 +1064,9 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         if self.diversity_rebuild_source is not None:
             GLib.source_remove(self.diversity_rebuild_source)
             self.diversity_rebuild_source = None
+        if self.tag_rebuild_source is not None:
+            GLib.source_remove(self.tag_rebuild_source)
+            self.tag_rebuild_source = None
         playlist_widget.PlaylistPageBase.do_destroy(self)
 
 

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -145,10 +145,16 @@ class QueueTrackPredictorPlugin:
     def save_model_catalog(self, catalog):
         model_store.save_catalog(self.get_model_path(), catalog)
 
-    def create_model_from_playlists(self, name, playlists):
+    def create_model_from_playlists(
+        self, name, playlists, playlist_names, replace=False
+    ):
         model = predictor_model.build_model(playlists, self.get_track_groups)
+        model['playlist_names'] = sorted(playlist_names)
         catalog = self.load_model_catalog()
-        model_store.add_model(catalog, name, model)
+        if replace:
+            model_store.replace_model(catalog, name, model)
+        else:
+            model_store.add_model(catalog, name, model)
         self.save_model_catalog(catalog)
         return model
 
@@ -253,10 +259,21 @@ class ModelManagerDialog(Gtk.Dialog):
         self.tree.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.tree.get_selection().connect('changed', self.on_selection_changed)
         self.tree.connect('row-activated', self.on_row_activated)
+        self.tree.connect('button-press-event', self.on_tree_button_press)
         self._add_text_column('', 0, False)
         self._add_text_column(_('Name'), 1, True)
         self._add_text_column(_('Playlists'), 2, False)
         self._add_text_column(_('Tracks'), 3, False)
+
+        self.context_menu = Gtk.Menu()
+        rebuild_menu_item = Gtk.MenuItem(label=_('Rebuild'))
+        rebuild_menu_item.connect('activate', self.on_rebuild_clicked)
+        self.context_menu.append(rebuild_menu_item)
+        self.context_menu.append(Gtk.SeparatorMenuItem())
+        remove_menu_item = Gtk.MenuItem(label=_('Remove'))
+        remove_menu_item.connect('activate', self.on_remove_clicked)
+        self.context_menu.append(remove_menu_item)
+        self.context_menu.show_all()
 
         scroller = Gtk.ScrolledWindow()
         scroller.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
@@ -267,6 +284,9 @@ class ModelManagerDialog(Gtk.Dialog):
         self.add_button_widget = Gtk.Button(label=_('Add'))
         self.add_button_widget.connect('clicked', self.on_add_clicked)
         buttons.pack_start(self.add_button_widget, False, False, 0)
+        self.rebuild_button = Gtk.Button(label=_('Rebuild'))
+        self.rebuild_button.connect('clicked', self.on_rebuild_clicked)
+        buttons.pack_start(self.rebuild_button, False, False, 0)
         self.rename_button = Gtk.Button(label=_('Rename'))
         self.rename_button.connect('clicked', self.on_rename_clicked)
         buttons.pack_start(self.rename_button, False, False, 0)
@@ -317,6 +337,7 @@ class ModelManagerDialog(Gtk.Dialog):
 
     def on_selection_changed(self, selection):
         enabled = self.get_selected_name() is not None
+        self.rebuild_button.set_sensitive(enabled)
         self.rename_button.set_sensitive(enabled)
         self.remove_button.set_sensitive(enabled)
         self.select_button.set_sensitive(enabled)
@@ -330,6 +351,21 @@ class ModelManagerDialog(Gtk.Dialog):
             dialogs.error(self, _('A model with that name already exists.'))
             return
         self.plugin.train_dialog = TrainingDialog(self.plugin, self, name)
+        self.plugin.train_dialog.present()
+
+    def on_rebuild_clicked(self, button):
+        name = self.get_selected_name()
+        if name is None:
+            return
+        catalog = self.plugin.load_model_catalog()
+        playlist_names = catalog['models'][name].get('playlist_names', [])
+        self.plugin.train_dialog = TrainingDialog(
+            self.plugin,
+            self,
+            name,
+            replace=True,
+            selected_playlist_names=playlist_names,
+        )
         self.plugin.train_dialog.present()
 
     def on_rename_clicked(self, button):
@@ -375,6 +411,16 @@ class ModelManagerDialog(Gtk.Dialog):
         self.tree.get_selection().select_path(path)
         self.on_select_clicked(None)
 
+    def on_tree_button_press(self, tree, event):
+        if event.button != 3:
+            return False
+        row = tree.get_path_at_pos(int(event.x), int(event.y))
+        if row is None:
+            return False
+        tree.get_selection().select_path(row[0])
+        self.context_menu.popup_at_pointer(event)
+        return True
+
     def on_delete_event(self, widget, event):
         self.plugin.model_manager_dialog = None
 
@@ -410,20 +456,31 @@ def prompt_for_model_name(parent, title, initial=''):
 
 
 class TrainingDialog(Gtk.Dialog):
-    def __init__(self, plugin, parent, model_name):
+    def __init__(
+        self,
+        plugin,
+        parent,
+        model_name,
+        replace=False,
+        selected_playlist_names=None,
+    ):
+        action = _('Rebuild') if replace else _('Create')
         Gtk.Dialog.__init__(
             self,
-            title=_('Create Prediction Model “%s”') % model_name,
+            title=_('%(action)s Prediction Model “%(name)s”')
+            % {'action': action, 'name': model_name},
             transient_for=parent,
             modal=True,
         )
         self.plugin = plugin
         self.model_name = model_name
+        self.replace = replace
+        self.selected_playlist_names = set(selected_playlist_names or [])
         self.set_default_size(420, 360)
         self.add_buttons(
             Gtk.STOCK_CANCEL,
             Gtk.ResponseType.CANCEL,
-            _('Create'),
+            action,
             Gtk.ResponseType.OK,
         )
         self.connect('response', self.on_response)
@@ -472,7 +529,13 @@ class TrainingDialog(Gtk.Dialog):
     def populate_playlists(self):
         manager = self.plugin.exaile.playlists
         for name in sorted(manager.list_playlists()):
-            self.store.append((False, name, manager.get_playlist(name)))
+            self.store.append(
+                (
+                    name in self.selected_playlist_names,
+                    name,
+                    manager.get_playlist(name),
+                )
+            )
 
     def on_playlist_toggled(self, renderer, path):
         self.store[path][0] = not self.store[path][0]
@@ -484,6 +547,9 @@ class TrainingDialog(Gtk.Dialog):
     def get_selected_playlists(self):
         return [row[2] for row in self.store if row[0]]
 
+    def get_selected_playlist_names(self):
+        return [row[1] for row in self.store if row[0]]
+
     def on_response(self, dialog, response):
         if response == Gtk.ResponseType.OK:
             playlists = self.get_selected_playlists()
@@ -493,7 +559,10 @@ class TrainingDialog(Gtk.Dialog):
 
             try:
                 trained_model = self.plugin.create_model_from_playlists(
-                    self.model_name, playlists
+                    self.model_name,
+                    playlists,
+                    self.get_selected_playlist_names(),
+                    replace=self.replace,
                 )
             except Exception as exc:
                 dialogs.error(self, _("Could not create suggestions model: %s") % exc)
@@ -501,8 +570,12 @@ class TrainingDialog(Gtk.Dialog):
 
             dialogs.info(
                 self,
-                _("Created model from %(playlists)d playlist(s) and %(tracks)d track(s).")
+                _(
+                    "%(action)s model from %(playlists)d playlist(s) and "
+                    "%(tracks)d track(s)."
+                )
                 % {
+                    'action': _('Rebuilt') if self.replace else _('Created'),
                     'playlists': trained_model.get('playlist_count', 0),
                     'tracks': trained_model.get('track_count', 0),
                 },

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -10,7 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 from gi.repository import GLib, Gtk
 
 from xl import player, providers, settings, xdg
-from xl.playlist import Playlist
+from xl.playlist import Playlist, SmartPlaylist
 from xl.nls import gettext as _, ngettext
 from xlgui import guiutil, main
 from xlgui.accelerators import Accelerator
@@ -42,6 +42,7 @@ class QueueTrackPredictorPlugin:
         self.exaile = None
         self.menu_item = None
         self.playlist_menu_item = None
+        self.smart_playlist_menu_item = None
         self.train_dialog = None
         self.model_manager_dialog = None
         self.model_manager_open_source = None
@@ -75,6 +76,15 @@ class QueueTrackPredictorPlugin:
 
         self.playlist_menu_item = PredictionModelsMenuItem(self)
         self.playlist_menu_item.register('playlist-context-menu')
+
+        self.smart_playlist_menu_item = menu.simple_menu_item(
+            'queue-track-predictor-smart-playlist-source',
+            ['export-files'],
+            _('Use as Track Suggestion Source'),
+            callback=self.on_use_smart_playlist_source,
+            condition_fn=self.can_use_smart_playlist_source,
+        )
+        self.smart_playlist_menu_item.register('playlist-panel-context-menu')
 
         SuggestNextTrackButton.plugin = self
         providers.register('playlist-notebook-actions', SuggestNextTrackButton)
@@ -116,6 +126,10 @@ class QueueTrackPredictorPlugin:
         if self.playlist_menu_item is not None:
             self.playlist_menu_item.unregister()
             self.playlist_menu_item = None
+
+        if self.smart_playlist_menu_item is not None:
+            self.smart_playlist_menu_item.unregister()
+            self.smart_playlist_menu_item = None
 
         if self.button_registered:
             providers.unregister(
@@ -201,6 +215,14 @@ class QueueTrackPredictorPlugin:
             self._get_parent_window(parent),
             model_name,
         )
+
+    def can_use_smart_playlist_source(self, name, parent, context):
+        return isinstance(context['selected-playlist'], SmartPlaylist)
+
+    def on_use_smart_playlist_source(self, widget, name, parent, context):
+        playlist = context['selected-playlist']
+        if isinstance(playlist, SmartPlaylist):
+            self.set_suggestion_source(playlist.name)
 
     def suggest_after_playlist_position(
         self, playlist, position, parent_window=None, model_name=None
@@ -381,6 +403,7 @@ class QueueTrackPredictorPlugin:
             )
         )
         model_tuning = self._get_tuning_settings()
+        source_name = self.get_suggestion_source()
         self.suggestion_generation += 1
         generation = self.suggestion_generation
         if self.suggestion_future is not None:
@@ -395,6 +418,7 @@ class QueueTrackPredictorPlugin:
             model_tuning,
             parent_window,
             model_name,
+            source_name,
         )
 
     def _compute_suggestions(
@@ -407,6 +431,7 @@ class QueueTrackPredictorPlugin:
         model_tuning,
         parent_window,
         model_name,
+        source_name,
     ):
         try:
             model_name, trained_model = self.load_model_entry(model_name)
@@ -436,7 +461,34 @@ class QueueTrackPredictorPlugin:
                     model_name, trained_model, model_tuning
                 )
             )
-            candidate_tracks = self.exaile.collection.get_tracks()
+            if source_name:
+                try:
+                    source = self.exaile.smart_playlists.get_playlist(source_name)
+                except ValueError:
+                    GLib.idle_add(
+                        self._show_suggestion_message,
+                        generation,
+                        parent_window,
+                        False,
+                        _('The smart playlist “%s” is no longer available.')
+                        % source_name,
+                    )
+                    return
+                candidate_tracks = list(
+                    source.get_playlist(self.exaile.collection)
+                )
+                if not candidate_tracks:
+                    GLib.idle_add(
+                        self._show_suggestion_message,
+                        generation,
+                        parent_window,
+                        False,
+                        _('The smart playlist “%s” contains no tracks.')
+                        % source_name,
+                    )
+                    return
+            else:
+                candidate_tracks = self.exaile.collection.get_tracks()
             candidate_features = predictor_model.make_candidate_features(
                 candidate_tracks,
                 self.get_track_groups,
@@ -485,6 +537,7 @@ class QueueTrackPredictorPlugin:
             scored_tracks,
             diversity,
             model_name,
+            source_name,
         )
 
     def _show_suggestion_message(
@@ -499,7 +552,13 @@ class QueueTrackPredictorPlugin:
         return False
 
     def _apply_suggestion_result(
-        self, generation, parent_window, scored_tracks, diversity, model_name
+        self,
+        generation,
+        parent_window,
+        scored_tracks,
+        diversity,
+        model_name,
+        source_name,
     ):
         if generation != self.suggestion_generation:
             return False
@@ -524,10 +583,14 @@ class QueueTrackPredictorPlugin:
                 excluded_locations,
                 model_name,
             )
-        self.show_suggestions_playlist(scored_tracks, diversity, model_name)
+        self.show_suggestions_playlist(
+            scored_tracks, diversity, model_name, source_name
+        )
         return False
 
-    def show_suggestions_playlist(self, scored_tracks, diversity, model_name):
+    def show_suggestions_playlist(
+        self, scored_tracks, diversity, model_name, source_name
+    ):
         playlist_notebook = self._get_suggestions_notebook()
         if playlist_notebook is None:
             playlist_notebook = main.get_playlist_notebook()
@@ -538,6 +601,7 @@ class QueueTrackPredictorPlugin:
                 player.PLAYER,
                 diversity,
                 model_name,
+                source_name,
             )
             self.suggestions_page.connect(
                 'destroy', self.on_suggestions_page_destroyed
@@ -552,6 +616,7 @@ class QueueTrackPredictorPlugin:
             self.suggestions_playlist.replace_tracks(scored_tracks)
             self.suggestions_page.set_diversity(diversity)
             self.suggestions_page.set_model_name(model_name)
+            self.suggestions_page.set_source_name(source_name)
             playlist_notebook.set_current_page(
                 playlist_notebook.page_num(self.suggestions_page)
             )
@@ -576,6 +641,24 @@ class QueueTrackPredictorPlugin:
             excluded_locations,
             model_name,
         )
+
+    def get_suggestion_source(self):
+        return settings.get_option(
+            predictor_preferences.SUGGESTION_SOURCE_OPTION, ''
+        )
+
+    def get_smart_playlist_names(self):
+        return sorted(self.exaile.smart_playlists.list_playlists(), key=str.lower)
+
+    def set_suggestion_source(self, source_name):
+        source_name = source_name or ''
+        settings.set_option(
+            predictor_preferences.SUGGESTION_SOURCE_OPTION, source_name
+        )
+        if self.suggestions_page is not None:
+            self.suggestions_page.set_source_name(source_name)
+        if self.suggestion_request is not None:
+            self.suggest_from_tracks(*self.suggestion_request)
 
     def _get_suggestions_notebook(self):
         if self.suggestions_tab is None or self.suggestions_page is None:
@@ -781,6 +864,7 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         playlist_player,
         diversity,
         model_name,
+        source_name,
     ):
         playlist_widget.PlaylistPageBase.__init__(
             self, suggestions_playlist, playlist_player
@@ -791,6 +875,7 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         self.bpm_rebuild_source = None
         self.model_name = None
         self.model_names = []
+        self.source_name = None
         self.swindow = Gtk.ScrolledWindow()
         self.swindow.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         self.view = SuggestionsPlaylistView(
@@ -841,6 +926,10 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
             'changed', self.on_model_choice_changed
         )
         diversity_box.pack_start(self.model_choice, False, False, 0)
+        source_label = Gtk.Label(label=_('Source:'))
+        diversity_box.pack_start(source_label, False, False, 0)
+        self._build_source_choice()
+        diversity_box.pack_start(self.source_choice, False, False, 0)
         self.tuning_toggle = Gtk.ToggleButton(label=_('Tune Tags'))
         self.tuning_toggle.set_tooltip_text(
             _('Tune tag preferences for this prediction model')
@@ -896,8 +985,61 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         diversity_box.pack_end(self.search_entry.entry, False, True, 0)
         self.pack_start(diversity_box, False, False, 0)
         self.set_model_name(model_name)
+        self.set_source_name(source_name)
         self.content_stack.set_visible_child_name('suggestions')
         self.show_all()
+
+    def _build_source_choice(self):
+        self.source_choice = Gtk.ComboBoxText()
+        self.source_choices = {}
+        self.source_choice.set_tooltip_text(
+            _('Limit suggestions to tracks in a smart playlist')
+        )
+        self.source_choice_changed_id = self.source_choice.connect(
+            'changed', self.on_source_choice_changed
+        )
+        self.source_choice.connect(
+            'button-press-event', self.on_source_choice_button_press
+        )
+
+    def refresh_source_choices(self):
+        names = self.plugin.get_smart_playlist_names()
+        choices = [('', _('Entire collection'))]
+        if self.source_name and self.source_name not in names:
+            choices.append(
+                (
+                    self.source_name,
+                    _('Unavailable: %s') % self.source_name,
+                )
+            )
+        choices.extend((name, name) for name in names)
+
+        self.source_choice.handler_block(self.source_choice_changed_id)
+        self.source_choice.remove_all()
+        self.source_choices.clear()
+        active_id = None
+        for index, (source_name, display_name) in enumerate(choices):
+            choice_id = str(index)
+            self.source_choices[choice_id] = source_name
+            self.source_choice.append(choice_id, display_name)
+            if source_name == self.source_name:
+                active_id = choice_id
+        self.source_choice.set_active_id(active_id)
+        self.source_choice.handler_unblock(self.source_choice_changed_id)
+
+    def on_source_choice_button_press(self, choice, event):
+        self.refresh_source_choices()
+        return False
+
+    def on_source_choice_changed(self, choice):
+        choice_id = choice.get_active_id()
+        if choice_id is None:
+            return
+        source_name = self.source_choices[choice_id]
+        if source_name == self.source_name:
+            return
+        self.source_name = source_name
+        self.plugin.set_suggestion_source(source_name)
 
     def _build_tag_tuning_panel(self):
         panel = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
@@ -1251,6 +1393,11 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
             self._update_tuning_button_label()
             return
         self._populate_tag_tuning(model)
+
+    def set_source_name(self, source_name):
+        source_name = source_name or ''
+        self.source_name = source_name
+        self.refresh_source_choices()
 
     def on_model_choice_changed(self, choice):
         model_name = choice.get_active_id()

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -16,6 +16,7 @@ from xlgui.widgets import dialogs, menu, notebook, playlist as playlist_widget
 
 from . import model as predictor_model
 from . import model_store
+from . import preferences as predictor_preferences
 
 
 MODEL_DIR = 'queuetrackpredictor'
@@ -36,6 +37,9 @@ class QueueTrackPredictorPlugin:
 
     def enable(self, exaile):
         self.exaile = exaile
+
+    def get_preferences_pane(self):
+        return predictor_preferences
 
     def on_gui_loaded(self):
         self.menu_item = menu.simple_menu_item(
@@ -196,10 +200,17 @@ class QueueTrackPredictorPlugin:
             return
 
         try:
+            max_suggestions = int(
+                settings.get_option(
+                    predictor_preferences.MAX_SUGGESTIONS_OPTION,
+                    predictor_preferences.DEFAULT_MAX_SUGGESTIONS,
+                )
+            )
             scored_locations = predictor_model.get_scored_suggestion_locations(
                 trained_model,
                 previous_tracks[-3:],
                 self.get_track_groups,
+                max_suggestions=max_suggestions,
                 excluded_locations=excluded_locations,
             )
         except Exception as exc:
@@ -207,7 +218,9 @@ class QueueTrackPredictorPlugin:
             return
 
         scored_tracks = predictor_model.resolve_scored_suggestion_tracks(
-            self.exaile.collection, scored_locations
+            self.exaile.collection,
+            scored_locations,
+            max_suggestions=max_suggestions,
         )
 
         if not scored_tracks:

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -62,14 +62,7 @@ class QueueTrackPredictorPlugin:
         )
         self.menu_item.register('menubar-tools-menu')
 
-        self.playlist_menu_item = menu.simple_menu_item(
-            'queue-track-predictor-playlist-suggest',
-            ['enqueue'],
-            _('Suggest Next Track'),
-            'list-add',
-            callback=self.on_playlist_suggest_next_track,
-            condition_fn=self.can_suggest_from_playlist_context,
-        )
+        self.playlist_menu_item = PredictionModelsMenuItem(self)
         self.playlist_menu_item.register('playlist-context-menu')
 
         SuggestNextTrackButton.plugin = self
@@ -170,7 +163,9 @@ class QueueTrackPredictorPlugin:
             return False
         return True
 
-    def on_playlist_suggest_next_track(self, widget, name, parent, context):
+    def on_playlist_suggest_next_track(
+        self, widget, model_name, parent, context
+    ):
         selected_items = context['selected-items']
         if not selected_items:
             return
@@ -186,6 +181,7 @@ class QueueTrackPredictorPlugin:
             previous_tracks,
             self._get_parent_window(parent),
             excluded_locations=excluded_locations,
+            model_name=model_name,
         )
 
     def load_model_catalog(self):
@@ -209,12 +205,18 @@ class QueueTrackPredictorPlugin:
         self.save_model_catalog(catalog)
         return model
 
-    def load_model(self):
+    def load_model(self, model_name=None):
+        return self.load_model_entry(model_name)[1]
+
+    def load_model_entry(self, model_name=None):
         catalog = self.load_model_catalog()
-        selected = catalog.get('selected')
-        if selected is None:
+        model_name = model_name or catalog.get('selected')
+        if model_name is None:
             raise IOError('No prediction model is selected')
-        return catalog['models'][selected]
+        try:
+            return model_name, catalog['models'][model_name]
+        except KeyError:
+            raise ValueError('Prediction model “%s” does not exist' % model_name)
 
     def suggest_next_track(self, parent_window=None):
         parent_window = parent_window or self._get_parent_window()
@@ -225,7 +227,11 @@ class QueueTrackPredictorPlugin:
         self.suggest_from_tracks(queue_tracks[-RECENT_TRACK_COUNT:], parent_window)
 
     def suggest_from_tracks(
-        self, previous_tracks, parent_window=None, excluded_locations=None
+        self,
+        previous_tracks,
+        parent_window=None,
+        excluded_locations=None,
+        model_name=None,
     ):
         parent_window = parent_window or self._get_parent_window()
         previous_tracks = list(previous_tracks)
@@ -238,6 +244,7 @@ class QueueTrackPredictorPlugin:
             previous_tracks,
             parent_window,
             excluded_locations,
+            model_name,
         )
         max_suggestions = int(
             settings.get_option(
@@ -263,6 +270,7 @@ class QueueTrackPredictorPlugin:
             max_suggestions,
             diversity,
             parent_window,
+            model_name,
         )
 
     def _compute_suggestions(
@@ -273,9 +281,10 @@ class QueueTrackPredictorPlugin:
         max_suggestions,
         diversity,
         parent_window,
+        model_name,
     ):
         try:
-            trained_model = self.load_model()
+            model_name, trained_model = self.load_model_entry(model_name)
         except IOError:
             GLib.idle_add(
                 self._show_suggestion_message,
@@ -333,6 +342,7 @@ class QueueTrackPredictorPlugin:
             parent_window,
             scored_tracks,
             diversity,
+            model_name,
         )
 
     def _show_suggestion_message(
@@ -347,7 +357,7 @@ class QueueTrackPredictorPlugin:
         return False
 
     def _apply_suggestion_result(
-        self, generation, parent_window, scored_tracks, diversity
+        self, generation, parent_window, scored_tracks, diversity, model_name
     ):
         if generation != self.suggestion_generation:
             return False
@@ -355,16 +365,20 @@ class QueueTrackPredictorPlugin:
         if not scored_tracks:
             dialogs.info(parent_window, _("No suggestions found for the queue tail."))
             return False
-        self.show_suggestions_playlist(scored_tracks, diversity)
+        self.show_suggestions_playlist(scored_tracks, diversity, model_name)
         return False
 
-    def show_suggestions_playlist(self, scored_tracks, diversity):
+    def show_suggestions_playlist(self, scored_tracks, diversity, model_name):
         playlist_notebook = self._get_suggestions_notebook()
         if playlist_notebook is None:
             playlist_notebook = main.get_playlist_notebook()
             self.suggestions_playlist = SuggestionsPlaylist(scored_tracks)
             self.suggestions_page = SuggestionsPlaylistPage(
-                self, self.suggestions_playlist, player.PLAYER, diversity
+                self,
+                self.suggestions_playlist,
+                player.PLAYER,
+                diversity,
+                model_name,
             )
             self.suggestions_page.connect(
                 'destroy', self.on_suggestions_page_destroyed
@@ -378,6 +392,7 @@ class QueueTrackPredictorPlugin:
         else:
             self.suggestions_playlist.replace_tracks(scored_tracks)
             self.suggestions_page.set_diversity(diversity)
+            self.suggestions_page.set_model_name(model_name)
             playlist_notebook.set_current_page(
                 playlist_notebook.page_num(self.suggestions_page)
             )
@@ -409,6 +424,50 @@ class QueueTrackPredictorPlugin:
         self.suggestions_playlist = None
         self.suggestions_page = None
         self.suggestions_tab = None
+
+
+class PredictionModelsMenuItem(menu.MenuItem):
+    def __init__(self, plugin):
+        menu.MenuItem.__init__(
+            self, 'queue-track-predictor-playlist-suggest', None, ['enqueue']
+        )
+        self.plugin = plugin
+
+    def factory(self, menu_widget, parent, context):
+        if not self.plugin.can_suggest_from_playlist_context(
+            self.name, parent, context
+        ):
+            return None
+
+        item = Gtk.ImageMenuItem.new_with_mnemonic(_('Suggest Next Track'))
+        item.set_image(
+            Gtk.Image.new_from_icon_name('list-add', Gtk.IconSize.MENU)
+        )
+
+        try:
+            catalog = self.plugin.load_model_catalog()
+            names = model_store.model_names(catalog)
+        except Exception:
+            names = []
+
+        if not names:
+            item.set_sensitive(False)
+            return item
+
+        submenu = Gtk.Menu()
+        for model_name in names:
+            model_item = Gtk.MenuItem.new_with_label(model_name)
+            model_item.connect(
+                'activate',
+                self.plugin.on_playlist_suggest_next_track,
+                model_name,
+                parent,
+                context,
+            )
+            submenu.append(model_item)
+        submenu.show_all()
+        item.set_submenu(submenu)
+        return item
 
 
 class SuggestNextTrackButton(Gtk.Button, notebook.NotebookAction):
@@ -519,7 +578,14 @@ class SuggestionsPlaylistView(playlist_widget.PlaylistView):
 class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
     reorderable = False
 
-    def __init__(self, plugin, suggestions_playlist, playlist_player, diversity):
+    def __init__(
+        self,
+        plugin,
+        suggestions_playlist,
+        playlist_player,
+        diversity,
+        model_name,
+    ):
         playlist_widget.PlaylistPageBase.__init__(
             self, suggestions_playlist, playlist_player
         )
@@ -558,6 +624,12 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
 
         diversity_box = Gtk.Box(spacing=8)
         diversity_box.set_border_width(6)
+        self.model_label = Gtk.Label()
+        self.model_label.set_xalign(0)
+        self.set_model_name(model_name)
+        diversity_box.pack_start(self.model_label, False, False, 0)
+        separator = Gtk.Separator(orientation=Gtk.Orientation.VERTICAL)
+        diversity_box.pack_start(separator, False, False, 0)
         diversity_label = Gtk.Label(label=_('Diversity:'))
         diversity_box.pack_start(diversity_label, False, False, 0)
         self.diversity_scale = Gtk.Scale.new_with_range(
@@ -583,6 +655,9 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
     def set_diversity(self, diversity):
         if int(round(self.diversity_scale.get_value())) != int(round(diversity)):
             self.diversity_scale.set_value(diversity)
+
+    def set_model_name(self, model_name):
+        self.model_label.set_text(_('Model: %s') % model_name)
 
     def on_search_entry_activate(self, entry):
         self.view.filter_tracks(entry.get_text() or None)
@@ -682,7 +757,7 @@ class ModelManagerDialog(Gtk.Dialog):
         selected_name = catalog.get('selected')
         self.store.clear()
         path_to_select = None
-        for name in sorted(catalog['models']):
+        for name in model_store.model_names(catalog):
             model = catalog['models'][name]
             tree_iter = self.store.append(
                 (

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -919,10 +919,9 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         tools.pack_start(self.tag_filter_choice, False, False, 0)
 
         self.tag_sort_choice = Gtk.ComboBoxText()
-        self.tag_sort_choice.append('adjusted', _('Adjusted First'))
         self.tag_sort_choice.append('name', _('Name'))
         self.tag_sort_choice.append('bias', _('Bias'))
-        self.tag_sort_choice.set_active_id('adjusted')
+        self.tag_sort_choice.set_active_id('name')
         self.tag_sort_choice.set_tooltip_text(_('Sort tags'))
         self.tag_sort_choice.connect('changed', self.on_tag_sort_changed)
         tools.pack_start(self.tag_sort_choice, False, False, 0)
@@ -1071,24 +1070,13 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         second_tag = self.tag_children[second]
         first_bias = self.tag_biases.get(first_tag, 0)
         second_bias = self.tag_biases.get(second_tag, 0)
-        mode = self.tag_sort_choice.get_active_id() or 'adjusted'
-        if mode == 'name':
-            first_key = (first_tag.casefold(), first_tag)
-            second_key = (second_tag.casefold(), second_tag)
-        elif mode == 'bias':
+        mode = self.tag_sort_choice.get_active_id() or 'name'
+        if mode == 'bias':
             first_key = (-first_bias, first_tag.casefold(), first_tag)
             second_key = (-second_bias, second_tag.casefold(), second_tag)
         else:
-            first_key = (
-                first_bias == 0,
-                first_tag.casefold(),
-                first_tag,
-            )
-            second_key = (
-                second_bias == 0,
-                second_tag.casefold(),
-                second_tag,
-            )
+            first_key = (first_tag.casefold(), first_tag)
+            second_key = (second_tag.casefold(), second_tag)
         return (first_key > second_key) - (first_key < second_key)
 
     def on_tag_sort_changed(self, widget):

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -305,6 +305,15 @@ class QueueTrackPredictorPlugin:
             return
 
         try:
+            candidate_tracks = self.exaile.collection.get_tracks()
+            candidate_features = predictor_model.make_candidate_features(
+                candidate_tracks,
+                self.get_track_groups,
+                trained_model.get(
+                    'bpm_band_size', predictor_model.DEFAULT_BPM_BAND_SIZE
+                ),
+                trained_model.get('included_tags'),
+            )
             candidate_limit = max_suggestions * CANDIDATE_POOL_MULTIPLIER
             scored_locations = predictor_model.get_scored_suggestion_locations(
                 trained_model,
@@ -312,6 +321,7 @@ class QueueTrackPredictorPlugin:
                 self.get_track_groups,
                 max_suggestions=candidate_limit,
                 excluded_locations=excluded_locations,
+                candidate_features=candidate_features,
             )
             scored_locations = predictor_model.rerank_suggestions_for_diversity(
                 trained_model,
@@ -320,6 +330,7 @@ class QueueTrackPredictorPlugin:
                 self.get_track_groups,
                 max_suggestions=max_suggestions,
                 diversity=diversity,
+                candidate_features=candidate_features,
             )
             scored_tracks = predictor_model.resolve_scored_suggestion_tracks(
                 self.exaile.collection,

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -948,9 +948,6 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         self.tag_tuning_flow.connect(
             'selected-children-changed', self.on_tag_selection_changed
         )
-        self.tag_tuning_flow.connect(
-            'child-activated', self.on_tag_child_activated
-        )
         self.tag_tuning_flow.connect('key-press-event', self.on_tag_key_pressed)
 
         tag_scroller = Gtk.ScrolledWindow()
@@ -1029,8 +1026,13 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
             )
             bias_label.set_xalign(1)
             self._set_tag_bias_label(bias_label, self.tag_biases.get(tag, 0))
+            bias_button = Gtk.Button()
+            bias_button.set_relief(Gtk.ReliefStyle.NONE)
+            bias_button.set_tooltip_text(_('Click to change this tag bias'))
+            bias_button.add(bias_label)
+            bias_button.connect('clicked', self.on_tag_bias_clicked, tag)
             tile.pack_start(tag_label, True, True, 0)
-            tile.pack_end(bias_label, False, False, 0)
+            tile.pack_end(bias_button, False, False, 0)
             child.add(tile)
             self.tag_children[child] = tag
             self.tag_bias_labels[tag] = bias_label
@@ -1110,19 +1112,22 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         if not selected:
             return
         for tag in selected:
-            if bias == 0:
-                self.tag_biases.pop(tag, None)
-            else:
-                self.tag_biases[tag] = bias
-            self._set_tag_bias_label(self.tag_bias_labels[tag], bias)
+            self._set_tag_bias(tag, bias)
         self._tag_biases_changed()
 
-    def on_tag_child_activated(self, flowbox, child):
-        tag = self.tag_children[child]
+    def _set_tag_bias(self, tag, bias):
+        if bias == 0:
+            self.tag_biases.pop(tag, None)
+        else:
+            self.tag_biases[tag] = bias
+        self._set_tag_bias_label(self.tag_bias_labels[tag], bias)
+
+    def on_tag_bias_clicked(self, button, tag):
         bias = self.tag_biases.get(tag, 0)
         levels = (-2, -1, 0, 1, 2)
         next_bias = levels[(levels.index(bias) + 1) % len(levels)]
-        self.set_selected_tag_bias(next_bias)
+        self._set_tag_bias(tag, next_bias)
+        self._tag_biases_changed()
 
     def on_tag_key_pressed(self, flowbox, event):
         bias_for_key = {'1': -2, '2': -1, '3': 0, '4': 1, '5': 2, '0': 0}

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -195,9 +195,11 @@ class QueueTrackPredictorPlugin:
         model_store.save_catalog(self.get_model_path(), catalog)
 
     def create_model_from_playlists(
-        self, name, playlists, playlist_names, replace=False
+        self, name, playlists, playlist_names, included_tags, replace=False
     ):
-        model = predictor_model.build_model(playlists, self.get_track_groups)
+        model = predictor_model.build_model(
+            playlists, self.get_track_groups, included_tags=included_tags
+        )
         model['playlist_names'] = sorted(playlist_names)
         catalog = self.load_model_catalog()
         if replace:
@@ -821,11 +823,11 @@ class TrainingDialog(Gtk.Dialog):
         replace=False,
         selected_playlist_names=None,
     ):
-        action = _('Rebuild') if replace else _('Create')
+        self.action = _('Rebuild') if replace else _('Create')
         Gtk.Dialog.__init__(
             self,
             title=_('%(action)s Prediction Model “%(name)s”')
-            % {'action': action, 'name': model_name},
+            % {'action': self.action, 'name': model_name},
             transient_for=parent,
             modal=True,
         )
@@ -833,48 +835,98 @@ class TrainingDialog(Gtk.Dialog):
         self.model_name = model_name
         self.replace = replace
         self.selected_playlist_names = set(selected_playlist_names or [])
+        self.page = 'playlists'
         self.set_default_size(420, 360)
         self.add_buttons(
             Gtk.STOCK_CANCEL,
             Gtk.ResponseType.CANCEL,
-            action,
+            Gtk.STOCK_GO_BACK,
+            Gtk.ResponseType.APPLY,
+            _('Next'),
             Gtk.ResponseType.OK,
         )
+        self.back_button = self.get_widget_for_response(Gtk.ResponseType.APPLY)
+        self.primary_button = self.get_widget_for_response(Gtk.ResponseType.OK)
+        self.set_default_response(Gtk.ResponseType.OK)
         self.connect('response', self.on_response)
         self.connect('delete-event', self.on_delete_event)
 
         content = self.get_content_area()
         content.set_border_width(6)
+        self.playlist_page = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        self.tag_page = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        content.pack_start(self.playlist_page, True, True, 0)
+        content.pack_start(self.tag_page, True, True, 0)
 
         label = Gtk.Label(label=_('Select saved playlists to analyze.'))
         label.set_xalign(0)
-        content.pack_start(label, False, False, 0)
+        self.playlist_page.pack_start(label, False, False, 0)
 
         select_box = Gtk.Box(spacing=6)
         self.select_all_button = Gtk.Button(label=_('Select All'))
         self.select_all_button.connect('clicked', self.on_select_all_clicked)
         select_box.pack_start(self.select_all_button, False, False, 0)
-        content.pack_start(select_box, False, False, 4)
+        self.playlist_page.pack_start(select_box, False, False, 4)
 
-        self.store = Gtk.ListStore(bool, str, object)
-        self.tree = Gtk.TreeView(model=self.store)
-        self.tree.set_headers_visible(True)
+        self.playlist_store = Gtk.ListStore(bool, str, object)
+        self.playlist_tree = Gtk.TreeView(model=self.playlist_store)
+        self.playlist_tree.set_headers_visible(True)
 
         toggle = Gtk.CellRendererToggle()
         toggle.connect('toggled', self.on_playlist_toggled)
         toggle_column = Gtk.TreeViewColumn('', toggle, active=0)
-        self.tree.append_column(toggle_column)
+        self.playlist_tree.append_column(toggle_column)
 
         text = Gtk.CellRendererText()
         name_column = Gtk.TreeViewColumn(_('Playlist'), text, text=1)
         name_column.set_expand(True)
-        self.tree.append_column(name_column)
+        self.playlist_tree.append_column(name_column)
 
         scroller = Gtk.ScrolledWindow()
         scroller.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scroller.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
-        scroller.add(self.tree)
-        content.pack_start(scroller, True, True, 6)
+        scroller.add(self.playlist_tree)
+        self.playlist_page.pack_start(scroller, True, True, 6)
+
+        tag_label = Gtk.Label(
+            label=_('Select GroupTagger tags to include in the prediction model.')
+        )
+        tag_label.set_xalign(0)
+        self.tag_page.pack_start(tag_label, False, False, 0)
+
+        tag_buttons = Gtk.Box(spacing=6)
+        select_all_tags = Gtk.Button(label=_('Select All'))
+        select_all_tags.connect(
+            'clicked', lambda button: self.set_all_tags_selected(True)
+        )
+        tag_buttons.pack_start(select_all_tags, False, False, 0)
+        deselect_all_tags = Gtk.Button(label=_('Deselect All'))
+        deselect_all_tags.connect(
+            'clicked', lambda button: self.set_all_tags_selected(False)
+        )
+        tag_buttons.pack_start(deselect_all_tags, False, False, 0)
+        self.tag_page.pack_start(tag_buttons, False, False, 4)
+
+        self.tag_store = Gtk.ListStore(bool, str)
+        self.tag_tree = Gtk.TreeView(model=self.tag_store)
+        self.tag_tree.set_headers_visible(True)
+        tag_toggle = Gtk.CellRendererToggle()
+        tag_toggle.connect('toggled', self.on_tag_toggled)
+        self.tag_tree.append_column(
+            Gtk.TreeViewColumn('', tag_toggle, active=0)
+        )
+        tag_text = Gtk.CellRendererText()
+        tag_column = Gtk.TreeViewColumn(_('Tag'), tag_text, text=1)
+        tag_column.set_expand(True)
+        self.tag_tree.append_column(tag_column)
+
+        tag_scroller = Gtk.ScrolledWindow()
+        tag_scroller.set_policy(
+            Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC
+        )
+        tag_scroller.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
+        tag_scroller.add(self.tag_tree)
+        self.tag_page.pack_start(tag_scroller, True, True, 6)
 
         self.status = Gtk.Label()
         self.status.set_xalign(0)
@@ -882,11 +934,12 @@ class TrainingDialog(Gtk.Dialog):
 
         self.populate_playlists()
         self.show_all()
+        self.show_playlist_page()
 
     def populate_playlists(self):
         manager = self.plugin.exaile.playlists
         for name in sorted(manager.list_playlists()):
-            self.store.append(
+            self.playlist_store.append(
                 (
                     name in self.selected_playlist_names,
                     name,
@@ -895,50 +948,130 @@ class TrainingDialog(Gtk.Dialog):
             )
 
     def on_playlist_toggled(self, renderer, path):
-        self.store[path][0] = not self.store[path][0]
+        self.playlist_store[path][0] = not self.playlist_store[path][0]
 
     def on_select_all_clicked(self, button):
-        for row in self.store:
+        for row in self.playlist_store:
             row[0] = True
 
     def get_selected_playlists(self):
-        return [row[2] for row in self.store if row[0]]
+        return [row[2] for row in self.playlist_store if row[0]]
 
     def get_selected_playlist_names(self):
-        return [row[1] for row in self.store if row[0]]
+        return [row[1] for row in self.playlist_store if row[0]]
+
+    def show_playlist_page(self):
+        self.page = 'playlists'
+        self.status.set_text('')
+        self.tag_page.hide()
+        self.playlist_page.show_all()
+        self.back_button.hide()
+        self.primary_button.set_label(_('Next'))
+
+    def show_tag_page(self):
+        playlists = self.get_selected_playlists()
+        if not playlists:
+            self.status.set_text(_('Select at least one playlist.'))
+            return False
+
+        try:
+            tags = predictor_model.get_playlist_tags(
+                playlists, self.plugin.get_track_groups
+            )
+        except Exception as exc:
+            dialogs.error(self, _('Could not read playlist tags: %s') % exc)
+            return False
+
+        excluded_tags = set(
+            settings.get_option(predictor_preferences.EXCLUDED_TAGS_OPTION, [])
+        )
+        self.tag_store.clear()
+        for tag in sorted(tags, key=str.casefold):
+            self.tag_store.append((tag not in excluded_tags, tag))
+
+        self.page = 'tags'
+        self.status.set_text(
+            ''
+            if tags
+            else _('No GroupTagger tags found; the model will use BPM only.')
+        )
+        self.playlist_page.hide()
+        self.tag_page.show_all()
+        self.back_button.show()
+        self.primary_button.set_label(self.action)
+        return True
+
+    def on_tag_toggled(self, renderer, path):
+        row = self.tag_store[path]
+        row[0] = not row[0]
+        self.remember_tag_selection(row[1], row[0])
+
+    def set_all_tags_selected(self, selected):
+        excluded_tags = set(
+            settings.get_option(predictor_preferences.EXCLUDED_TAGS_OPTION, [])
+        )
+        for row in self.tag_store:
+            row[0] = selected
+            if selected:
+                excluded_tags.discard(row[1])
+            else:
+                excluded_tags.add(row[1])
+        settings.set_option(
+            predictor_preferences.EXCLUDED_TAGS_OPTION, sorted(excluded_tags)
+        )
+
+    def remember_tag_selection(self, tag, selected):
+        excluded_tags = set(
+            settings.get_option(predictor_preferences.EXCLUDED_TAGS_OPTION, [])
+        )
+        if selected:
+            excluded_tags.discard(tag)
+        else:
+            excluded_tags.add(tag)
+        settings.set_option(
+            predictor_preferences.EXCLUDED_TAGS_OPTION, sorted(excluded_tags)
+        )
+
+    def get_selected_tags(self):
+        return [row[1] for row in self.tag_store if row[0]]
 
     def on_response(self, dialog, response):
-        if response == Gtk.ResponseType.OK:
-            playlists = self.get_selected_playlists()
-            if not playlists:
-                self.status.set_text(_('Select at least one playlist.'))
-                return
+        if response == Gtk.ResponseType.APPLY and self.page == 'tags':
+            self.show_playlist_page()
+            return
+        if response != Gtk.ResponseType.OK:
+            self.destroy()
+            return
+        if self.page == 'playlists':
+            self.show_tag_page()
+            return
 
-            try:
-                trained_model = self.plugin.create_model_from_playlists(
-                    self.model_name,
-                    playlists,
-                    self.get_selected_playlist_names(),
-                    replace=self.replace,
-                )
-            except Exception as exc:
-                dialogs.error(self, _("Could not create suggestions model: %s") % exc)
-                return
-
-            dialogs.info(
-                self,
-                _(
-                    "%(action)s model from %(playlists)d playlist(s) and "
-                    "%(tracks)d track(s)."
-                )
-                % {
-                    'action': _('Rebuilt') if self.replace else _('Created'),
-                    'playlists': trained_model.get('playlist_count', 0),
-                    'tracks': trained_model.get('track_count', 0),
-                },
+        try:
+            trained_model = self.plugin.create_model_from_playlists(
+                self.model_name,
+                self.get_selected_playlists(),
+                self.get_selected_playlist_names(),
+                self.get_selected_tags(),
+                replace=self.replace,
             )
-            if self.plugin.model_manager_dialog is not None:
-                self.plugin.model_manager_dialog.refresh(self.model_name)
+        except Exception as exc:
+            dialogs.error(self, _("Could not create suggestions model: %s") % exc)
+            return
+
+        dialogs.info(
+            self,
+            _(
+                "%(action)s model from %(playlists)d playlist(s) and "
+                "%(tracks)d track(s)."
+            )
+            % {
+                'action': _('Rebuilt') if self.replace else _('Created'),
+                'playlists': trained_model.get('playlist_count', 0),
+                'tracks': trained_model.get('track_count', 0),
+            },
+        )
+        if self.plugin.model_manager_dialog is not None:
+            self.plugin.model_manager_dialog.refresh(self.model_name)
 
         self.destroy()
 

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -241,65 +241,110 @@ class QueueTrackPredictorPlugin:
     def create_model_from_playlists(
         self, name, playlists, playlist_names, included_tags, replace=False
     ):
-        existing_biases = {}
-        existing_bpm_bias = predictor_model.DEFAULT_BPM_BIAS
-        if replace:
-            try:
-                existing_model = self.load_model(name)
-                existing_biases = existing_model.get('tag_biases', {})
-                existing_bpm_bias = existing_model.get(
-                    'bpm_bias', predictor_model.DEFAULT_BPM_BIAS
-                )
-            except (IOError, KeyError, ValueError):
-                pass
         model = predictor_model.build_model(
             playlists, self.get_track_groups, included_tags=included_tags
         )
         model['playlist_names'] = sorted(playlist_names)
-        included_tag_set = (
-            None if included_tags is None else set(included_tags)
-        )
-        model['tag_biases'] = {
-            tag: bias
-            for tag, bias in existing_biases.items()
-            if (included_tag_set is None or tag in included_tag_set)
-            and bias in predictor_model.TAG_BIAS_FACTORS
-        }
-        model['bpm_bias'] = predictor_model.clamp_bpm_bias(existing_bpm_bias)
         catalog = self.load_model_catalog()
         if replace:
             model_store.replace_model(catalog, name, model)
         else:
             model_store.add_model(catalog, name, model)
         self.save_model_catalog(catalog)
+        if not replace:
+            self.set_last_model_name(name)
         return model
 
+    def _get_model_tuning_settings(self):
+        tuning = settings.get_option(
+            predictor_preferences.MODEL_TUNING_OPTION, {}
+        )
+        return tuning if isinstance(tuning, dict) else {}
+
+    def get_model_tuning(self, model_name, model=None, all_tuning=None):
+        model = model or self.load_model(model_name)
+        all_tuning = (
+            self._get_model_tuning_settings()
+            if all_tuning is None
+            else all_tuning
+        )
+        tuning = all_tuning.get(model_name, {})
+        return predictor_model.normalize_model_tuning(model, tuning)
+
+    def _set_model_tuning(self, model_name, tag_biases=None, bpm_bias=None):
+        model = self.load_model(model_name)
+        all_tuning = dict(self._get_model_tuning_settings())
+        tuning = self.get_model_tuning(model_name, model, all_tuning)
+        if tag_biases is not None:
+            tuning['tag_biases'] = tag_biases
+        if bpm_bias is not None:
+            tuning['bpm_bias'] = predictor_model.clamp_bpm_bias(bpm_bias)
+        tuning = self.get_model_tuning(
+            model_name, model, {model_name: tuning}
+        )
+        if tuning['tag_biases'] or tuning['bpm_bias'] != 0:
+            all_tuning[model_name] = tuning
+        else:
+            all_tuning.pop(model_name, None)
+        settings.set_option(
+            predictor_preferences.MODEL_TUNING_OPTION, all_tuning
+        )
+
     def set_model_tag_biases(self, model_name, tag_biases):
-        catalog = self.load_model_catalog()
-        model = catalog['models'][model_name]
-        included_tags = model.get('included_tags')
-        model['tag_biases'] = {
-            tag: int(bias)
-            for tag, bias in tag_biases.items()
-            if bias in predictor_model.TAG_BIAS_FACTORS
-            and bias != 0
-            and (included_tags is None or tag in included_tags)
-        }
-        self.save_model_catalog(catalog)
+        self._set_model_tuning(model_name, tag_biases=tag_biases)
 
     def set_model_bpm_bias(self, model_name, bpm_bias):
-        catalog = self.load_model_catalog()
-        catalog['models'][model_name]['bpm_bias'] = (
-            predictor_model.clamp_bpm_bias(bpm_bias)
+        self._set_model_tuning(model_name, bpm_bias=bpm_bias)
+
+    def get_default_model_name(self, catalog=None):
+        catalog = catalog or self.load_model_catalog()
+        model_name = settings.get_option(
+            predictor_preferences.LAST_MODEL_OPTION, ''
         )
-        self.save_model_catalog(catalog)
+        if model_name in catalog['models']:
+            return model_name
+        selected = catalog.get('selected')
+        if selected in catalog['models']:
+            return selected
+        return next(iter(model_store.model_names(catalog)), None)
+
+    def set_last_model_name(self, model_name):
+        settings.set_option(predictor_preferences.LAST_MODEL_OPTION, model_name)
+
+    def rename_model_settings(self, old_name, new_name):
+        all_tuning = dict(self._get_model_tuning_settings())
+        if old_name in all_tuning:
+            all_tuning[new_name] = all_tuning.pop(old_name)
+            settings.set_option(
+                predictor_preferences.MODEL_TUNING_OPTION, all_tuning
+            )
+        if (
+            settings.get_option(predictor_preferences.LAST_MODEL_OPTION, '')
+            == old_name
+        ):
+            self.set_last_model_name(new_name)
+
+    def remove_model_settings(self, model_name, catalog):
+        all_tuning = dict(self._get_model_tuning_settings())
+        if model_name in all_tuning:
+            del all_tuning[model_name]
+            settings.set_option(
+                predictor_preferences.MODEL_TUNING_OPTION, all_tuning
+            )
+        if (
+            settings.get_option(predictor_preferences.LAST_MODEL_OPTION, '')
+            == model_name
+        ):
+            self.set_last_model_name(
+                self.get_default_model_name(catalog) or ''
+            )
 
     def load_model(self, model_name=None):
         return self.load_model_entry(model_name)[1]
 
     def load_model_entry(self, model_name=None):
         catalog = self.load_model_catalog()
-        model_name = model_name or catalog.get('selected')
+        model_name = model_name or self.get_default_model_name(catalog)
         if model_name is None:
             raise IOError('No prediction model is selected')
         try:
@@ -308,11 +353,12 @@ class QueueTrackPredictorPlugin:
             raise ValueError('Prediction model “%s” does not exist' % model_name)
 
     def remember_used_model(self, model_name):
-        catalog = self.load_model_catalog()
-        if catalog.get('selected') == model_name:
+        if (
+            settings.get_option(predictor_preferences.LAST_MODEL_OPTION, '')
+            == model_name
+        ):
             return
-        model_store.select_model(catalog, model_name)
-        self.save_model_catalog(catalog)
+        self.set_last_model_name(model_name)
 
     def suggest_next_track(self, parent_window=None):
         parent_window = parent_window or self._get_parent_window()
@@ -354,6 +400,7 @@ class QueueTrackPredictorPlugin:
                 predictor_preferences.DEFAULT_DIVERSITY,
             )
         )
+        model_tuning = self._get_model_tuning_settings()
         self.suggestion_generation += 1
         generation = self.suggestion_generation
         if self.suggestion_future is not None:
@@ -365,6 +412,7 @@ class QueueTrackPredictorPlugin:
             excluded_locations,
             max_suggestions,
             diversity,
+            model_tuning,
             parent_window,
             model_name,
         )
@@ -376,6 +424,7 @@ class QueueTrackPredictorPlugin:
         excluded_locations,
         max_suggestions,
         diversity,
+        model_tuning,
         parent_window,
         model_name,
     ):
@@ -401,18 +450,24 @@ class QueueTrackPredictorPlugin:
             return
 
         try:
+            runtime_model = dict(trained_model)
+            runtime_model.update(
+                self.get_model_tuning(
+                    model_name, trained_model, model_tuning
+                )
+            )
             candidate_tracks = self.exaile.collection.get_tracks()
             candidate_features = predictor_model.make_candidate_features(
                 candidate_tracks,
                 self.get_track_groups,
-                trained_model.get(
+                runtime_model.get(
                     'bpm_band_size', predictor_model.DEFAULT_BPM_BAND_SIZE
                 ),
-                trained_model.get('included_tags'),
+                runtime_model.get('included_tags'),
             )
             candidate_limit = max_suggestions * CANDIDATE_POOL_MULTIPLIER
             scored_locations = predictor_model.get_scored_suggestion_locations(
-                trained_model,
+                runtime_model,
                 previous_tracks,
                 self.get_track_groups,
                 max_suggestions=candidate_limit,
@@ -420,7 +475,7 @@ class QueueTrackPredictorPlugin:
                 candidate_features=candidate_features,
             )
             scored_locations = predictor_model.rerank_suggestions_for_diversity(
-                trained_model,
+                runtime_model,
                 scored_locations,
                 previous_tracks[-RECENT_TRACK_COUNT:],
                 self.get_track_groups,
@@ -944,9 +999,8 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
             self.view.grab_focus()
 
     def _populate_tag_tuning(self, model):
-        bpm_bias = predictor_model.clamp_bpm_bias(
-            model.get('bpm_bias', predictor_model.DEFAULT_BPM_BIAS)
-        )
+        tuning = self.plugin.get_model_tuning(self.model_name, model)
+        bpm_bias = tuning['bpm_bias']
         self.bpm_bias_scale.handler_block(self.bpm_bias_changed_id)
         self.bpm_bias_scale.set_value(bpm_bias)
         self.bpm_bias_scale.handler_unblock(self.bpm_bias_changed_id)
@@ -961,7 +1015,7 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
             included_tags = set(included_tags)
         self.tag_biases = {
             tag: int(bias)
-            for tag, bias in model.get('tag_biases', {}).items()
+            for tag, bias in tuning['tag_biases'].items()
             if tag in included_tags
             and bias in predictor_model.TAG_BIAS_FACTORS
             and bias != 0
@@ -1300,7 +1354,7 @@ class ModelManagerDialog(Gtk.Dialog):
 
     def refresh(self, select_name=None):
         catalog = self.plugin.load_model_catalog()
-        selected_name = catalog.get('selected')
+        selected_name = self.plugin.get_default_model_name(catalog)
         self.store.clear()
         path_to_select = None
         for name in model_store.model_names(catalog):
@@ -1370,6 +1424,7 @@ class ModelManagerDialog(Gtk.Dialog):
             dialogs.error(self, str(exc))
             return
         self.plugin.save_model_catalog(catalog)
+        self.plugin.rename_model_settings(old_name, new_name)
         self.refresh(new_name)
 
     def on_remove_clicked(self, button):
@@ -1384,15 +1439,14 @@ class ModelManagerDialog(Gtk.Dialog):
         catalog = self.plugin.load_model_catalog()
         model_store.remove_model(catalog, name)
         self.plugin.save_model_catalog(catalog)
+        self.plugin.remove_model_settings(name, catalog)
         self.refresh()
 
     def on_select_clicked(self, button):
         name = self.get_selected_name()
         if name is None:
             return
-        catalog = self.plugin.load_model_catalog()
-        model_store.select_model(catalog, name)
-        self.plugin.save_model_catalog(catalog)
+        self.plugin.set_last_model_name(name)
         self.refresh(name)
 
     def on_row_activated(self, tree, path, column):

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -13,6 +13,7 @@ from xl import player, providers, settings, xdg
 from xl.playlist import Playlist
 from xl.nls import gettext as _, ngettext
 from xlgui import guiutil, main
+from xlgui.accelerators import Accelerator
 from xlgui.widgets import dialogs, menu, notebook, playlist as playlist_widget
 
 from . import model as predictor_model
@@ -51,6 +52,7 @@ class QueueTrackPredictorPlugin:
         self.suggestion_generation = 0
         self.suggestion_executor = None
         self.suggestion_future = None
+        self.suggest_accelerator = None
         self.button_registered = False
 
     def enable(self, exaile):
@@ -75,8 +77,14 @@ class QueueTrackPredictorPlugin:
         self.playlist_menu_item.register('playlist-context-menu')
 
         SuggestNextTrackButton.plugin = self
-        providers.register('main-panel-actions', SuggestNextTrackButton)
+        providers.register('playlist-notebook-actions', SuggestNextTrackButton)
         self.button_registered = True
+        self.suggest_accelerator = Accelerator(
+            '<Primary><Shift>g',
+            _('Suggest Next Track'),
+            self.on_suggest_accelerator,
+        )
+        providers.register('mainwindow-accelerators', self.suggest_accelerator)
 
     def disable(self, exaile):
         self.suggestion_generation += 1
@@ -110,9 +118,16 @@ class QueueTrackPredictorPlugin:
             self.playlist_menu_item = None
 
         if self.button_registered:
-            providers.unregister('main-panel-actions', SuggestNextTrackButton)
+            providers.unregister(
+                'playlist-notebook-actions', SuggestNextTrackButton
+            )
             self.button_registered = False
             SuggestNextTrackButton.plugin = None
+        if self.suggest_accelerator is not None:
+            providers.unregister(
+                'mainwindow-accelerators', self.suggest_accelerator
+            )
+            self.suggest_accelerator = None
 
     def get_model_path(self):
         directory = os.path.join(xdg.get_plugin_data_dir(), MODEL_DIR)
@@ -179,8 +194,17 @@ class QueueTrackPredictorPlugin:
         if not selected_items:
             return
 
-        position, track = selected_items[0]
-        playlist = context['playlist']
+        position = selected_items[-1][0]
+        self.suggest_after_playlist_position(
+            context['playlist'],
+            position,
+            self._get_parent_window(parent),
+            model_name,
+        )
+
+    def suggest_after_playlist_position(
+        self, playlist, position, parent_window=None, model_name=None
+    ):
         start = max(0, position - (RECENT_TRACK_COUNT - 1))
         previous_tracks = [playlist[idx] for idx in range(start, position + 1)]
         excluded_locations = set()
@@ -188,10 +212,25 @@ class QueueTrackPredictorPlugin:
             excluded_locations.add(playlist[position + 1].get_loc_for_io())
         self.suggest_from_tracks(
             previous_tracks,
-            self._get_parent_window(parent),
+            parent_window or self._get_parent_window(),
             excluded_locations=excluded_locations,
             model_name=model_name,
         )
+
+    def suggest_from_current_page(self, page=None):
+        page = page or main.get_selected_page()
+        view = getattr(page, 'view', None)
+        playlist = getattr(page, 'playlist', None)
+        selected_items = view.get_selected_items() if view is not None else []
+        if playlist is not None and selected_items:
+            position = selected_items[-1][0]
+            self.suggest_after_playlist_position(playlist, position)
+            return
+        self.suggest_next_track()
+
+    def on_suggest_accelerator(self, *args):
+        self.suggest_from_current_page()
+        return True
 
     def load_model_catalog(self):
         return model_store.load_catalog(self.get_model_path())
@@ -267,6 +306,13 @@ class QueueTrackPredictorPlugin:
             return model_name, catalog['models'][model_name]
         except KeyError:
             raise ValueError('Prediction model “%s” does not exist' % model_name)
+
+    def remember_used_model(self, model_name):
+        catalog = self.load_model_catalog()
+        if catalog.get('selected') == model_name:
+            return
+        model_store.select_model(catalog, model_name)
+        self.save_model_catalog(catalog)
 
     def suggest_next_track(self, parent_window=None):
         parent_window = parent_window or self._get_parent_window()
@@ -423,6 +469,13 @@ class QueueTrackPredictorPlugin:
         if generation != self.suggestion_generation:
             return False
         self.suggestion_future = None
+        try:
+            self.remember_used_model(model_name)
+        except Exception as exc:
+            dialogs.error(
+                parent_window,
+                _('Could not remember the last suggestion model: %s') % exc,
+            )
         if not scored_tracks:
             dialogs.info(parent_window, _("No suggestions found for the queue tail."))
             return False
@@ -546,20 +599,38 @@ class SuggestNextTrackButton(Gtk.Button, notebook.NotebookAction):
     name = 'queue-track-predictor'
     position = Gtk.PackType.END
 
-    def __init__(self, panel_notebook):
+    def __init__(self, playlist_notebook):
         Gtk.Button.__init__(self)
-        notebook.NotebookAction.__init__(self, panel_notebook)
+        notebook.NotebookAction.__init__(self, playlist_notebook)
 
         self.set_image(Gtk.Image.new_from_icon_name('list-add', Gtk.IconSize.BUTTON))
-        self.set_tooltip_text(_('Suggest Next Track'))
+        self.set_has_tooltip(True)
         self.set_focus_on_click(False)
         self.set_relief(Gtk.ReliefStyle.NONE)
         self.connect('clicked', self.on_clicked)
+        self.connect('query-tooltip', self.on_query_tooltip)
         self.show_all()
 
     def on_clicked(self, button):
         if self.plugin is not None:
-            self.plugin.suggest_next_track()
+            self.plugin.suggest_from_current_page(self.notebook.get_current_tab())
+
+    def on_query_tooltip(self, widget, x, y, keyboard_mode, tooltip):
+        page = self.notebook.get_current_tab()
+        view = getattr(page, 'view', None)
+        count = view.get_selection_count() if view is not None else 0
+        shortcut = Gtk.accelerator_get_label(
+            self.plugin.suggest_accelerator.key,
+            self.plugin.suggest_accelerator.mods,
+        )
+        if count == 1:
+            text = _('Suggest after selected track (%s)') % shortcut
+        elif count > 1:
+            text = _('Suggest after last selected track (%s)') % shortcut
+        else:
+            text = _('Suggest from queue (%s)') % shortcut
+        tooltip.set_text(text)
+        return True
 
 
 class SuggestionsPlaylist(Playlist):

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -6,7 +6,8 @@
 # (at your option) any later version.
 
 import os
-from gi.repository import Gtk
+from concurrent.futures import ThreadPoolExecutor
+from gi.repository import GLib, Gtk
 
 from xl import player, providers, settings, xdg
 from xl.playlist import Playlist
@@ -21,6 +22,9 @@ from . import preferences as predictor_preferences
 
 MODEL_DIR = 'queuetrackpredictor'
 MODEL_FILE = 'models.pickle'
+RECENT_TRACK_COUNT = 15
+CANDIDATE_POOL_MULTIPLIER = 5
+DIVERSITY_REBUILD_DELAY_MS = 200
 
 
 class QueueTrackPredictorPlugin:
@@ -33,10 +37,17 @@ class QueueTrackPredictorPlugin:
         self.suggestions_playlist = None
         self.suggestions_page = None
         self.suggestions_tab = None
+        self.suggestion_request = None
+        self.suggestion_generation = 0
+        self.suggestion_executor = None
+        self.suggestion_future = None
         self.button_registered = False
 
     def enable(self, exaile):
         self.exaile = exaile
+        self.suggestion_executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix='track-predictor'
+        )
 
     def get_preferences_pane(self):
         return predictor_preferences
@@ -65,6 +76,13 @@ class QueueTrackPredictorPlugin:
         self.button_registered = True
 
     def disable(self, exaile):
+        self.suggestion_generation += 1
+        if self.suggestion_future is not None:
+            self.suggestion_future.cancel()
+            self.suggestion_future = None
+        if self.suggestion_executor is not None:
+            self.suggestion_executor.shutdown(wait=False)
+            self.suggestion_executor = None
         if self.train_dialog is not None:
             self.train_dialog.destroy()
             self.train_dialog = None
@@ -137,7 +155,7 @@ class QueueTrackPredictorPlugin:
 
         position, track = selected_items[0]
         playlist = context['playlist']
-        start = max(0, position - 2)
+        start = max(0, position - (RECENT_TRACK_COUNT - 1))
         previous_tracks = [playlist[idx] for idx in range(start, position + 1)]
         excluded_locations = set()
         if position + 1 < len(playlist):
@@ -180,62 +198,149 @@ class QueueTrackPredictorPlugin:
         if len(queue_tracks) < 1:
             dialogs.info(parent_window, _("At least one track must be in the queue."))
             return
-        self.suggest_from_tracks(queue_tracks[-3:], parent_window)
+        self.suggest_from_tracks(queue_tracks[-RECENT_TRACK_COUNT:], parent_window)
 
     def suggest_from_tracks(
         self, previous_tracks, parent_window=None, excluded_locations=None
     ):
         parent_window = parent_window or self._get_parent_window()
-        try:
-            trained_model = self.load_model()
-        except IOError:
-            dialogs.info(parent_window, _("Create a track suggestions model first."))
-            return
-        except Exception as exc:
-            dialogs.error(parent_window, _("Could not load suggestions model: %s") % exc)
-            return
-
+        previous_tracks = list(previous_tracks)
+        excluded_locations = set(excluded_locations or [])
         if len(previous_tracks) < 1:
             dialogs.info(parent_window, _("At least one track is required for suggestions."))
             return
 
-        try:
-            max_suggestions = int(
-                settings.get_option(
-                    predictor_preferences.MAX_SUGGESTIONS_OPTION,
-                    predictor_preferences.DEFAULT_MAX_SUGGESTIONS,
-                )
+        self.suggestion_request = (
+            previous_tracks,
+            parent_window,
+            excluded_locations,
+        )
+        max_suggestions = int(
+            settings.get_option(
+                predictor_preferences.MAX_SUGGESTIONS_OPTION,
+                predictor_preferences.DEFAULT_MAX_SUGGESTIONS,
             )
-            scored_locations = predictor_model.get_scored_suggestion_locations(
-                trained_model,
-                previous_tracks[-3:],
-                self.get_track_groups,
-                max_suggestions=max_suggestions,
-                excluded_locations=excluded_locations,
+        )
+        diversity = int(
+            settings.get_option(
+                predictor_preferences.DIVERSITY_OPTION,
+                predictor_preferences.DEFAULT_DIVERSITY,
             )
-        except Exception as exc:
-            dialogs.error(parent_window, _("Could not create suggestions: %s") % exc)
-            return
-
-        scored_tracks = predictor_model.resolve_scored_suggestion_tracks(
-            self.exaile.collection,
-            scored_locations,
-            max_suggestions=max_suggestions,
+        )
+        self.suggestion_generation += 1
+        generation = self.suggestion_generation
+        if self.suggestion_future is not None:
+            self.suggestion_future.cancel()
+        self.suggestion_future = self.suggestion_executor.submit(
+            self._compute_suggestions,
+            generation,
+            previous_tracks,
+            excluded_locations,
+            max_suggestions,
+            diversity,
+            parent_window,
         )
 
-        if not scored_tracks:
-            dialogs.info(parent_window, _("No suggestions found for the queue tail."))
+    def _compute_suggestions(
+        self,
+        generation,
+        previous_tracks,
+        excluded_locations,
+        max_suggestions,
+        diversity,
+        parent_window,
+    ):
+        try:
+            trained_model = self.load_model()
+        except IOError:
+            GLib.idle_add(
+                self._show_suggestion_message,
+                generation,
+                parent_window,
+                False,
+                _("Create a track suggestions model first."),
+            )
+            return
+        except Exception as exc:
+            GLib.idle_add(
+                self._show_suggestion_message,
+                generation,
+                parent_window,
+                True,
+                _("Could not load suggestions model: %s") % exc,
+            )
             return
 
-        self.show_suggestions_playlist(scored_tracks)
+        try:
+            candidate_limit = max_suggestions * CANDIDATE_POOL_MULTIPLIER
+            scored_locations = predictor_model.get_scored_suggestion_locations(
+                trained_model,
+                previous_tracks,
+                self.get_track_groups,
+                max_suggestions=candidate_limit,
+                excluded_locations=excluded_locations,
+            )
+            scored_locations = predictor_model.rerank_suggestions_for_diversity(
+                trained_model,
+                scored_locations,
+                previous_tracks[-RECENT_TRACK_COUNT:],
+                self.get_track_groups,
+                max_suggestions=max_suggestions,
+                diversity=diversity,
+            )
+            scored_tracks = predictor_model.resolve_scored_suggestion_tracks(
+                self.exaile.collection,
+                scored_locations,
+                max_suggestions=max_suggestions,
+            )
+        except Exception as exc:
+            GLib.idle_add(
+                self._show_suggestion_message,
+                generation,
+                parent_window,
+                True,
+                _("Could not create suggestions: %s") % exc,
+            )
+            return
 
-    def show_suggestions_playlist(self, scored_tracks):
+        GLib.idle_add(
+            self._apply_suggestion_result,
+            generation,
+            parent_window,
+            scored_tracks,
+            diversity,
+        )
+
+    def _show_suggestion_message(
+        self, generation, parent_window, is_error, message
+    ):
+        if generation != self.suggestion_generation:
+            return False
+        if is_error:
+            dialogs.error(parent_window, message)
+        else:
+            dialogs.info(parent_window, message)
+        return False
+
+    def _apply_suggestion_result(
+        self, generation, parent_window, scored_tracks, diversity
+    ):
+        if generation != self.suggestion_generation:
+            return False
+        self.suggestion_future = None
+        if not scored_tracks:
+            dialogs.info(parent_window, _("No suggestions found for the queue tail."))
+            return False
+        self.show_suggestions_playlist(scored_tracks, diversity)
+        return False
+
+    def show_suggestions_playlist(self, scored_tracks, diversity):
         playlist_notebook = self._get_suggestions_notebook()
         if playlist_notebook is None:
             playlist_notebook = main.get_playlist_notebook()
             self.suggestions_playlist = SuggestionsPlaylist(scored_tracks)
             self.suggestions_page = SuggestionsPlaylistPage(
-                self.suggestions_playlist, player.PLAYER
+                self, self.suggestions_playlist, player.PLAYER, diversity
             )
             self.suggestions_page.connect(
                 'destroy', self.on_suggestions_page_destroyed
@@ -248,10 +353,18 @@ class QueueTrackPredictorPlugin:
             )
         else:
             self.suggestions_playlist.replace_tracks(scored_tracks)
+            self.suggestions_page.set_diversity(diversity)
             playlist_notebook.set_current_page(
                 playlist_notebook.page_num(self.suggestions_page)
             )
             self.suggestions_page.focus()
+
+    def set_suggestion_diversity(self, diversity):
+        settings.set_option(
+            predictor_preferences.DIVERSITY_OPTION, int(round(diversity))
+        )
+        if self.suggestion_request is not None:
+            self.suggest_from_tracks(*self.suggestion_request)
 
     def _get_suggestions_notebook(self):
         if self.suggestions_tab is None or self.suggestions_page is None:
@@ -382,10 +495,12 @@ class SuggestionsPlaylistView(playlist_widget.PlaylistView):
 class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
     reorderable = False
 
-    def __init__(self, suggestions_playlist, playlist_player):
+    def __init__(self, plugin, suggestions_playlist, playlist_player, diversity):
         playlist_widget.PlaylistPageBase.__init__(
             self, suggestions_playlist, playlist_player
         )
+        self.plugin = plugin
+        self.diversity_rebuild_source = None
         self.swindow = Gtk.ScrolledWindow()
         self.swindow.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         self.view = SuggestionsPlaylistView(
@@ -394,6 +509,22 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         self.view.drag_dest_unset()
         self.swindow.add(self.view)
         self.pack_start(self.swindow, True, True, 0)
+
+        diversity_box = Gtk.Box(spacing=8)
+        diversity_box.set_border_width(6)
+        diversity_label = Gtk.Label(label=_('Diversity:'))
+        diversity_box.pack_start(diversity_label, False, False, 0)
+        self.diversity_scale = Gtk.Scale.new_with_range(
+            Gtk.Orientation.HORIZONTAL, 0, 100, 5
+        )
+        self.diversity_scale.set_hexpand(True)
+        self.diversity_scale.set_digits(0)
+        self.diversity_scale.add_mark(0, Gtk.PositionType.BOTTOM, _('Prediction'))
+        self.diversity_scale.add_mark(100, Gtk.PositionType.BOTTOM, _('Diverse'))
+        self.diversity_scale.set_value(diversity)
+        self.diversity_scale.connect('value-changed', self.on_diversity_changed)
+        diversity_box.pack_start(self.diversity_scale, True, True, 0)
+        self.pack_start(diversity_box, False, False, 0)
         self.show_all()
 
     def focus(self):
@@ -401,6 +532,28 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
 
     def get_page_name(self):
         return _('Track Suggestions')
+
+    def set_diversity(self, diversity):
+        if int(round(self.diversity_scale.get_value())) != int(round(diversity)):
+            self.diversity_scale.set_value(diversity)
+
+    def on_diversity_changed(self, scale):
+        if self.diversity_rebuild_source is not None:
+            GLib.source_remove(self.diversity_rebuild_source)
+        self.diversity_rebuild_source = GLib.timeout_add(
+            DIVERSITY_REBUILD_DELAY_MS, self.regenerate_suggestions
+        )
+
+    def regenerate_suggestions(self):
+        self.diversity_rebuild_source = None
+        self.plugin.set_suggestion_diversity(self.diversity_scale.get_value())
+        return False
+
+    def do_destroy(self):
+        if self.diversity_rebuild_source is not None:
+            GLib.source_remove(self.diversity_rebuild_source)
+            self.diversity_rebuild_source = None
+        playlist_widget.PlaylistPageBase.do_destroy(self)
 
 
 class ModelManagerDialog(Gtk.Dialog):

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -196,7 +196,7 @@ class QueueTrackPredictorPlugin:
             return
 
         try:
-            locations = predictor_model.get_suggestion_locations(
+            scored_locations = predictor_model.get_scored_suggestion_locations(
                 trained_model,
                 previous_tracks[-3:],
                 self.get_track_groups,
@@ -206,21 +206,21 @@ class QueueTrackPredictorPlugin:
             dialogs.error(parent_window, _("Could not create suggestions: %s") % exc)
             return
 
-        tracks = predictor_model.resolve_suggestion_tracks(
-            self.exaile.collection, locations
+        scored_tracks = predictor_model.resolve_scored_suggestion_tracks(
+            self.exaile.collection, scored_locations
         )
 
-        if not tracks:
+        if not scored_tracks:
             dialogs.info(parent_window, _("No suggestions found for the queue tail."))
             return
 
-        self.show_suggestions_playlist(tracks)
+        self.show_suggestions_playlist(scored_tracks)
 
-    def show_suggestions_playlist(self, tracks):
+    def show_suggestions_playlist(self, scored_tracks):
         playlist_notebook = self._get_suggestions_notebook()
         if playlist_notebook is None:
             playlist_notebook = main.get_playlist_notebook()
-            self.suggestions_playlist = SuggestionsPlaylist(tracks)
+            self.suggestions_playlist = SuggestionsPlaylist(scored_tracks)
             self.suggestions_page = SuggestionsPlaylistPage(
                 self.suggestions_playlist, player.PLAYER
             )
@@ -234,7 +234,7 @@ class QueueTrackPredictorPlugin:
                 self.suggestions_tab, self.suggestions_page
             )
         else:
-            self.suggestions_playlist.replace_tracks(tracks)
+            self.suggestions_playlist.replace_tracks(scored_tracks)
             playlist_notebook.set_current_page(
                 playlist_notebook.page_num(self.suggestions_page)
             )
@@ -283,11 +283,24 @@ class SuggestNextTrackButton(Gtk.Button, notebook.NotebookAction):
 
 
 class SuggestionsPlaylist(Playlist):
-    def __init__(self, tracks):
-        Playlist.__init__(self, _('Track Suggestions'), list(tracks))
+    def __init__(self, scored_tracks):
+        self.scores = {}
+        tracks = self._set_scores(scored_tracks)
+        Playlist.__init__(self, _('Track Suggestions'), tracks)
 
-    def replace_tracks(self, tracks):
-        Playlist.__setitem__(self, slice(None, None, None), list(tracks))
+    def replace_tracks(self, scored_tracks):
+        tracks = self._set_scores(scored_tracks)
+        Playlist.__setitem__(self, slice(None, None, None), tracks)
+
+    def _set_scores(self, scored_tracks):
+        scored_tracks = list(scored_tracks)
+        self.scores = {
+            track.get_loc_for_io(): score for track, score in scored_tracks
+        }
+        return [track for track, score in scored_tracks]
+
+    def get_score(self, track):
+        return self.scores.get(track.get_loc_for_io())
 
     # The plugin can replace the result set, but user-facing playlist
     # operations must not mutate it.
@@ -322,6 +335,37 @@ class SuggestionsPlaylist(Playlist):
         pass
 
 
+class SuggestionsPlaylistView(playlist_widget.PlaylistView):
+    def _setup_columns(self):
+        playlist_widget.PlaylistView._setup_columns(self)
+        score_renderer = Gtk.CellRendererText()
+        score_renderer.set_property('xalign', 1.0)
+        score_column = Gtk.TreeViewColumn(_('Score'), score_renderer)
+        score_column.name = '__queue_predictor_score'
+        score_column.set_cell_data_func(score_renderer, self.render_score)
+        score_column.set_clickable(False)
+        score_column.set_resizable(True)
+        score_column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
+        score_column.set_fixed_width(70)
+        score_column.set_alignment(1.0)
+        self.score_column = score_column
+        self.insert_column(score_column, 1)
+
+    def on_columns_changed(self, widget):
+        columns = [
+            column.name
+            for column in self.get_columns()[1:]
+            if column is not self.score_column
+        ]
+        if columns != settings.get_option('gui/columns', []):
+            settings.set_option('gui/columns', columns)
+
+    def render_score(self, column, renderer, tree_model, tree_iter, data=None):
+        track = tree_model.get_value(tree_iter, 0)
+        score = self.playlist.get_score(track)
+        renderer.set_property('text', '' if score is None else str(score))
+
+
 class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
     reorderable = False
 
@@ -331,7 +375,7 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         )
         self.swindow = Gtk.ScrolledWindow()
         self.swindow.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-        self.view = playlist_widget.PlaylistView(
+        self.view = SuggestionsPlaylistView(
             suggestions_playlist, playlist_player
         )
         self.view.drag_dest_unset()

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -26,6 +26,7 @@ RECENT_TRACK_COUNT = 15
 CANDIDATE_POOL_MULTIPLIER = 5
 DIVERSITY_REBUILD_DELAY_MS = 200
 TAG_BIAS_REBUILD_DELAY_MS = 250
+BPM_BIAS_REBUILD_DELAY_MS = 250
 TAG_BIAS_LABELS = {
     -2: _('Strongly away'),
     -1: _('Away'),
@@ -202,9 +203,14 @@ class QueueTrackPredictorPlugin:
         self, name, playlists, playlist_names, included_tags, replace=False
     ):
         existing_biases = {}
+        existing_bpm_bias = predictor_model.DEFAULT_BPM_BIAS
         if replace:
             try:
-                existing_biases = self.load_model(name).get('tag_biases', {})
+                existing_model = self.load_model(name)
+                existing_biases = existing_model.get('tag_biases', {})
+                existing_bpm_bias = existing_model.get(
+                    'bpm_bias', predictor_model.DEFAULT_BPM_BIAS
+                )
             except (IOError, KeyError, ValueError):
                 pass
         model = predictor_model.build_model(
@@ -220,6 +226,7 @@ class QueueTrackPredictorPlugin:
             if (included_tag_set is None or tag in included_tag_set)
             and bias in predictor_model.TAG_BIAS_FACTORS
         }
+        model['bpm_bias'] = predictor_model.clamp_bpm_bias(existing_bpm_bias)
         catalog = self.load_model_catalog()
         if replace:
             model_store.replace_model(catalog, name, model)
@@ -239,6 +246,13 @@ class QueueTrackPredictorPlugin:
             and bias != 0
             and (included_tags is None or tag in included_tags)
         }
+        self.save_model_catalog(catalog)
+
+    def set_model_bpm_bias(self, model_name, bpm_bias):
+        catalog = self.load_model_catalog()
+        catalog['models'][model_name]['bpm_bias'] = (
+            predictor_model.clamp_bpm_bias(bpm_bias)
+        )
         self.save_model_catalog(catalog)
 
     def load_model(self, model_name=None):
@@ -655,6 +669,7 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         self.plugin = plugin
         self.diversity_rebuild_source = None
         self.tag_rebuild_source = None
+        self.bpm_rebuild_source = None
         self.model_name = None
         self.swindow = Gtk.ScrolledWindow()
         self.swindow.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
@@ -719,6 +734,38 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         self.diversity_scale.set_value(diversity)
         self.diversity_scale.connect('value-changed', self.on_diversity_changed)
         diversity_box.pack_start(self.diversity_scale, True, True, 0)
+        bpm_separator = Gtk.Separator(orientation=Gtk.Orientation.VERTICAL)
+        diversity_box.pack_start(bpm_separator, False, False, 0)
+        bpm_label = Gtk.Label(label=_('BPM bias:'))
+        diversity_box.pack_start(bpm_label, False, False, 0)
+        self.bpm_bias_scale = Gtk.Scale.new_with_range(
+            Gtk.Orientation.HORIZONTAL,
+            -predictor_model.BPM_BIAS_FULL_EFFECT_DELTA,
+            predictor_model.BPM_BIAS_FULL_EFFECT_DELTA,
+            5,
+        )
+        self.bpm_bias_scale.set_hexpand(True)
+        self.bpm_bias_scale.set_digits(0)
+        self.bpm_bias_scale.set_draw_value(True)
+        self.bpm_bias_scale.add_mark(
+            -predictor_model.BPM_BIAS_FULL_EFFECT_DELTA,
+            Gtk.PositionType.BOTTOM,
+            _('Slower'),
+        )
+        self.bpm_bias_scale.add_mark(0, Gtk.PositionType.BOTTOM, _('Neutral'))
+        self.bpm_bias_scale.add_mark(
+            predictor_model.BPM_BIAS_FULL_EFFECT_DELTA,
+            Gtk.PositionType.BOTTOM,
+            _('Faster'),
+        )
+        self.bpm_bias_scale.set_tooltip_text(
+            _('Favor tracks slower or faster than the latest track')
+        )
+        self.bpm_bias_changed_id = self.bpm_bias_scale.connect(
+            'value-changed', self.on_bpm_bias_changed
+        )
+        self.bpm_bias_scale.connect('format-value', self.format_bpm_bias_value)
+        diversity_box.pack_start(self.bpm_bias_scale, True, True, 0)
         diversity_box.pack_end(self.search_entry.entry, False, True, 0)
         self.pack_start(diversity_box, False, False, 0)
         self.set_model_name(model_name)
@@ -753,7 +800,7 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         self.tag_sort_choice.connect('changed', self.on_tag_sort_changed)
         tools.pack_start(self.tag_sort_choice, False, False, 0)
 
-        self.reset_all_tags_button = Gtk.Button(label=_('Reset All'))
+        self.reset_all_tags_button = Gtk.Button(label=_('Reset Tags'))
         self.reset_all_tags_button.connect('clicked', self.on_reset_all_tags)
         tools.pack_start(self.reset_all_tags_button, False, False, 0)
         panel.pack_start(tools, False, False, 0)
@@ -826,6 +873,12 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
             self.view.grab_focus()
 
     def _populate_tag_tuning(self, model):
+        bpm_bias = predictor_model.clamp_bpm_bias(
+            model.get('bpm_bias', predictor_model.DEFAULT_BPM_BIAS)
+        )
+        self.bpm_bias_scale.handler_block(self.bpm_bias_changed_id)
+        self.bpm_bias_scale.set_value(bpm_bias)
+        self.bpm_bias_scale.handler_unblock(self.bpm_bias_changed_id)
         included_tags = model.get('included_tags')
         if included_tags is None:
             included_tags = {
@@ -869,9 +922,7 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         self.tag_tuning_flow.invalidate_filter()
         self.tag_tuning_flow.invalidate_sort()
         has_tags = bool(self.tag_children)
-        if not has_tags and self.tuning_toggle.get_active():
-            self.tuning_toggle.set_active(False)
-        self.tuning_toggle.set_sensitive(has_tags)
+        self.tuning_toggle.set_sensitive(True)
         self.reset_all_tags_button.set_sensitive(bool(self.tag_biases))
         self.tag_selection_label.set_text(
             _('Select one or more tags.')
@@ -1013,6 +1064,38 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
             _('Tune Tags (%d)') % adjusted if adjusted else _('Tune Tags')
         )
 
+    def on_bpm_bias_changed(self, scale):
+        if self.bpm_rebuild_source is not None:
+            GLib.source_remove(self.bpm_rebuild_source)
+        self.bpm_rebuild_source = GLib.timeout_add(
+            BPM_BIAS_REBUILD_DELAY_MS, self.regenerate_bpm_suggestions
+        )
+
+    def format_bpm_bias_value(self, scale, value):
+        value = int(round(value))
+        if value < 0:
+            return _('%d BPM slower') % abs(value)
+        if value > 0:
+            return _('%d BPM faster') % value
+        return _('Neutral')
+
+    def regenerate_bpm_suggestions(self):
+        self.bpm_rebuild_source = None
+        try:
+            self.plugin.set_model_bpm_bias(
+                self.model_name, self.bpm_bias_scale.get_value()
+            )
+        except Exception as exc:
+            dialogs.error(
+                self.plugin._get_parent_window(),
+                _('Could not save BPM tuning: %s') % exc,
+            )
+            self._populate_tag_tuning(self.plugin.load_model(self.model_name))
+            return False
+        if self.plugin.suggestion_request is not None:
+            self.plugin.suggest_from_tracks(*self.plugin.suggestion_request)
+        return False
+
     def regenerate_tag_suggestions(self):
         self.tag_rebuild_source = None
         if self.plugin.suggestion_request is not None:
@@ -1067,6 +1150,9 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         if self.tag_rebuild_source is not None:
             GLib.source_remove(self.tag_rebuild_source)
             self.tag_rebuild_source = None
+        if self.bpm_rebuild_source is not None:
+            GLib.source_remove(self.bpm_rebuild_source)
+            self.bpm_rebuild_source = None
         playlist_widget.PlaylistPageBase.do_destroy(self)
 
 

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -1,0 +1,424 @@
+# Copyright (C) 2026 Exaile contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+
+import os
+import pickle
+
+from gi.repository import Gtk
+
+from xl import player, providers, settings, xdg
+from xl.nls import gettext as _
+from xlgui import main
+from xlgui.widgets import dialogs, menu, notebook
+
+from . import model as predictor_model
+
+
+MODEL_DIR = 'queuetrackpredictor'
+MODEL_FILE = 'model.pickle'
+
+
+class QueueTrackPredictorPlugin:
+    def __init__(self):
+        self.exaile = None
+        self.menu_item = None
+        self.playlist_menu_item = None
+        self.train_dialog = None
+        self.suggestion_dialog = None
+        self.button_registered = False
+
+    def enable(self, exaile):
+        self.exaile = exaile
+
+    def on_gui_loaded(self):
+        self.menu_item = menu.simple_menu_item(
+            'queue-track-predictor-create',
+            ['plugin-sep'],
+            _('Create Track Suggestions Model'),
+            callback=self.on_create_model,
+        )
+        self.menu_item.register('menubar-tools-menu')
+
+        self.playlist_menu_item = menu.simple_menu_item(
+            'queue-track-predictor-playlist-suggest',
+            ['enqueue'],
+            _('Suggest Next Track'),
+            'list-add',
+            callback=self.on_playlist_suggest_next_track,
+            condition_fn=self.can_suggest_from_playlist_context,
+        )
+        self.playlist_menu_item.register('playlist-context-menu')
+
+        SuggestNextTrackButton.plugin = self
+        providers.register('main-panel-actions', SuggestNextTrackButton)
+        self.button_registered = True
+
+    def disable(self, exaile):
+        if self.train_dialog is not None:
+            self.train_dialog.destroy()
+            self.train_dialog = None
+        if self.suggestion_dialog is not None:
+            self.suggestion_dialog.destroy()
+            self.suggestion_dialog = None
+
+        if self.menu_item is not None:
+            self.menu_item.unregister()
+            self.menu_item = None
+
+        if self.playlist_menu_item is not None:
+            self.playlist_menu_item.unregister()
+            self.playlist_menu_item = None
+
+        if self.button_registered:
+            providers.unregister('main-panel-actions', SuggestNextTrackButton)
+            self.button_registered = False
+            SuggestNextTrackButton.plugin = None
+
+    def get_model_path(self):
+        directory = os.path.join(xdg.get_plugin_data_dir(), MODEL_DIR)
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+        return os.path.join(directory, MODEL_FILE)
+
+    def get_track_groups(self, track):
+        if 'grouptagger' not in self.exaile.plugins.enabled_plugins:
+            raise RuntimeError(
+                _("GroupTagger plugin must be enabled to create or use suggestions.")
+            )
+        tagname = settings.get_option('plugin/grouptagger/tagname', 'grouping')
+        grouping = track.get_tag_raw(tagname, True)
+        if grouping is None:
+            return set()
+        return {group.replace('_', ' ') for group in grouping.split()}
+
+    def _get_parent_window(self, parent=None):
+        if parent is not None and hasattr(parent, 'window'):
+            return parent.window
+        try:
+            return main.mainwindow().window
+        except Exception:
+            return None
+
+    def on_create_model(self, widget, name, parent, context):
+        if self.train_dialog is None:
+            self.train_dialog = TrainingDialog(self, self._get_parent_window(parent))
+        self.train_dialog.present()
+
+    def can_suggest_from_playlist_context(self, name, parent, context):
+        if context['selection-count'] != 1:
+            return False
+        selected_items = context['selected-items']
+        if not selected_items:
+            return False
+        return True
+
+    def on_playlist_suggest_next_track(self, widget, name, parent, context):
+        selected_items = context['selected-items']
+        if not selected_items:
+            return
+
+        position, track = selected_items[0]
+        playlist = context['playlist']
+        start = max(0, position - 2)
+        previous_tracks = [playlist[idx] for idx in range(start, position + 1)]
+        excluded_locations = set()
+        if position + 1 < len(playlist):
+            excluded_locations.add(playlist[position + 1].get_loc_for_io())
+        self.suggest_from_tracks(
+            previous_tracks,
+            self._get_parent_window(parent),
+            excluded_locations=excluded_locations,
+        )
+
+    def create_model_from_playlists(self, playlists):
+        model = predictor_model.build_model(playlists, self.get_track_groups)
+        with open(self.get_model_path(), 'wb') as model_file:
+            pickle.dump(model, model_file, protocol=2)
+        return model
+
+    def load_model(self):
+        with open(self.get_model_path(), 'rb') as model_file:
+            return pickle.load(model_file)
+
+    def suggest_next_track(self, parent_window=None):
+        parent_window = parent_window or self._get_parent_window()
+        queue_tracks = list(player.QUEUE)
+        if len(queue_tracks) < 1:
+            dialogs.info(parent_window, _("At least one track must be in the queue."))
+            return
+        self.suggest_from_tracks(queue_tracks[-3:], parent_window)
+
+    def suggest_from_tracks(
+        self, previous_tracks, parent_window=None, excluded_locations=None
+    ):
+        parent_window = parent_window or self._get_parent_window()
+        try:
+            trained_model = self.load_model()
+        except IOError:
+            dialogs.info(parent_window, _("Create a track suggestions model first."))
+            return
+        except Exception as exc:
+            dialogs.error(parent_window, _("Could not load suggestions model: %s") % exc)
+            return
+
+        if len(previous_tracks) < 1:
+            dialogs.info(parent_window, _("At least one track is required for suggestions."))
+            return
+
+        try:
+            locations = predictor_model.get_suggestion_locations(
+                trained_model,
+                previous_tracks[-3:],
+                self.get_track_groups,
+                excluded_locations=excluded_locations,
+            )
+        except Exception as exc:
+            dialogs.error(parent_window, _("Could not create suggestions: %s") % exc)
+            return
+
+        tracks = predictor_model.resolve_suggestion_tracks(
+            self.exaile.collection, locations
+        )
+
+        if not tracks:
+            dialogs.info(parent_window, _("No suggestions found for the queue tail."))
+            return
+
+        if self.suggestion_dialog is not None:
+            self.suggestion_dialog.destroy()
+
+        self.suggestion_dialog = SuggestionsDialog(self, parent_window, tracks)
+        self.suggestion_dialog.present()
+
+    def append_to_queue(self, track):
+        player.QUEUE.append(track)
+
+
+class SuggestNextTrackButton(Gtk.Button, notebook.NotebookAction):
+    plugin = None
+    name = 'queue-track-predictor'
+    position = Gtk.PackType.END
+
+    def __init__(self, panel_notebook):
+        Gtk.Button.__init__(self)
+        notebook.NotebookAction.__init__(self, panel_notebook)
+
+        self.set_image(Gtk.Image.new_from_icon_name('list-add', Gtk.IconSize.BUTTON))
+        self.set_tooltip_text(_('Suggest Next Track'))
+        self.set_focus_on_click(False)
+        self.set_relief(Gtk.ReliefStyle.NONE)
+        self.connect('clicked', self.on_clicked)
+        self.show_all()
+
+    def on_clicked(self, button):
+        if self.plugin is not None:
+            self.plugin.suggest_next_track()
+
+
+class TrainingDialog(Gtk.Dialog):
+    def __init__(self, plugin, parent):
+        Gtk.Dialog.__init__(
+            self,
+            title=_('Create Track Suggestions Model'),
+            transient_for=parent,
+            modal=True,
+        )
+        self.plugin = plugin
+        self.set_default_size(420, 360)
+        self.add_buttons(
+            Gtk.STOCK_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            _('Create'),
+            Gtk.ResponseType.OK,
+        )
+        self.connect('response', self.on_response)
+        self.connect('delete-event', self.on_delete_event)
+
+        content = self.get_content_area()
+        content.set_border_width(6)
+
+        label = Gtk.Label(label=_('Select saved playlists to analyze.'))
+        label.set_xalign(0)
+        content.pack_start(label, False, False, 0)
+
+        select_box = Gtk.Box(spacing=6)
+        self.select_all_button = Gtk.Button(label=_('Select All'))
+        self.select_all_button.connect('clicked', self.on_select_all_clicked)
+        select_box.pack_start(self.select_all_button, False, False, 0)
+        content.pack_start(select_box, False, False, 4)
+
+        self.store = Gtk.ListStore(bool, str, object)
+        self.tree = Gtk.TreeView(model=self.store)
+        self.tree.set_headers_visible(True)
+
+        toggle = Gtk.CellRendererToggle()
+        toggle.connect('toggled', self.on_playlist_toggled)
+        toggle_column = Gtk.TreeViewColumn('', toggle, active=0)
+        self.tree.append_column(toggle_column)
+
+        text = Gtk.CellRendererText()
+        name_column = Gtk.TreeViewColumn(_('Playlist'), text, text=1)
+        name_column.set_expand(True)
+        self.tree.append_column(name_column)
+
+        scroller = Gtk.ScrolledWindow()
+        scroller.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scroller.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
+        scroller.add(self.tree)
+        content.pack_start(scroller, True, True, 6)
+
+        self.status = Gtk.Label()
+        self.status.set_xalign(0)
+        content.pack_start(self.status, False, False, 0)
+
+        self.populate_playlists()
+        self.show_all()
+
+    def populate_playlists(self):
+        manager = self.plugin.exaile.playlists
+        for name in sorted(manager.list_playlists()):
+            self.store.append((False, name, manager.get_playlist(name)))
+
+    def on_playlist_toggled(self, renderer, path):
+        self.store[path][0] = not self.store[path][0]
+
+    def on_select_all_clicked(self, button):
+        for row in self.store:
+            row[0] = True
+
+    def get_selected_playlists(self):
+        return [row[2] for row in self.store if row[0]]
+
+    def on_response(self, dialog, response):
+        if response == Gtk.ResponseType.OK:
+            playlists = self.get_selected_playlists()
+            if not playlists:
+                self.status.set_text(_('Select at least one playlist.'))
+                return
+
+            try:
+                trained_model = self.plugin.create_model_from_playlists(playlists)
+            except Exception as exc:
+                dialogs.error(self, _("Could not create suggestions model: %s") % exc)
+                return
+
+            dialogs.info(
+                self,
+                _("Created model from %(playlists)d playlist(s) and %(tracks)d track(s).")
+                % {
+                    'playlists': trained_model.get('playlist_count', 0),
+                    'tracks': trained_model.get('track_count', 0),
+                },
+            )
+
+        self.destroy()
+
+    def on_delete_event(self, widget, event):
+        self.plugin.train_dialog = None
+
+    def destroy(self):
+        self.plugin.train_dialog = None
+        Gtk.Dialog.destroy(self)
+
+
+class SuggestionsDialog(Gtk.Dialog):
+    def __init__(self, plugin, parent, tracks):
+        Gtk.Dialog.__init__(
+            self,
+            title=_('Suggested Next Tracks'),
+            transient_for=parent,
+            modal=True,
+        )
+        self.plugin = plugin
+        self.set_default_size(720, 420)
+        self.add_buttons(
+            Gtk.STOCK_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            _('Add to Queue'),
+            Gtk.ResponseType.OK,
+        )
+        self.connect('response', self.on_response)
+        self.connect('delete-event', self.on_delete_event)
+
+        self.store = Gtk.ListStore(str, str, str, str, object)
+        for track in tracks:
+            self.store.append(
+                (
+                    track.get_tag_display('title'),
+                    track.get_tag_display('artist'),
+                    _display_bpm(track),
+                    _display_groups(plugin, track),
+                    track,
+                )
+            )
+
+        self.tree = Gtk.TreeView(model=self.store)
+        self.tree.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+        self.tree.get_selection().select_path(0)
+        self.tree.connect('row-activated', self.on_row_activated)
+        self._add_text_column(_('Title'), 0, True)
+        self._add_text_column(_('Artist'), 1, True)
+        self._add_text_column(_('BPM'), 2, False)
+        self._add_text_column(_('Groups'), 3, True)
+
+        scroller = Gtk.ScrolledWindow()
+        scroller.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scroller.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
+        scroller.add(self.tree)
+
+        content = self.get_content_area()
+        content.set_border_width(6)
+        content.pack_start(scroller, True, True, 0)
+        self.show_all()
+
+    def _add_text_column(self, title, column_id, expand):
+        renderer = Gtk.CellRendererText()
+        renderer.set_property('ellipsize', 3)
+        column = Gtk.TreeViewColumn(title, renderer, text=column_id)
+        column.set_expand(expand)
+        self.tree.append_column(column)
+
+    def get_selected_track(self):
+        model, tree_iter = self.tree.get_selection().get_selected()
+        if tree_iter is None:
+            return None
+        return model[tree_iter][4]
+
+    def on_response(self, dialog, response):
+        if response == Gtk.ResponseType.OK:
+            self.add_selected_track()
+        self.destroy()
+
+    def on_row_activated(self, tree, path, column):
+        self.tree.get_selection().select_path(path)
+        self.add_selected_track()
+        self.destroy()
+
+    def add_selected_track(self):
+        track = self.get_selected_track()
+        if track is not None:
+            self.plugin.append_to_queue(track)
+
+    def on_delete_event(self, widget, event):
+        self.plugin.suggestion_dialog = None
+
+    def destroy(self):
+        self.plugin.suggestion_dialog = None
+        Gtk.Dialog.destroy(self)
+
+
+def _display_bpm(track):
+    bpm = track.get_tag_raw('bpm', True)
+    return '' if bpm is None else str(bpm)
+
+
+def _display_groups(plugin, track):
+    groups = plugin.get_track_groups(track)
+    return ', '.join(sorted(groups))
+
+
+plugin_class = QueueTrackPredictorPlugin

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -6,8 +6,6 @@
 # (at your option) any later version.
 
 import os
-import pickle
-
 from gi.repository import Gtk
 
 from xl import player, providers, settings, xdg
@@ -16,10 +14,11 @@ from xlgui import main
 from xlgui.widgets import dialogs, menu, notebook
 
 from . import model as predictor_model
+from . import model_store
 
 
 MODEL_DIR = 'queuetrackpredictor'
-MODEL_FILE = 'model.pickle'
+MODEL_FILE = 'models.pickle'
 
 
 class QueueTrackPredictorPlugin:
@@ -28,6 +27,7 @@ class QueueTrackPredictorPlugin:
         self.menu_item = None
         self.playlist_menu_item = None
         self.train_dialog = None
+        self.model_manager_dialog = None
         self.suggestion_dialog = None
         self.button_registered = False
 
@@ -36,10 +36,10 @@ class QueueTrackPredictorPlugin:
 
     def on_gui_loaded(self):
         self.menu_item = menu.simple_menu_item(
-            'queue-track-predictor-create',
+            'queue-track-predictor-manage',
             ['plugin-sep'],
-            _('Create Track Suggestions Model'),
-            callback=self.on_create_model,
+            _('Manage Track Prediction Models'),
+            callback=self.on_manage_models,
         )
         self.menu_item.register('menubar-tools-menu')
 
@@ -61,6 +61,9 @@ class QueueTrackPredictorPlugin:
         if self.train_dialog is not None:
             self.train_dialog.destroy()
             self.train_dialog = None
+        if self.model_manager_dialog is not None:
+            self.model_manager_dialog.destroy()
+            self.model_manager_dialog = None
         if self.suggestion_dialog is not None:
             self.suggestion_dialog.destroy()
             self.suggestion_dialog = None
@@ -103,10 +106,12 @@ class QueueTrackPredictorPlugin:
         except Exception:
             return None
 
-    def on_create_model(self, widget, name, parent, context):
-        if self.train_dialog is None:
-            self.train_dialog = TrainingDialog(self, self._get_parent_window(parent))
-        self.train_dialog.present()
+    def on_manage_models(self, widget, name, parent, context):
+        if self.model_manager_dialog is None:
+            self.model_manager_dialog = ModelManagerDialog(
+                self, self._get_parent_window(parent)
+            )
+        self.model_manager_dialog.present()
 
     def can_suggest_from_playlist_context(self, name, parent, context):
         if context['selection-count'] != 1:
@@ -134,15 +139,25 @@ class QueueTrackPredictorPlugin:
             excluded_locations=excluded_locations,
         )
 
-    def create_model_from_playlists(self, playlists):
+    def load_model_catalog(self):
+        return model_store.load_catalog(self.get_model_path())
+
+    def save_model_catalog(self, catalog):
+        model_store.save_catalog(self.get_model_path(), catalog)
+
+    def create_model_from_playlists(self, name, playlists):
         model = predictor_model.build_model(playlists, self.get_track_groups)
-        with open(self.get_model_path(), 'wb') as model_file:
-            pickle.dump(model, model_file, protocol=2)
+        catalog = self.load_model_catalog()
+        model_store.add_model(catalog, name, model)
+        self.save_model_catalog(catalog)
         return model
 
     def load_model(self):
-        with open(self.get_model_path(), 'rb') as model_file:
-            return pickle.load(model_file)
+        catalog = self.load_model_catalog()
+        selected = catalog.get('selected')
+        if selected is None:
+            raise IOError('No prediction model is selected')
+        return catalog['models'][selected]
 
     def suggest_next_track(self, parent_window=None):
         parent_window = parent_window or self._get_parent_window()
@@ -219,15 +234,191 @@ class SuggestNextTrackButton(Gtk.Button, notebook.NotebookAction):
             self.plugin.suggest_next_track()
 
 
-class TrainingDialog(Gtk.Dialog):
+class ModelManagerDialog(Gtk.Dialog):
     def __init__(self, plugin, parent):
         Gtk.Dialog.__init__(
             self,
-            title=_('Create Track Suggestions Model'),
+            title=_('Track Prediction Models'),
             transient_for=parent,
             modal=True,
         )
         self.plugin = plugin
+        self.set_default_size(560, 360)
+        self.add_button(Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
+        self.connect('response', lambda dialog, response: self.destroy())
+        self.connect('delete-event', self.on_delete_event)
+
+        self.store = Gtk.ListStore(str, str, str, str)
+        self.tree = Gtk.TreeView(model=self.store)
+        self.tree.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+        self.tree.get_selection().connect('changed', self.on_selection_changed)
+        self.tree.connect('row-activated', self.on_row_activated)
+        self._add_text_column('', 0, False)
+        self._add_text_column(_('Name'), 1, True)
+        self._add_text_column(_('Playlists'), 2, False)
+        self._add_text_column(_('Tracks'), 3, False)
+
+        scroller = Gtk.ScrolledWindow()
+        scroller.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scroller.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
+        scroller.add(self.tree)
+
+        buttons = Gtk.Box(spacing=6)
+        self.add_button_widget = Gtk.Button(label=_('Add'))
+        self.add_button_widget.connect('clicked', self.on_add_clicked)
+        buttons.pack_start(self.add_button_widget, False, False, 0)
+        self.rename_button = Gtk.Button(label=_('Rename'))
+        self.rename_button.connect('clicked', self.on_rename_clicked)
+        buttons.pack_start(self.rename_button, False, False, 0)
+        self.remove_button = Gtk.Button(label=_('Remove'))
+        self.remove_button.connect('clicked', self.on_remove_clicked)
+        buttons.pack_start(self.remove_button, False, False, 0)
+        self.select_button = Gtk.Button(label=_('Select'))
+        self.select_button.connect('clicked', self.on_select_clicked)
+        buttons.pack_end(self.select_button, False, False, 0)
+
+        content = self.get_content_area()
+        content.set_border_width(6)
+        content.pack_start(scroller, True, True, 0)
+        content.pack_start(buttons, False, False, 6)
+        self.refresh()
+        self.show_all()
+
+    def _add_text_column(self, title, column_id, expand):
+        renderer = Gtk.CellRendererText()
+        column = Gtk.TreeViewColumn(title, renderer, text=column_id)
+        column.set_expand(expand)
+        self.tree.append_column(column)
+
+    def refresh(self, select_name=None):
+        catalog = self.plugin.load_model_catalog()
+        selected_name = catalog.get('selected')
+        self.store.clear()
+        path_to_select = None
+        for name in sorted(catalog['models']):
+            model = catalog['models'][name]
+            tree_iter = self.store.append(
+                (
+                    '\N{BLACK CIRCLE}' if name == selected_name else '',
+                    name,
+                    str(model.get('playlist_count', 0)),
+                    str(model.get('track_count', 0)),
+                )
+            )
+            if name == (select_name or selected_name):
+                path_to_select = self.store.get_path(tree_iter)
+        if path_to_select is not None:
+            self.tree.get_selection().select_path(path_to_select)
+        self.on_selection_changed(self.tree.get_selection())
+
+    def get_selected_name(self):
+        model, tree_iter = self.tree.get_selection().get_selected()
+        return None if tree_iter is None else model[tree_iter][1]
+
+    def on_selection_changed(self, selection):
+        enabled = self.get_selected_name() is not None
+        self.rename_button.set_sensitive(enabled)
+        self.remove_button.set_sensitive(enabled)
+        self.select_button.set_sensitive(enabled)
+
+    def on_add_clicked(self, button):
+        name = prompt_for_model_name(self, _('Add Prediction Model'))
+        if name is None:
+            return
+        catalog = self.plugin.load_model_catalog()
+        if name in catalog['models']:
+            dialogs.error(self, _('A model with that name already exists.'))
+            return
+        self.plugin.train_dialog = TrainingDialog(self.plugin, self, name)
+        self.plugin.train_dialog.present()
+
+    def on_rename_clicked(self, button):
+        old_name = self.get_selected_name()
+        if old_name is None:
+            return
+        new_name = prompt_for_model_name(self, _('Rename Prediction Model'), old_name)
+        if new_name is None:
+            return
+        catalog = self.plugin.load_model_catalog()
+        try:
+            model_store.rename_model(catalog, old_name, new_name)
+        except ValueError as exc:
+            dialogs.error(self, str(exc))
+            return
+        self.plugin.save_model_catalog(catalog)
+        self.refresh(new_name)
+
+    def on_remove_clicked(self, button):
+        name = self.get_selected_name()
+        if name is None:
+            return
+        response = dialogs.yesno(
+            self, _('Remove the prediction model “%s”?') % name
+        )
+        if response != Gtk.ResponseType.YES:
+            return
+        catalog = self.plugin.load_model_catalog()
+        model_store.remove_model(catalog, name)
+        self.plugin.save_model_catalog(catalog)
+        self.refresh()
+
+    def on_select_clicked(self, button):
+        name = self.get_selected_name()
+        if name is None:
+            return
+        catalog = self.plugin.load_model_catalog()
+        model_store.select_model(catalog, name)
+        self.plugin.save_model_catalog(catalog)
+        self.refresh(name)
+
+    def on_row_activated(self, tree, path, column):
+        self.tree.get_selection().select_path(path)
+        self.on_select_clicked(None)
+
+    def on_delete_event(self, widget, event):
+        self.plugin.model_manager_dialog = None
+
+    def destroy(self):
+        self.plugin.model_manager_dialog = None
+        Gtk.Dialog.destroy(self)
+
+
+def prompt_for_model_name(parent, title, initial=''):
+    dialog = Gtk.Dialog(title=title, transient_for=parent, modal=True)
+    dialog.add_buttons(
+        Gtk.STOCK_CANCEL,
+        Gtk.ResponseType.CANCEL,
+        Gtk.STOCK_OK,
+        Gtk.ResponseType.OK,
+    )
+    entry = Gtk.Entry()
+    entry.set_text(initial)
+    entry.set_activates_default(True)
+    dialog.set_default_response(Gtk.ResponseType.OK)
+    content = dialog.get_content_area()
+    content.set_border_width(12)
+    content.pack_start(Gtk.Label(label=_('Model name:')), False, False, 0)
+    content.pack_start(entry, False, False, 6)
+    dialog.show_all()
+    response = dialog.run()
+    name = entry.get_text().strip() if response == Gtk.ResponseType.OK else None
+    dialog.destroy()
+    if response == Gtk.ResponseType.OK and not name:
+        dialogs.error(parent, _('Model name cannot be empty.'))
+        return None
+    return name
+
+
+class TrainingDialog(Gtk.Dialog):
+    def __init__(self, plugin, parent, model_name):
+        Gtk.Dialog.__init__(
+            self,
+            title=_('Create Prediction Model “%s”') % model_name,
+            transient_for=parent,
+            modal=True,
+        )
+        self.plugin = plugin
+        self.model_name = model_name
         self.set_default_size(420, 360)
         self.add_buttons(
             Gtk.STOCK_CANCEL,
@@ -301,7 +492,9 @@ class TrainingDialog(Gtk.Dialog):
                 return
 
             try:
-                trained_model = self.plugin.create_model_from_playlists(playlists)
+                trained_model = self.plugin.create_model_from_playlists(
+                    self.model_name, playlists
+                )
             except Exception as exc:
                 dialogs.error(self, _("Could not create suggestions model: %s") % exc)
                 return
@@ -314,6 +507,8 @@ class TrainingDialog(Gtk.Dialog):
                     'tracks': trained_model.get('track_count', 0),
                 },
             )
+            if self.plugin.model_manager_dialog is not None:
+                self.plugin.model_manager_dialog.refresh(self.model_name)
 
         self.destroy()
 

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -255,46 +255,38 @@ class QueueTrackPredictorPlugin:
             self.set_last_model_name(name)
         return model
 
-    def _get_model_tuning_settings(self):
-        tuning = settings.get_option(
-            predictor_preferences.MODEL_TUNING_OPTION, {}
-        )
-        return tuning if isinstance(tuning, dict) else {}
+    def _get_tuning_settings(self):
+        return {
+            'tag_biases': settings.get_option(
+                predictor_preferences.TAG_BIASES_OPTION, {}
+            ),
+            'bpm_bias': settings.get_option(
+                predictor_preferences.BPM_BIAS_OPTION,
+                predictor_model.DEFAULT_BPM_BIAS,
+            ),
+        }
 
-    def get_model_tuning(self, model_name, model=None, all_tuning=None):
+    def get_model_tuning(self, model_name, model=None, tuning=None):
         model = model or self.load_model(model_name)
-        all_tuning = (
-            self._get_model_tuning_settings()
-            if all_tuning is None
-            else all_tuning
-        )
-        tuning = all_tuning.get(model_name, {})
+        tuning = self._get_tuning_settings() if tuning is None else tuning
         return predictor_model.normalize_model_tuning(model, tuning)
 
-    def _set_model_tuning(self, model_name, tag_biases=None, bpm_bias=None):
-        model = self.load_model(model_name)
-        all_tuning = dict(self._get_model_tuning_settings())
-        tuning = self.get_model_tuning(model_name, model, all_tuning)
-        if tag_biases is not None:
-            tuning['tag_biases'] = tag_biases
-        if bpm_bias is not None:
-            tuning['bpm_bias'] = predictor_model.clamp_bpm_bias(bpm_bias)
-        tuning = self.get_model_tuning(
-            model_name, model, {model_name: tuning}
-        )
-        if tuning['tag_biases'] or tuning['bpm_bias'] != 0:
-            all_tuning[model_name] = tuning
-        else:
-            all_tuning.pop(model_name, None)
-        settings.set_option(
-            predictor_preferences.MODEL_TUNING_OPTION, all_tuning
-        )
-
     def set_model_tag_biases(self, model_name, tag_biases):
-        self._set_model_tuning(model_name, tag_biases=tag_biases)
+        model = self.load_model(model_name)
+        stored_biases = predictor_model.merge_model_tag_biases(
+            model,
+            self._get_tuning_settings()['tag_biases'],
+            tag_biases,
+        )
+        settings.set_option(
+            predictor_preferences.TAG_BIASES_OPTION, stored_biases
+        )
 
-    def set_model_bpm_bias(self, model_name, bpm_bias):
-        self._set_model_tuning(model_name, bpm_bias=bpm_bias)
+    def set_model_bpm_bias(self, _model_name, bpm_bias):
+        settings.set_option(
+            predictor_preferences.BPM_BIAS_OPTION,
+            predictor_model.clamp_bpm_bias(bpm_bias),
+        )
 
     def get_default_model_name(self, catalog=None):
         catalog = catalog or self.load_model_catalog()
@@ -312,12 +304,6 @@ class QueueTrackPredictorPlugin:
         settings.set_option(predictor_preferences.LAST_MODEL_OPTION, model_name)
 
     def rename_model_settings(self, old_name, new_name):
-        all_tuning = dict(self._get_model_tuning_settings())
-        if old_name in all_tuning:
-            all_tuning[new_name] = all_tuning.pop(old_name)
-            settings.set_option(
-                predictor_preferences.MODEL_TUNING_OPTION, all_tuning
-            )
         if (
             settings.get_option(predictor_preferences.LAST_MODEL_OPTION, '')
             == old_name
@@ -325,12 +311,6 @@ class QueueTrackPredictorPlugin:
             self.set_last_model_name(new_name)
 
     def remove_model_settings(self, model_name, catalog):
-        all_tuning = dict(self._get_model_tuning_settings())
-        if model_name in all_tuning:
-            del all_tuning[model_name]
-            settings.set_option(
-                predictor_preferences.MODEL_TUNING_OPTION, all_tuning
-            )
         if (
             settings.get_option(predictor_preferences.LAST_MODEL_OPTION, '')
             == model_name
@@ -400,7 +380,7 @@ class QueueTrackPredictorPlugin:
                 predictor_preferences.DEFAULT_DIVERSITY,
             )
         )
-        model_tuning = self._get_model_tuning_settings()
+        model_tuning = self._get_tuning_settings()
         self.suggestion_generation += 1
         generation = self.suggestion_generation
         if self.suggestion_future is not None:
@@ -583,6 +563,19 @@ class QueueTrackPredictorPlugin:
         )
         if self.suggestion_request is not None:
             self.suggest_from_tracks(*self.suggestion_request)
+
+    def set_suggestion_model(self, model_name):
+        if self.suggestion_request is None:
+            return
+        previous_tracks, parent_window, excluded_locations, _ = (
+            self.suggestion_request
+        )
+        self.suggest_from_tracks(
+            previous_tracks,
+            parent_window,
+            excluded_locations,
+            model_name,
+        )
 
     def _get_suggestions_notebook(self):
         if self.suggestions_tab is None or self.suggestions_page is None:
@@ -797,6 +790,7 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         self.tag_rebuild_source = None
         self.bpm_rebuild_source = None
         self.model_name = None
+        self.model_names = []
         self.swindow = Gtk.ScrolledWindow()
         self.swindow.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         self.view = SuggestionsPlaylistView(
@@ -837,9 +831,16 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
 
         diversity_box = Gtk.Box(spacing=8)
         diversity_box.set_border_width(6)
-        self.model_label = Gtk.Label()
-        self.model_label.set_xalign(0)
-        diversity_box.pack_start(self.model_label, False, False, 0)
+        model_label = Gtk.Label(label=_('Model:'))
+        diversity_box.pack_start(model_label, False, False, 0)
+        self.model_choice = Gtk.ComboBoxText()
+        self.model_choice.set_tooltip_text(
+            _('Choose the prediction model used for these suggestions')
+        )
+        self.model_choice_changed_id = self.model_choice.connect(
+            'changed', self.on_model_choice_changed
+        )
+        diversity_box.pack_start(self.model_choice, False, False, 0)
         self.tuning_toggle = Gtk.ToggleButton(label=_('Tune Tags'))
         self.tuning_toggle.set_tooltip_text(
             _('Tune tag preferences for this prediction model')
@@ -1004,15 +1005,7 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         self.bpm_bias_scale.handler_block(self.bpm_bias_changed_id)
         self.bpm_bias_scale.set_value(bpm_bias)
         self.bpm_bias_scale.handler_unblock(self.bpm_bias_changed_id)
-        included_tags = model.get('included_tags')
-        if included_tags is None:
-            included_tags = {
-                tag
-                for summary in model.get('candidate_features', {}).values()
-                for tag in summary.get('groups', ())
-            }
-        else:
-            included_tags = set(included_tags)
+        included_tags = predictor_model.get_model_tags(model)
         self.tag_biases = {
             tag: int(bias)
             for tag, bias in tuning['tag_biases'].items()
@@ -1235,7 +1228,20 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
             self.diversity_scale.set_value(diversity)
 
     def set_model_name(self, model_name):
-        self.model_label.set_text(_('Model: %s') % model_name)
+        try:
+            names = model_store.model_names(self.plugin.load_model_catalog())
+        except Exception:
+            names = [model_name]
+        if names != self.model_names:
+            self.model_choice.handler_block(self.model_choice_changed_id)
+            self.model_choice.remove_all()
+            for name in names:
+                self.model_choice.append(name, name)
+            self.model_choice.handler_unblock(self.model_choice_changed_id)
+            self.model_names = names
+        self.model_choice.handler_block(self.model_choice_changed_id)
+        self.model_choice.set_active_id(model_name)
+        self.model_choice.handler_unblock(self.model_choice_changed_id)
         if model_name == self.model_name:
             return
         self.model_name = model_name
@@ -1252,6 +1258,13 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
             self._update_tuning_button_label()
             return
         self._populate_tag_tuning(model)
+
+    def on_model_choice_changed(self, choice):
+        model_name = choice.get_active_id()
+        if model_name is None or model_name == self.model_name:
+            return
+        self.set_model_name(model_name)
+        self.plugin.set_suggestion_model(model_name)
 
     def on_search_entry_activate(self, entry):
         self.view.filter_tracks(entry.get_text() or None)

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -12,7 +12,7 @@ from gi.repository import GLib, Gtk
 from xl import player, providers, settings, xdg
 from xl.playlist import Playlist
 from xl.nls import gettext as _
-from xlgui import main
+from xlgui import guiutil, main
 from xlgui.widgets import dialogs, menu, notebook, playlist as playlist_widget
 
 from . import model as predictor_model
@@ -506,6 +506,28 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         self.view = SuggestionsPlaylistView(
             suggestions_playlist, playlist_player
         )
+        self.search_entry = guiutil.SearchEntry()
+        self.search_entry.entry.set_size_request(300, -1)
+        self.search_entry.entry.set_valign(Gtk.Align.CENTER)
+        self.search_entry.entry.set_icon_from_icon_name(
+            Gtk.EntryIconPosition.PRIMARY, 'edit-find'
+        )
+        self.search_entry.entry.set_icon_from_icon_name(
+            Gtk.EntryIconPosition.SECONDARY, 'edit-clear'
+        )
+        self.search_entry.entry.set_icon_sensitive(
+            Gtk.EntryIconPosition.PRIMARY, False
+        )
+        self.search_entry.entry.set_icon_sensitive(
+            Gtk.EntryIconPosition.SECONDARY, False
+        )
+        self.search_entry.entry.set_placeholder_text(_('Search'))
+        self.search_entry.entry.connect('activate', self.on_search_entry_activate)
+        self.view.set_search_entry(self.search_entry.entry)
+        self.view.connect(
+            'start-interactive-search',
+            lambda *args: self.search_entry.entry.grab_focus(),
+        )
         self.view.drag_dest_unset()
         self.swindow.add(self.view)
         self.pack_start(self.swindow, True, True, 0)
@@ -524,6 +546,7 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
         self.diversity_scale.set_value(diversity)
         self.diversity_scale.connect('value-changed', self.on_diversity_changed)
         diversity_box.pack_start(self.diversity_scale, True, True, 0)
+        diversity_box.pack_end(self.search_entry.entry, False, True, 0)
         self.pack_start(diversity_box, False, False, 0)
         self.show_all()
 
@@ -536,6 +559,9 @@ class SuggestionsPlaylistPage(playlist_widget.PlaylistPageBase):
     def set_diversity(self, diversity):
         if int(round(self.diversity_scale.get_value())) != int(round(diversity)):
             self.diversity_scale.set_value(diversity)
+
+    def on_search_entry_activate(self, entry):
+        self.view.filter_tracks(entry.get_text() or None)
 
     def on_diversity_changed(self, scale):
         if self.diversity_rebuild_source is not None:

--- a/plugins/queuetrackpredictor/__init__.py
+++ b/plugins/queuetrackpredictor/__init__.py
@@ -34,6 +34,7 @@ class QueueTrackPredictorPlugin:
         self.playlist_menu_item = None
         self.train_dialog = None
         self.model_manager_dialog = None
+        self.model_manager_open_source = None
         self.suggestions_playlist = None
         self.suggestions_page = None
         self.suggestions_tab = None
@@ -77,6 +78,9 @@ class QueueTrackPredictorPlugin:
 
     def disable(self, exaile):
         self.suggestion_generation += 1
+        if self.model_manager_open_source is not None:
+            GLib.source_remove(self.model_manager_open_source)
+            self.model_manager_open_source = None
         if self.suggestion_future is not None:
             self.suggestion_future.cancel()
             self.suggestion_future = None
@@ -134,11 +138,29 @@ class QueueTrackPredictorPlugin:
             return None
 
     def on_manage_models(self, widget, name, parent, context):
+        # Opening a modal window from inside a Gtk.MenuItem activation can cause
+        # the provider menu to tear down its children while GTK is still
+        # dispatching the event. In particular, this is unsafe on Wayland.
+        # Wait until the menu event has completely unwound before changing the
+        # active toplevel window.
+        if self.model_manager_open_source is not None:
+            return
+        self.model_manager_open_source = GLib.idle_add(
+            self._open_model_manager, self._get_parent_window(parent)
+        )
+
+    def _open_model_manager(self, parent_window):
+        self.model_manager_open_source = None
         if self.model_manager_dialog is None:
             self.model_manager_dialog = ModelManagerDialog(
-                self, self._get_parent_window(parent)
+                self, parent_window
             )
         self.model_manager_dialog.present()
+        return False
+
+    def on_model_manager_destroyed(self, dialog):
+        if dialog is self.model_manager_dialog:
+            self.model_manager_dialog = None
 
     def can_suggest_from_playlist_context(self, name, parent, context):
         if context['selection-count'] != 1:
@@ -594,7 +616,7 @@ class ModelManagerDialog(Gtk.Dialog):
         self.set_default_size(560, 360)
         self.add_button(Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
         self.connect('response', lambda dialog, response: self.destroy())
-        self.connect('delete-event', self.on_delete_event)
+        self.connect('destroy', self.plugin.on_model_manager_destroyed)
 
         self.store = Gtk.ListStore(str, str, str, str)
         self.tree = Gtk.TreeView(model=self.store)
@@ -608,6 +630,7 @@ class ModelManagerDialog(Gtk.Dialog):
         self._add_text_column(_('Tracks'), 3, False)
 
         self.context_menu = Gtk.Menu()
+        self.context_menu.attach_to_widget(self.tree, None)
         rebuild_menu_item = Gtk.MenuItem(label=_('Rebuild'))
         rebuild_menu_item.connect('activate', self.on_rebuild_clicked)
         self.context_menu.append(rebuild_menu_item)
@@ -762,14 +785,6 @@ class ModelManagerDialog(Gtk.Dialog):
         tree.get_selection().select_path(row[0])
         self.context_menu.popup_at_pointer(event)
         return True
-
-    def on_delete_event(self, widget, event):
-        self.plugin.model_manager_dialog = None
-
-    def destroy(self):
-        self.plugin.model_manager_dialog = None
-        Gtk.Dialog.destroy(self)
-
 
 def prompt_for_model_name(parent, title, initial=''):
     dialog = Gtk.Dialog(title=title, transient_for=parent, modal=True)

--- a/plugins/queuetrackpredictor/model.py
+++ b/plugins/queuetrackpredictor/model.py
@@ -118,6 +118,25 @@ def get_suggestion_locations(
     max_suggestions=DEFAULT_MAX_SUGGESTIONS,
     excluded_locations=None,
 ):
+    return [
+        location
+        for location, _score in get_scored_suggestion_locations(
+            model,
+            previous_tracks,
+            get_track_groups,
+            max_suggestions,
+            excluded_locations,
+        )
+    ]
+
+
+def get_scored_suggestion_locations(
+    model,
+    previous_tracks,
+    get_track_groups,
+    max_suggestions=DEFAULT_MAX_SUGGESTIONS,
+    excluded_locations=None,
+):
     if model.get('version') != MODEL_VERSION:
         raise ValueError("Unsupported queue predictor model version")
 
@@ -151,7 +170,7 @@ def get_suggestion_locations(
         excluded_locations.update(transition_counts.get(context, {}).keys())
     suggestions = []
 
-    for loc, _count in _rank_counts(counts):
+    for loc, score in _rank_counts(counts):
         if loc in excluded_locations:
             continue
         if loc in previous_locations:
@@ -159,7 +178,7 @@ def get_suggestion_locations(
         if loc in seen:
             continue
         seen.add(loc)
-        suggestions.append(loc)
+        suggestions.append((loc, score))
         if len(suggestions) >= max_suggestions:
             break
 
@@ -210,6 +229,19 @@ def resolve_suggestion_tracks(
         track = collection.get_track_by_loc(loc)
         if track is not None:
             tracks.append(track)
+        if len(tracks) >= max_suggestions:
+            break
+    return tracks
+
+
+def resolve_scored_suggestion_tracks(
+    collection, scored_locations, max_suggestions=DEFAULT_MAX_SUGGESTIONS
+):
+    tracks = []
+    for loc, score in scored_locations:
+        track = collection.get_track_by_loc(loc)
+        if track is not None:
+            tracks.append((track, score))
         if len(tracks) >= max_suggestions:
             break
     return tracks

--- a/plugins/queuetrackpredictor/model.py
+++ b/plugins/queuetrackpredictor/model.py
@@ -14,6 +14,8 @@ DEFAULT_BPM_BAND_SIZE = 5
 MAX_CONTEXT_LENGTH = 3
 DEFAULT_MAX_SUGGESTIONS = 10
 DEFAULT_DIVERSITY = 50
+DEFAULT_BPM_BIAS = 0
+BPM_BIAS_FULL_EFFECT_DELTA = 30
 TAG_BIAS_FACTORS = {
     -2: 0.5,
     -1: 0.75,
@@ -41,7 +43,7 @@ def _get_track_bpm(track):
 
     try:
         return int(round(float(bpm)))
-    except (TypeError, ValueError):
+    except (OverflowError, TypeError, ValueError):
         return None
 
 
@@ -233,6 +235,12 @@ def get_scored_suggestion_locations(
         candidate_features or model.get('candidate_features', {}),
         model.get('tag_biases', {}),
     )
+    counts = apply_bpm_bias(
+        counts,
+        candidate_features or model.get('candidate_features', {}),
+        context[-1][1],
+        model.get('bpm_bias', DEFAULT_BPM_BIAS),
+    )
 
     seen = set()
     previous_locations = {_get_track_location(track) for track in previous_tracks}
@@ -278,6 +286,43 @@ def apply_tag_biases(counts, candidate_features, tag_biases):
             # prevents tracks with many tags from receiving an accidental boost.
             factor = math.prod(factors) ** (1.0 / len(factors))
             score *= factor
+        adjusted[location] = score
+    return adjusted
+
+
+def clamp_bpm_bias(bias):
+    try:
+        bias = int(round(float(bias)))
+    except (OverflowError, TypeError, ValueError):
+        return DEFAULT_BPM_BIAS
+    return max(
+        -BPM_BIAS_FULL_EFFECT_DELTA,
+        min(BPM_BIAS_FULL_EFFECT_DELTA, bias),
+    )
+
+
+def apply_bpm_bias(counts, candidate_features, reference_bpm, bpm_bias):
+    """Favor bounded tempo movement relative to the latest track."""
+    bpm_bias = clamp_bpm_bias(bpm_bias)
+    if bpm_bias == 0 or reference_bpm is None:
+        return counts
+
+    adjusted = Counter()
+    requested_delta = abs(float(bpm_bias))
+    requested_direction = 1.0 if bpm_bias > 0 else -1.0
+    for location, score in counts.items():
+        candidate_bpm = candidate_features.get(location, {}).get('bpm_band')
+        if candidate_bpm is not None:
+            directional_delta = (
+                float(candidate_bpm - reference_bpm) * requested_direction
+            )
+            effect_delta = max(
+                -requested_delta,
+                min(requested_delta, directional_delta),
+            )
+            # The selected BPM amount caps the directional effect. At the
+            # 30 BPM endpoint this ranges from 0.5x to 2x.
+            score *= 2.0 ** (effect_delta / BPM_BIAS_FULL_EFFECT_DELTA)
         adjusted[location] = score
     return adjusted
 

--- a/plugins/queuetrackpredictor/model.py
+++ b/plugins/queuetrackpredictor/model.py
@@ -45,18 +45,33 @@ def bucket_bpm(bpm, band_size=DEFAULT_BPM_BAND_SIZE):
     return bpm - (bpm % band_size)
 
 
-def track_features(track, get_track_groups, bpm_band_size=DEFAULT_BPM_BAND_SIZE):
+def track_features(
+    track,
+    get_track_groups,
+    bpm_band_size=DEFAULT_BPM_BAND_SIZE,
+    included_tags=None,
+):
     groups = get_track_groups(track) or []
+    if included_tags is not None:
+        groups = set(groups) & set(included_tags)
     return (
         tuple(sorted(groups)),
         bucket_bpm(_get_track_bpm(track), bpm_band_size),
     )
 
 
-def make_track_summary(track, get_track_groups, bpm_band_size=DEFAULT_BPM_BAND_SIZE):
+def make_track_summary(
+    track,
+    get_track_groups,
+    bpm_band_size=DEFAULT_BPM_BAND_SIZE,
+    included_tags=None,
+):
+    features = track_features(
+        track, get_track_groups, bpm_band_size, included_tags
+    )
     return {
-        'groups': track_features(track, get_track_groups, bpm_band_size)[0],
-        'bpm_band': track_features(track, get_track_groups, bpm_band_size)[1],
+        'groups': features[0],
+        'bpm_band': features[1],
         'title': _get_track_display(track, 'title'),
         'artist': _get_track_display(track, 'artist'),
     }
@@ -69,7 +84,21 @@ def _get_track_display(track, tag):
         return ''
 
 
-def build_model(playlists, get_track_groups, bpm_band_size=DEFAULT_BPM_BAND_SIZE):
+def get_playlist_tags(playlists, get_track_groups):
+    tags = set()
+    for playlist in playlists:
+        for track in playlist:
+            tags.update(get_track_groups(track) or [])
+    return tags
+
+
+def build_model(
+    playlists,
+    get_track_groups,
+    bpm_band_size=DEFAULT_BPM_BAND_SIZE,
+    included_tags=None,
+):
+    included_tags = None if included_tags is None else set(included_tags)
     transition_counts = defaultdict(Counter)
     candidate_features = {}
     playlist_count = 0
@@ -81,14 +110,17 @@ def build_model(playlists, get_track_groups, bpm_band_size=DEFAULT_BPM_BAND_SIZE
         track_count += len(tracks)
 
         feature_cache = [
-            track_features(track, get_track_groups, bpm_band_size) for track in tracks
+            track_features(
+                track, get_track_groups, bpm_band_size, included_tags
+            )
+            for track in tracks
         ]
 
         for track in tracks:
             loc = _get_track_location(track)
             if loc is not None and loc not in candidate_features:
                 candidate_features[loc] = make_track_summary(
-                    track, get_track_groups, bpm_band_size
+                    track, get_track_groups, bpm_band_size, included_tags
                 )
 
         for idx in range(1, len(tracks)):
@@ -103,6 +135,9 @@ def build_model(playlists, get_track_groups, bpm_band_size=DEFAULT_BPM_BAND_SIZE
         'version': MODEL_VERSION,
         'created_at': datetime.now(timezone.utc).isoformat(),
         'bpm_band_size': bpm_band_size,
+        'included_tags': (
+            None if included_tags is None else sorted(included_tags)
+        ),
         'playlist_count': playlist_count,
         'track_count': track_count,
         'transition_counts': {
@@ -145,8 +180,9 @@ def get_scored_suggestion_locations(
         return []
 
     bpm_band_size = model.get('bpm_band_size', DEFAULT_BPM_BAND_SIZE)
+    included_tags = model.get('included_tags')
     context = tuple(
-        track_features(track, get_track_groups, bpm_band_size)
+        track_features(track, get_track_groups, bpm_band_size, included_tags)
         for track in previous_tracks[-MAX_CONTEXT_LENGTH:]
     )
 
@@ -239,8 +275,11 @@ def rerank_suggestions_for_diversity(
     strength = min(float(diversity), 100.0) / 100.0
     candidate_features = model.get('candidate_features', {})
     bpm_band_size = model.get('bpm_band_size', DEFAULT_BPM_BAND_SIZE)
+    included_tags = model.get('included_tags')
     recent_features = [
-        make_track_summary(track, get_track_groups, bpm_band_size)
+        make_track_summary(
+            track, get_track_groups, bpm_band_size, included_tags
+        )
         for track in previous_tracks
     ]
     highest_score = max(score for location, score in candidates) or 1

--- a/plugins/queuetrackpredictor/model.py
+++ b/plugins/queuetrackpredictor/model.py
@@ -25,6 +25,17 @@ TAG_BIAS_FACTORS = {
 }
 
 
+def get_model_tags(model):
+    included_tags = model.get('included_tags')
+    if included_tags is not None:
+        return set(included_tags)
+    return {
+        tag
+        for summary in model.get('candidate_features', {}).values()
+        for tag in summary.get('groups', ())
+    }
+
+
 def normalize_model_tuning(model, tuning):
     """Validate runtime tuning stored separately from a trained model."""
     if not isinstance(tuning, dict):
@@ -46,6 +57,17 @@ def normalize_model_tuning(model, tuning):
             tuning.get('bpm_bias', DEFAULT_BPM_BIAS)
         ),
     }
+
+
+def merge_model_tag_biases(model, stored_biases, model_biases):
+    """Update global biases exposed by one model without losing hidden tags."""
+    merged = normalize_model_tuning(
+        {}, {'tag_biases': stored_biases}
+    )['tag_biases']
+    for tag in get_model_tags(model):
+        merged.pop(tag, None)
+    merged.update(model_biases)
+    return normalize_model_tuning({}, {'tag_biases': merged})['tag_biases']
 
 
 def _get_track_location(track):

--- a/plugins/queuetrackpredictor/model.py
+++ b/plugins/queuetrackpredictor/model.py
@@ -12,6 +12,7 @@ MODEL_VERSION = 1
 DEFAULT_BPM_BAND_SIZE = 5
 MAX_CONTEXT_LENGTH = 3
 DEFAULT_MAX_SUGGESTIONS = 10
+DEFAULT_DIVERSITY = 50
 
 
 def _get_track_location(track):
@@ -219,6 +220,108 @@ def _candidate_similarity_score(last_feature, candidate_features):
 
 def _rank_counts(counts):
     return sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+
+
+def rerank_suggestions_for_diversity(
+    model,
+    scored_locations,
+    previous_tracks,
+    get_track_groups,
+    max_suggestions=DEFAULT_MAX_SUGGESTIONS,
+    diversity=DEFAULT_DIVERSITY,
+):
+    candidates = list(scored_locations)
+    if diversity <= 0:
+        return candidates[:max_suggestions]
+    if not candidates:
+        return []
+
+    strength = min(float(diversity), 100.0) / 100.0
+    candidate_features = model.get('candidate_features', {})
+    bpm_band_size = model.get('bpm_band_size', DEFAULT_BPM_BAND_SIZE)
+    recent_features = [
+        make_track_summary(track, get_track_groups, bpm_band_size)
+        for track in previous_tracks
+    ]
+    highest_score = max(score for location, score in candidates) or 1
+    selected = []
+
+    while candidates and len(selected) < max_suggestions:
+        best = max(
+            candidates,
+            key=lambda candidate: _diverse_candidate_score(
+                candidate,
+                candidate_features,
+                recent_features,
+                selected,
+                highest_score,
+                strength,
+            ),
+        )
+        candidates.remove(best)
+        selected.append(best)
+
+    return selected
+
+
+def _diverse_candidate_score(
+    candidate,
+    candidate_features,
+    recent_features,
+    selected,
+    highest_score,
+    strength,
+):
+    location, prediction_score = candidate
+    features = candidate_features.get(location, {})
+    relevance = float(prediction_score) / highest_score
+
+    if recent_features:
+        weights = list(range(1, len(recent_features) + 1))
+        recent_similarity = sum(
+            _summary_similarity(features, recent) * weight
+            for recent, weight in zip(recent_features, weights)
+        ) / sum(weights)
+    else:
+        recent_similarity = 0.0
+
+    selected_similarity = max(
+        (
+            _summary_similarity(features, candidate_features.get(selected_loc, {}))
+            for selected_loc, score in selected
+        ),
+        default=0.0,
+    )
+    novelty = 1.0 - ((recent_similarity * 0.65) + (selected_similarity * 0.35))
+    return ((1.0 - strength) * relevance) + (strength * novelty)
+
+
+def _summary_similarity(first, second):
+    first_groups = set(first.get('groups') or ())
+    second_groups = set(second.get('groups') or ())
+    all_groups = first_groups | second_groups
+    group_similarity = (
+        float(len(first_groups & second_groups)) / len(all_groups)
+        if all_groups
+        else 0.0
+    )
+
+    first_artist = first.get('artist') or ''
+    second_artist = second.get('artist') or ''
+    artist_similarity = float(bool(first_artist and first_artist == second_artist))
+
+    first_bpm = first.get('bpm_band')
+    second_bpm = second.get('bpm_band')
+    if first_bpm is None or second_bpm is None:
+        bpm_similarity = 0.0
+    else:
+        bpm_similarity = max(0.0, 1.0 - (abs(first_bpm - second_bpm) / 30.0))
+
+    return (
+        (group_similarity * 0.55)
+        + (artist_similarity * 0.25)
+        + (bpm_similarity * 0.20)
+    )
 
 
 def resolve_suggestion_tracks(

--- a/plugins/queuetrackpredictor/model.py
+++ b/plugins/queuetrackpredictor/model.py
@@ -5,6 +5,7 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
+import math
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 
@@ -13,6 +14,13 @@ DEFAULT_BPM_BAND_SIZE = 5
 MAX_CONTEXT_LENGTH = 3
 DEFAULT_MAX_SUGGESTIONS = 10
 DEFAULT_DIVERSITY = 50
+TAG_BIAS_FACTORS = {
+    -2: 0.5,
+    -1: 0.75,
+    0: 1.0,
+    1: 4.0 / 3.0,
+    2: 2.0,
+}
 
 
 def _get_track_location(track):
@@ -220,6 +228,11 @@ def get_scored_suggestion_locations(
     counts.update(
         _get_similar_candidate_counts(model, context[-1], candidate_features)
     )
+    counts = apply_tag_biases(
+        counts,
+        candidate_features or model.get('candidate_features', {}),
+        model.get('tag_biases', {}),
+    )
 
     seen = set()
     previous_locations = {_get_track_location(track) for track in previous_tracks}
@@ -244,6 +257,29 @@ def get_scored_suggestion_locations(
             break
 
     return suggestions
+
+
+def apply_tag_biases(counts, candidate_features, tag_biases):
+    """Apply bounded, non-stacking tag preferences to candidate scores."""
+    if not tag_biases:
+        return counts
+
+    adjusted = Counter()
+    for location, score in counts.items():
+        groups = candidate_features.get(location, {}).get('groups') or ()
+        factors = [
+            TAG_BIAS_FACTORS.get(tag_biases.get(tag), 1.0)
+            for tag in groups
+            if tag_biases.get(tag) in TAG_BIAS_FACTORS
+            and tag_biases.get(tag) != 0
+        ]
+        if factors:
+            # A geometric mean lets opposing preferences balance each other and
+            # prevents tracks with many tags from receiving an accidental boost.
+            factor = math.prod(factors) ** (1.0 / len(factors))
+            score *= factor
+        adjusted[location] = score
+    return adjusted
 
 
 def _get_similar_candidate_counts(

--- a/plugins/queuetrackpredictor/model.py
+++ b/plugins/queuetrackpredictor/model.py
@@ -1,0 +1,215 @@
+# Copyright (C) 2026 Exaile contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+
+MODEL_VERSION = 1
+DEFAULT_BPM_BAND_SIZE = 5
+MAX_CONTEXT_LENGTH = 3
+DEFAULT_MAX_SUGGESTIONS = 10
+
+
+def _get_track_location(track):
+    try:
+        return track.get_loc_for_io()
+    except Exception:
+        return None
+
+
+def _get_track_bpm(track):
+    try:
+        bpm = track.get_tag_raw('bpm', True)
+    except Exception:
+        return None
+
+    if bpm in (None, ''):
+        return None
+
+    try:
+        return int(round(float(bpm)))
+    except (TypeError, ValueError):
+        return None
+
+
+def bucket_bpm(bpm, band_size=DEFAULT_BPM_BAND_SIZE):
+    if bpm is None:
+        return None
+    if band_size <= 0:
+        return bpm
+    return bpm - (bpm % band_size)
+
+
+def track_features(track, get_track_groups, bpm_band_size=DEFAULT_BPM_BAND_SIZE):
+    groups = get_track_groups(track) or []
+    return (
+        tuple(sorted(groups)),
+        bucket_bpm(_get_track_bpm(track), bpm_band_size),
+    )
+
+
+def make_track_summary(track, get_track_groups, bpm_band_size=DEFAULT_BPM_BAND_SIZE):
+    return {
+        'groups': track_features(track, get_track_groups, bpm_band_size)[0],
+        'bpm_band': track_features(track, get_track_groups, bpm_band_size)[1],
+        'title': _get_track_display(track, 'title'),
+        'artist': _get_track_display(track, 'artist'),
+    }
+
+
+def _get_track_display(track, tag):
+    try:
+        return track.get_tag_display(tag)
+    except Exception:
+        return ''
+
+
+def build_model(playlists, get_track_groups, bpm_band_size=DEFAULT_BPM_BAND_SIZE):
+    transition_counts = defaultdict(Counter)
+    candidate_features = {}
+    playlist_count = 0
+    track_count = 0
+
+    for playlist in playlists:
+        tracks = list(playlist)
+        playlist_count += 1
+        track_count += len(tracks)
+
+        feature_cache = [
+            track_features(track, get_track_groups, bpm_band_size) for track in tracks
+        ]
+
+        for track in tracks:
+            loc = _get_track_location(track)
+            if loc is not None and loc not in candidate_features:
+                candidate_features[loc] = make_track_summary(
+                    track, get_track_groups, bpm_band_size
+                )
+
+        for idx in range(1, len(tracks)):
+            next_loc = _get_track_location(tracks[idx])
+            if next_loc is None:
+                continue
+            for context_length in range(1, min(MAX_CONTEXT_LENGTH, idx) + 1):
+                context = tuple(feature_cache[idx - context_length : idx])
+                transition_counts[context][next_loc] += 1
+
+    return {
+        'version': MODEL_VERSION,
+        'created_at': datetime.now(timezone.utc).isoformat(),
+        'bpm_band_size': bpm_band_size,
+        'playlist_count': playlist_count,
+        'track_count': track_count,
+        'transition_counts': {
+            context: dict(counts) for context, counts in transition_counts.items()
+        },
+        'candidate_features': candidate_features,
+    }
+
+
+def get_suggestion_locations(
+    model,
+    previous_tracks,
+    get_track_groups,
+    max_suggestions=DEFAULT_MAX_SUGGESTIONS,
+    excluded_locations=None,
+):
+    if model.get('version') != MODEL_VERSION:
+        raise ValueError("Unsupported queue predictor model version")
+
+    if len(previous_tracks) < 1:
+        return []
+
+    bpm_band_size = model.get('bpm_band_size', DEFAULT_BPM_BAND_SIZE)
+    context = tuple(
+        track_features(track, get_track_groups, bpm_band_size)
+        for track in previous_tracks[-MAX_CONTEXT_LENGTH:]
+    )
+
+    transition_counts = model.get('transition_counts', {})
+    counts = Counter()
+    for suffix_length in range(len(context) - 1, 0, -1):
+        suffix = context[-suffix_length:]
+        weight = suffix_length + 1
+        counts.update(
+            {
+                loc: count * weight
+                for loc, count in transition_counts.get(suffix, {}).items()
+            }
+        )
+    counts.update(_get_similar_candidate_counts(model, context[-1]))
+
+    seen = set()
+    previous_locations = {_get_track_location(track) for track in previous_tracks}
+    previous_locations.discard(None)
+    excluded_locations = set(excluded_locations or [])
+    if len(context) > 1:
+        excluded_locations.update(transition_counts.get(context, {}).keys())
+    suggestions = []
+
+    for loc, _count in _rank_counts(counts):
+        if loc in excluded_locations:
+            continue
+        if loc in previous_locations:
+            continue
+        if loc in seen:
+            continue
+        seen.add(loc)
+        suggestions.append(loc)
+        if len(suggestions) >= max_suggestions:
+            break
+
+    return suggestions
+
+
+def _get_similar_candidate_counts(model, last_feature):
+    candidate_features = model.get('candidate_features', {})
+    global_counts = Counter()
+    for candidates in model.get('transition_counts', {}).values():
+        global_counts.update(candidates)
+
+    counts = Counter()
+    for loc, count in global_counts.items():
+        features = candidate_features.get(loc)
+        if features is None:
+            continue
+        score = _candidate_similarity_score(last_feature, features)
+        if score > 0:
+            counts[loc] = (score * 1000) + count
+    return counts
+
+
+def _candidate_similarity_score(last_feature, candidate_features):
+    last_groups, last_bpm_band = last_feature
+    candidate_groups = set(candidate_features.get('groups') or ())
+    candidate_bpm_band = candidate_features.get('bpm_band')
+
+    score = len(set(last_groups) & candidate_groups) * 4
+    if (
+        last_bpm_band is not None
+        and candidate_bpm_band is not None
+        and abs(last_bpm_band - candidate_bpm_band) <= 10
+    ):
+        score += 1
+    return score
+
+
+def _rank_counts(counts):
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+
+
+def resolve_suggestion_tracks(
+    collection, locations, max_suggestions=DEFAULT_MAX_SUGGESTIONS
+):
+    tracks = []
+    for loc in locations:
+        track = collection.get_track_by_loc(loc)
+        if track is not None:
+            tracks.append(track)
+        if len(tracks) >= max_suggestions:
+            break
+    return tracks

--- a/plugins/queuetrackpredictor/model.py
+++ b/plugins/queuetrackpredictor/model.py
@@ -77,6 +77,23 @@ def make_track_summary(
     }
 
 
+def make_candidate_features(
+    tracks,
+    get_track_groups,
+    bpm_band_size=DEFAULT_BPM_BAND_SIZE,
+    included_tags=None,
+):
+    """Build the runtime feature lookup used to score candidate tracks."""
+    candidates = {}
+    for track in tracks:
+        loc = _get_track_location(track)
+        if loc is not None and loc not in candidates:
+            candidates[loc] = make_track_summary(
+                track, get_track_groups, bpm_band_size, included_tags
+            )
+    return candidates
+
+
 def _get_track_display(track, tag):
     try:
         return track.get_tag_display(tag)
@@ -153,6 +170,7 @@ def get_suggestion_locations(
     get_track_groups,
     max_suggestions=DEFAULT_MAX_SUGGESTIONS,
     excluded_locations=None,
+    candidate_features=None,
 ):
     return [
         location
@@ -162,6 +180,7 @@ def get_suggestion_locations(
             get_track_groups,
             max_suggestions,
             excluded_locations,
+            candidate_features,
         )
     ]
 
@@ -172,6 +191,7 @@ def get_scored_suggestion_locations(
     get_track_groups,
     max_suggestions=DEFAULT_MAX_SUGGESTIONS,
     excluded_locations=None,
+    candidate_features=None,
 ):
     if model.get('version') != MODEL_VERSION:
         raise ValueError("Unsupported queue predictor model version")
@@ -197,7 +217,9 @@ def get_scored_suggestion_locations(
                 for loc, count in transition_counts.get(suffix, {}).items()
             }
         )
-    counts.update(_get_similar_candidate_counts(model, context[-1]))
+    counts.update(
+        _get_similar_candidate_counts(model, context[-1], candidate_features)
+    )
 
     seen = set()
     previous_locations = {_get_track_location(track) for track in previous_tracks}
@@ -208,6 +230,8 @@ def get_scored_suggestion_locations(
     suggestions = []
 
     for loc, score in _rank_counts(counts):
+        if candidate_features is not None and loc not in candidate_features:
+            continue
         if loc in excluded_locations:
             continue
         if loc in previous_locations:
@@ -222,20 +246,27 @@ def get_scored_suggestion_locations(
     return suggestions
 
 
-def _get_similar_candidate_counts(model, last_feature):
-    candidate_features = model.get('candidate_features', {})
+def _get_similar_candidate_counts(
+    model, last_feature, candidate_features=None
+):
+    use_all_candidates = candidate_features is not None
+    if candidate_features is None:
+        candidate_features = model.get('candidate_features', {})
     global_counts = Counter()
     for candidates in model.get('transition_counts', {}).values():
         global_counts.update(candidates)
 
     counts = Counter()
-    for loc, count in global_counts.items():
+    candidate_locations = (
+        candidate_features if use_all_candidates else global_counts
+    )
+    for loc in candidate_locations:
         features = candidate_features.get(loc)
         if features is None:
             continue
         score = _candidate_similarity_score(last_feature, features)
         if score > 0:
-            counts[loc] = (score * 1000) + count
+            counts[loc] = (score * 1000) + global_counts.get(loc, 0)
     return counts
 
 
@@ -265,6 +296,7 @@ def rerank_suggestions_for_diversity(
     get_track_groups,
     max_suggestions=DEFAULT_MAX_SUGGESTIONS,
     diversity=DEFAULT_DIVERSITY,
+    candidate_features=None,
 ):
     candidates = list(scored_locations)
     if diversity <= 0:
@@ -273,7 +305,8 @@ def rerank_suggestions_for_diversity(
         return []
 
     strength = min(float(diversity), 100.0) / 100.0
-    candidate_features = model.get('candidate_features', {})
+    if candidate_features is None:
+        candidate_features = model.get('candidate_features', {})
     bpm_band_size = model.get('bpm_band_size', DEFAULT_BPM_BAND_SIZE)
     included_tags = model.get('included_tags')
     recent_features = [

--- a/plugins/queuetrackpredictor/model.py
+++ b/plugins/queuetrackpredictor/model.py
@@ -25,6 +25,29 @@ TAG_BIAS_FACTORS = {
 }
 
 
+def normalize_model_tuning(model, tuning):
+    """Validate runtime tuning stored separately from a trained model."""
+    if not isinstance(tuning, dict):
+        tuning = {}
+    raw_tag_biases = tuning.get('tag_biases', {})
+    if not isinstance(raw_tag_biases, dict):
+        raw_tag_biases = {}
+    included_tags = model.get('included_tags')
+    tag_biases = {
+        tag: int(bias)
+        for tag, bias in raw_tag_biases.items()
+        if bias in TAG_BIAS_FACTORS
+        and bias != 0
+        and (included_tags is None or tag in included_tags)
+    }
+    return {
+        'tag_biases': tag_biases,
+        'bpm_bias': clamp_bpm_bias(
+            tuning.get('bpm_bias', DEFAULT_BPM_BIAS)
+        ),
+    }
+
+
 def _get_track_location(track):
     try:
         return track.get_loc_for_io()

--- a/plugins/queuetrackpredictor/model_store.py
+++ b/plugins/queuetrackpredictor/model_store.py
@@ -58,6 +58,12 @@ def add_model(catalog, name, model):
     catalog['selected'] = name
 
 
+def replace_model(catalog, name, model):
+    if name not in catalog['models']:
+        raise KeyError(name)
+    catalog['models'][name] = model
+
+
 def remove_model(catalog, name):
     if name not in catalog['models']:
         raise KeyError(name)

--- a/plugins/queuetrackpredictor/model_store.py
+++ b/plugins/queuetrackpredictor/model_store.py
@@ -17,6 +17,10 @@ def empty_catalog():
     return {'version': CATALOG_VERSION, 'selected': None, 'models': {}}
 
 
+def model_names(catalog):
+    return sorted(catalog['models'], key=lambda name: (name.casefold(), name))
+
+
 def load_catalog(path):
     try:
         with open(path, 'rb') as catalog_file:
@@ -29,7 +33,7 @@ def load_catalog(path):
     if not isinstance(catalog.get('models'), dict):
         raise ValueError('Invalid queue predictor catalog')
     if catalog.get('selected') not in catalog['models']:
-        catalog['selected'] = next(iter(sorted(catalog['models'])), None)
+        catalog['selected'] = next(iter(model_names(catalog)), None)
     return catalog
 
 
@@ -69,7 +73,7 @@ def remove_model(catalog, name):
         raise KeyError(name)
     del catalog['models'][name]
     if catalog.get('selected') == name:
-        catalog['selected'] = next(iter(sorted(catalog['models'])), None)
+        catalog['selected'] = next(iter(model_names(catalog)), None)
 
 
 def rename_model(catalog, old_name, new_name):

--- a/plugins/queuetrackpredictor/model_store.py
+++ b/plugins/queuetrackpredictor/model_store.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2026 Exaile contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+
+import os
+import pickle
+import tempfile
+
+
+CATALOG_VERSION = 1
+
+
+def empty_catalog():
+    return {'version': CATALOG_VERSION, 'selected': None, 'models': {}}
+
+
+def load_catalog(path):
+    try:
+        with open(path, 'rb') as catalog_file:
+            catalog = pickle.load(catalog_file)
+    except IOError:
+        catalog = empty_catalog()
+
+    if catalog.get('version') != CATALOG_VERSION:
+        raise ValueError('Unsupported queue predictor catalog version')
+    if not isinstance(catalog.get('models'), dict):
+        raise ValueError('Invalid queue predictor catalog')
+    if catalog.get('selected') not in catalog['models']:
+        catalog['selected'] = next(iter(sorted(catalog['models'])), None)
+    return catalog
+
+
+def save_catalog(path, catalog):
+    directory = os.path.dirname(path)
+    if directory and not os.path.exists(directory):
+        os.makedirs(directory)
+    temporary = tempfile.NamedTemporaryFile(dir=directory, delete=False)
+    try:
+        with temporary:
+            pickle.dump(catalog, temporary, protocol=2)
+        os.replace(temporary.name, path)
+    except Exception:
+        try:
+            os.unlink(temporary.name)
+        except OSError:
+            pass
+        raise
+
+
+def add_model(catalog, name, model):
+    name = _validated_name(name)
+    if name in catalog['models']:
+        raise ValueError('A model with that name already exists')
+    catalog['models'][name] = model
+    catalog['selected'] = name
+
+
+def remove_model(catalog, name):
+    if name not in catalog['models']:
+        raise KeyError(name)
+    del catalog['models'][name]
+    if catalog.get('selected') == name:
+        catalog['selected'] = next(iter(sorted(catalog['models'])), None)
+
+
+def rename_model(catalog, old_name, new_name):
+    new_name = _validated_name(new_name)
+    if old_name not in catalog['models']:
+        raise KeyError(old_name)
+    if new_name != old_name and new_name in catalog['models']:
+        raise ValueError('A model with that name already exists')
+    if new_name == old_name:
+        return
+    catalog['models'][new_name] = catalog['models'].pop(old_name)
+    if catalog.get('selected') == old_name:
+        catalog['selected'] = new_name
+
+
+def select_model(catalog, name):
+    if name not in catalog['models']:
+        raise KeyError(name)
+    catalog['selected'] = name
+
+
+def _validated_name(name):
+    name = name.strip()
+    if not name:
+        raise ValueError('Model name cannot be empty')
+    return name

--- a/plugins/queuetrackpredictor/preferences.py
+++ b/plugins/queuetrackpredictor/preferences.py
@@ -23,6 +23,7 @@ EXCLUDED_TAGS_OPTION = 'plugin/queuetrackpredictor/excluded_tags'
 LAST_MODEL_OPTION = 'plugin/queuetrackpredictor/last_model'
 TAG_BIASES_OPTION = 'plugin/queuetrackpredictor/tag_biases'
 BPM_BIAS_OPTION = 'plugin/queuetrackpredictor/bpm_bias'
+SUGGESTION_SOURCE_OPTION = 'plugin/queuetrackpredictor/suggestion_source'
 
 
 class MaxSuggestionsPreference(widgets.SpinPreference):

--- a/plugins/queuetrackpredictor/preferences.py
+++ b/plugins/queuetrackpredictor/preferences.py
@@ -21,7 +21,8 @@ DIVERSITY_OPTION = 'plugin/queuetrackpredictor/diversity'
 DEFAULT_DIVERSITY = 50
 EXCLUDED_TAGS_OPTION = 'plugin/queuetrackpredictor/excluded_tags'
 LAST_MODEL_OPTION = 'plugin/queuetrackpredictor/last_model'
-MODEL_TUNING_OPTION = 'plugin/queuetrackpredictor/model_tuning'
+TAG_BIASES_OPTION = 'plugin/queuetrackpredictor/tag_biases'
+BPM_BIAS_OPTION = 'plugin/queuetrackpredictor/bpm_bias'
 
 
 class MaxSuggestionsPreference(widgets.SpinPreference):

--- a/plugins/queuetrackpredictor/preferences.py
+++ b/plugins/queuetrackpredictor/preferences.py
@@ -19,6 +19,7 @@ MAX_SUGGESTIONS_OPTION = 'plugin/queuetrackpredictor/max_suggestions'
 DEFAULT_MAX_SUGGESTIONS = 10
 DIVERSITY_OPTION = 'plugin/queuetrackpredictor/diversity'
 DEFAULT_DIVERSITY = 50
+EXCLUDED_TAGS_OPTION = 'plugin/queuetrackpredictor/excluded_tags'
 
 
 class MaxSuggestionsPreference(widgets.SpinPreference):

--- a/plugins/queuetrackpredictor/preferences.py
+++ b/plugins/queuetrackpredictor/preferences.py
@@ -17,8 +17,15 @@ ui = os.path.join(basedir, 'preferences.ui')
 
 MAX_SUGGESTIONS_OPTION = 'plugin/queuetrackpredictor/max_suggestions'
 DEFAULT_MAX_SUGGESTIONS = 10
+DIVERSITY_OPTION = 'plugin/queuetrackpredictor/diversity'
+DEFAULT_DIVERSITY = 50
 
 
 class MaxSuggestionsPreference(widgets.SpinPreference):
     default = DEFAULT_MAX_SUGGESTIONS
     name = MAX_SUGGESTIONS_OPTION
+
+
+class DiversityPreference(widgets.SpinPreference):
+    default = DEFAULT_DIVERSITY
+    name = DIVERSITY_OPTION

--- a/plugins/queuetrackpredictor/preferences.py
+++ b/plugins/queuetrackpredictor/preferences.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2026 Exaile contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+
+import os
+
+from xl.nls import gettext as _
+from xlgui.preferences import widgets
+
+
+name = _('Queue Track Predictor')
+basedir = os.path.dirname(os.path.realpath(__file__))
+ui = os.path.join(basedir, 'preferences.ui')
+
+MAX_SUGGESTIONS_OPTION = 'plugin/queuetrackpredictor/max_suggestions'
+DEFAULT_MAX_SUGGESTIONS = 10
+
+
+class MaxSuggestionsPreference(widgets.SpinPreference):
+    default = DEFAULT_MAX_SUGGESTIONS
+    name = MAX_SUGGESTIONS_OPTION

--- a/plugins/queuetrackpredictor/preferences.py
+++ b/plugins/queuetrackpredictor/preferences.py
@@ -20,6 +20,8 @@ DEFAULT_MAX_SUGGESTIONS = 10
 DIVERSITY_OPTION = 'plugin/queuetrackpredictor/diversity'
 DEFAULT_DIVERSITY = 50
 EXCLUDED_TAGS_OPTION = 'plugin/queuetrackpredictor/excluded_tags'
+LAST_MODEL_OPTION = 'plugin/queuetrackpredictor/last_model'
+MODEL_TUNING_OPTION = 'plugin/queuetrackpredictor/model_tuning'
 
 
 class MaxSuggestionsPreference(widgets.SpinPreference):

--- a/plugins/queuetrackpredictor/preferences.ui
+++ b/plugins/queuetrackpredictor/preferences.ui
@@ -7,6 +7,12 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="diversity_adjustment">
+    <property name="lower">0</property>
+    <property name="upper">100</property>
+    <property name="step_increment">5</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkGrid" id="preferences_pane">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -37,6 +43,34 @@
       <packing>
         <property name="left_attach">1</property>
         <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="diversity_label">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Diversity:</property>
+        <property name="tooltip_text" translatable="yes">Higher values favor suggestions that differ from recent tracks and from each other.</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSpinButton" id="plugin/queuetrackpredictor/diversity">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">start</property>
+        <property name="adjustment">diversity_adjustment</property>
+        <property name="numeric">True</property>
+        <property name="xalign">1</property>
+        <property name="tooltip_text" translatable="yes">0 keeps prediction order; 100 maximizes novelty among plausible candidates.</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">1</property>
       </packing>
     </child>
   </object>

--- a/plugins/queuetrackpredictor/preferences.ui
+++ b/plugins/queuetrackpredictor/preferences.ui
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="3.10"/>
+  <object class="GtkAdjustment" id="max_suggestions_adjustment">
+    <property name="lower">1</property>
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkGrid" id="preferences_pane">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="valign">start</property>
+    <property name="row_spacing">4</property>
+    <property name="column_spacing">8</property>
+    <child>
+      <object class="GtkLabel" id="max_suggestions_label">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Number of suggestions:</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSpinButton" id="plugin/queuetrackpredictor/max_suggestions">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">start</property>
+        <property name="adjustment">max_suggestions_adjustment</property>
+        <property name="numeric">True</property>
+        <property name="xalign">1</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/tests/plugins/test_queuetrackpredictor_model.py
+++ b/tests/plugins/test_queuetrackpredictor_model.py
@@ -1,0 +1,187 @@
+import importlib.util
+import os
+
+
+MODEL_PATH = os.path.join(
+    os.path.dirname(__file__),
+    '..',
+    '..',
+    'plugins',
+    'queuetrackpredictor',
+    'model.py',
+)
+SPEC = importlib.util.spec_from_file_location('queuetrackpredictor_model', MODEL_PATH)
+model = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(model)
+
+
+class FakeTrack:
+    def __init__(self, loc, groups=None, bpm=None, title=None, artist=None):
+        self.loc = loc
+        self.groups = set(groups or [])
+        self.bpm = bpm
+        self.title = title or loc
+        self.artist = artist or ''
+
+    def get_loc_for_io(self):
+        return self.loc
+
+    def get_tag_raw(self, tag, join=False):
+        if tag == 'bpm':
+            return self.bpm
+        return None
+
+    def get_tag_display(self, tag):
+        if tag == 'title':
+            return self.title
+        if tag == 'artist':
+            return self.artist
+        return ''
+
+
+def get_groups(track):
+    return track.groups
+
+
+def test_track_features_sort_groups_and_bucket_bpm():
+    track = FakeTrack('a', groups={'swing', 'blues'}, bpm='123')
+
+    assert model.track_features(track, get_groups) == (('blues', 'swing'), 120)
+
+
+def test_build_model_counts_feature_transitions():
+    a = FakeTrack('a', groups={'warm'}, bpm=120)
+    b = FakeTrack('b', groups={'cool'}, bpm=122)
+    c = FakeTrack('c', groups={'hot'}, bpm=130)
+    d = FakeTrack('d', groups={'hot'}, bpm=131)
+    e = FakeTrack('e', groups={'blue'}, bpm=100)
+
+    trained = model.build_model([[a, b, c, e], [a, b, c, e], [a, b, d]], get_groups)
+    one_track_context = (model.track_features(b, get_groups),)
+    two_track_context = (
+        model.track_features(a, get_groups),
+        model.track_features(b, get_groups),
+    )
+    three_track_context = (
+        model.track_features(a, get_groups),
+        model.track_features(b, get_groups),
+        model.track_features(c, get_groups),
+    )
+
+    assert trained['transition_counts'][one_track_context] == {'c': 2, 'd': 1}
+    assert trained['transition_counts'][two_track_context] == {'c': 2, 'd': 1}
+    assert trained['transition_counts'][three_track_context] == {'e': 2}
+    assert trained['playlist_count'] == 3
+    assert trained['track_count'] == 11
+
+
+def test_get_suggestion_locations_uses_broad_feature_matches_and_limits():
+    a = FakeTrack('a', groups={'warm'}, bpm=120)
+    b = FakeTrack('b', groups={'cool'}, bpm=122)
+    c = FakeTrack('c', groups={'hot'}, bpm=130)
+    d = FakeTrack('d', groups={'hot'}, bpm=131)
+    e = FakeTrack('e', groups={'hot'}, bpm=132)
+    x = FakeTrack('x', groups={'other'}, bpm=90)
+    y = FakeTrack('y', groups={'hot'}, bpm=135)
+
+    trained = model.build_model(
+        [[a, b, d], [a, b, c], [a, b, c], [a, b, e]], get_groups
+    )
+
+    assert model.get_suggestion_locations(
+        trained, [x, y], get_groups, max_suggestions=2
+    ) == ['c', 'd']
+
+
+def test_get_suggestion_locations_returns_empty_without_context_match():
+    a = FakeTrack('a', groups={'warm'}, bpm=120)
+    b = FakeTrack('b', groups={'cool'}, bpm=122)
+    c = FakeTrack('c', groups={'hot'}, bpm=130)
+    x = FakeTrack('x', groups={'other'}, bpm=90)
+    y = FakeTrack('y', groups={'other'}, bpm=95)
+
+    trained = model.build_model([[a, b, c]], get_groups)
+
+    assert model.get_suggestion_locations(trained, [x, y], get_groups) == []
+
+
+def test_get_suggestion_locations_uses_one_track_context_at_playlist_start():
+    a = FakeTrack('a', groups={'warm'}, bpm=120)
+    b = FakeTrack('b', groups={'cool'}, bpm=122)
+    c = FakeTrack('c', groups={'hot'}, bpm=130)
+    d = FakeTrack('d', groups={'cool'}, bpm=124)
+    e = FakeTrack('e', groups={'blue'}, bpm=100)
+
+    trained = model.build_model([[a, b, c], [d, e, c]], get_groups)
+
+    assert model.get_suggestion_locations(trained, [b], get_groups) == ['c']
+
+
+def test_get_suggestion_locations_falls_back_to_similar_candidates():
+    a = FakeTrack('a', groups={'warm'}, bpm=120)
+    b = FakeTrack('b', groups={'cool'}, bpm=122)
+    c = FakeTrack('c', groups={'hot'}, bpm=130)
+    x = FakeTrack('x', groups={'other'}, bpm=90)
+    y = FakeTrack('y', groups={'hot'}, bpm=136)
+
+    trained = model.build_model([[a, b, c]], get_groups)
+
+    assert model.get_suggestion_locations(trained, [x, y], get_groups) == ['c']
+
+
+def test_get_suggestion_locations_does_not_use_exact_pair_match():
+    a = FakeTrack('a', groups={'warm'}, bpm=120)
+    b = FakeTrack('b', groups={'cool'}, bpm=122)
+    c = FakeTrack('c', groups={'hot'}, bpm=130)
+    d = FakeTrack('d', groups={'warm'}, bpm=118)
+    e = FakeTrack('e', groups={'other'}, bpm=90)
+    f = FakeTrack('f', groups={'cool'}, bpm=126)
+
+    trained = model.build_model([[a, b, c], [d, e, f]], get_groups)
+
+    assert model.get_suggestion_locations(trained, [a, b], get_groups) == ['f']
+
+
+def test_get_suggestion_locations_does_not_use_exact_three_track_match():
+    a = FakeTrack('a', groups={'warm'}, bpm=120)
+    b = FakeTrack('b', groups={'cool'}, bpm=122)
+    c = FakeTrack('c', groups={'blue'}, bpm=100)
+    d = FakeTrack('d', groups={'hot'}, bpm=130)
+    e = FakeTrack('e', groups={'other'}, bpm=90)
+    f = FakeTrack('f', groups={'cool'}, bpm=126)
+
+    trained = model.build_model([[a, b, c, d], [e, b, c, f]], get_groups)
+
+    assert model.get_suggestion_locations(trained, [a, b, c], get_groups) == ['f']
+
+
+def test_get_suggestion_locations_can_exclude_known_next_track():
+    a = FakeTrack('a', groups={'warm'}, bpm=120)
+    b = FakeTrack('b', groups={'cool'}, bpm=122)
+    c = FakeTrack('c', groups={'hot'}, bpm=130)
+    d = FakeTrack('d', groups={'cool'}, bpm=124)
+    e = FakeTrack('e', groups={'warm'}, bpm=118)
+    f = FakeTrack('f', groups={'cool'}, bpm=126)
+
+    trained = model.build_model([[a, b, c], [d, e, f]], get_groups)
+
+    assert model.get_suggestion_locations(
+        trained, [a, b], get_groups, max_suggestions=1, excluded_locations={'c'}
+    ) == ['f']
+
+
+def test_invalid_bpm_is_bucketed_as_none():
+    track = FakeTrack('a', groups={'warm'}, bpm='not-a-number')
+
+    assert model.track_features(track, get_groups) == (('warm',), None)
+
+
+def test_resolve_suggestion_tracks_skips_missing_locations():
+    a = FakeTrack('a')
+    c = FakeTrack('c')
+
+    class Collection:
+        def get_track_by_loc(self, loc):
+            return {'a': a, 'c': c}.get(loc)
+
+    assert model.resolve_suggestion_tracks(Collection(), ['a', 'b', 'c']) == [a, c]

--- a/tests/plugins/test_queuetrackpredictor_model.py
+++ b/tests/plugins/test_queuetrackpredictor_model.py
@@ -174,6 +174,55 @@ def test_get_suggestion_locations_can_exclude_known_next_track():
     ) == ['f']
 
 
+def test_diversity_reranking_can_promote_novel_candidates():
+    recent = FakeTrack('recent', groups={'house'}, bpm=125, artist='Repeated')
+    trained = {
+        'bpm_band_size': 5,
+        'candidate_features': {
+            'same': {
+                'groups': ('house',),
+                'bpm_band': 125,
+                'artist': 'Repeated',
+            },
+            'similar': {
+                'groups': ('house',),
+                'bpm_band': 125,
+                'artist': 'Other',
+            },
+            'novel': {
+                'groups': ('disco',),
+                'bpm_band': 115,
+                'artist': 'New',
+            },
+        },
+    }
+    candidates = [('same', 100), ('similar', 95), ('novel', 80)]
+
+    assert model.rerank_suggestions_for_diversity(
+        trained, candidates, [recent], get_groups, max_suggestions=3, diversity=0
+    ) == candidates
+    assert model.rerank_suggestions_for_diversity(
+        trained, candidates, [recent], get_groups, max_suggestions=3, diversity=100
+    )[0][0] == 'novel'
+
+
+def test_diversity_reranking_varies_the_result_list():
+    trained = {
+        'candidate_features': {
+            'house-1': {'groups': ('house',), 'bpm_band': 125, 'artist': 'One'},
+            'house-2': {'groups': ('house',), 'bpm_band': 125, 'artist': 'Two'},
+            'disco': {'groups': ('disco',), 'bpm_band': 115, 'artist': 'Three'},
+        }
+    }
+    candidates = [('house-1', 100), ('house-2', 99), ('disco', 90)]
+
+    reranked = model.rerank_suggestions_for_diversity(
+        trained, candidates, [], get_groups, max_suggestions=2, diversity=60
+    )
+
+    assert [location for location, score in reranked] == ['house-1', 'disco']
+
+
 def test_invalid_bpm_is_bucketed_as_none():
     track = FakeTrack('a', groups={'warm'}, bpm='not-a-number')
 

--- a/tests/plugins/test_queuetrackpredictor_model.py
+++ b/tests/plugins/test_queuetrackpredictor_model.py
@@ -304,6 +304,16 @@ def test_model_tuning_is_normalized_separately_from_trained_model():
     ) == {'tag_biases': {'keep': 2}, 'bpm_bias': -10}
 
 
+def test_model_tag_bias_update_preserves_tags_hidden_by_model():
+    trained = {'included_tags': ['shared', 'model-a']}
+
+    assert model.merge_model_tag_biases(
+        trained,
+        {'shared': 2, 'model-a': -2, 'model-b': -1},
+        {'model-a': 1},
+    ) == {'model-a': 1, 'model-b': -1}
+
+
 def test_make_candidate_features_uses_model_feature_settings():
     track = FakeTrack(
         'collection-only',

--- a/tests/plugins/test_queuetrackpredictor_model.py
+++ b/tests/plugins/test_queuetrackpredictor_model.py
@@ -160,6 +160,71 @@ def test_get_suggestion_locations_falls_back_to_similar_candidates():
     assert model.get_suggestion_locations(trained, [x, y], get_groups) == ['c']
 
 
+def test_get_suggestion_locations_can_score_untrained_collection_track():
+    a = FakeTrack('a', groups={'warm'}, bpm=120)
+    b = FakeTrack('b', groups={'cool'}, bpm=122)
+    c = FakeTrack('c', groups={'blue'}, bpm=100)
+    recent = FakeTrack('recent', groups={'hot'}, bpm=136)
+    collection_track = FakeTrack(
+        'collection-only', groups={'hot'}, bpm=134, artist='New Artist'
+    )
+    trained = model.build_model([[a, b, c]], get_groups)
+    candidate_features = model.make_candidate_features(
+        [collection_track], get_groups
+    )
+
+    assert 'collection-only' not in trained['candidate_features']
+    assert model.get_suggestion_locations(
+        trained,
+        [recent],
+        get_groups,
+        candidate_features=candidate_features,
+    ) == ['collection-only']
+
+
+def test_make_candidate_features_uses_model_feature_settings():
+    track = FakeTrack(
+        'collection-only',
+        groups={'keep', 'ignore'},
+        bpm=127,
+        title='Collection track',
+        artist='Artist',
+    )
+
+    candidates = model.make_candidate_features(
+        [track], get_groups, bpm_band_size=10, included_tags=['keep']
+    )
+
+    assert candidates['collection-only'] == {
+        'groups': ('keep',),
+        'bpm_band': 120,
+        'title': 'Collection track',
+        'artist': 'Artist',
+    }
+
+
+def test_collection_candidates_exclude_trained_track_missing_from_collection():
+    a = FakeTrack('a', groups={'warm'}, bpm=120)
+    b = FakeTrack('b', groups={'cool'}, bpm=122)
+    trained_only = FakeTrack('trained-only', groups={'hot'}, bpm=130)
+    collection_only = FakeTrack('collection-only', groups={'hot'}, bpm=132)
+    context_start = FakeTrack('context-start', groups={'other'}, bpm=90)
+    trained = model.build_model([[a, b, trained_only]], get_groups)
+    candidate_features = model.make_candidate_features(
+        [a, b, collection_only], get_groups
+    )
+
+    suggestions = model.get_suggestion_locations(
+        trained,
+        [context_start, b],
+        get_groups,
+        candidate_features=candidate_features,
+    )
+
+    assert 'collection-only' in suggestions
+    assert 'trained-only' not in suggestions
+
+
 def test_get_suggestion_locations_does_not_use_exact_pair_match():
     a = FakeTrack('a', groups={'warm'}, bpm=120)
     b = FakeTrack('b', groups={'cool'}, bpm=122)
@@ -248,6 +313,28 @@ def test_diversity_reranking_varies_the_result_list():
     )
 
     assert [location for location, score in reranked] == ['house-1', 'disco']
+
+
+def test_diversity_reranking_uses_collection_candidate_features():
+    trained = {'candidate_features': {}}
+    candidates = [('similar', 100), ('novel', 90)]
+    recent = FakeTrack('recent', groups={'house'}, bpm=125, artist='One')
+    candidate_features = {
+        'similar': {'groups': ('house',), 'bpm_band': 125, 'artist': 'One'},
+        'novel': {'groups': ('disco',), 'bpm_band': 100, 'artist': 'Two'},
+    }
+
+    reranked = model.rerank_suggestions_for_diversity(
+        trained,
+        candidates,
+        [recent],
+        get_groups,
+        max_suggestions=2,
+        diversity=100,
+        candidate_features=candidate_features,
+    )
+
+    assert reranked[0][0] == 'novel'
 
 
 def test_invalid_bpm_is_bucketed_as_none():

--- a/tests/plugins/test_queuetrackpredictor_model.py
+++ b/tests/plugins/test_queuetrackpredictor_model.py
@@ -284,6 +284,26 @@ def test_clamp_bpm_bias_handles_out_of_range_and_invalid_values():
     assert model.clamp_bpm_bias(float('inf')) == 0
 
 
+def test_model_tuning_is_normalized_separately_from_trained_model():
+    trained = {
+        'included_tags': ['keep'],
+        'tag_biases': {'legacy': 2},
+        'bpm_bias': 30,
+    }
+
+    assert model.normalize_model_tuning(trained, {}) == {
+        'tag_biases': {},
+        'bpm_bias': 0,
+    }
+    assert model.normalize_model_tuning(
+        trained,
+        {
+            'tag_biases': {'keep': 2, 'excluded': -1, 'neutral': 0},
+            'bpm_bias': -10,
+        },
+    ) == {'tag_biases': {'keep': 2}, 'bpm_bias': -10}
+
+
 def test_make_candidate_features_uses_model_feature_settings():
     track = FakeTrack(
         'collection-only',

--- a/tests/plugins/test_queuetrackpredictor_model.py
+++ b/tests/plugins/test_queuetrackpredictor_model.py
@@ -92,6 +92,10 @@ def test_get_suggestion_locations_uses_broad_feature_matches_and_limits():
         trained, [x, y], get_groups, max_suggestions=2
     ) == ['c', 'd']
 
+    assert model.get_scored_suggestion_locations(
+        trained, [x, y], get_groups, max_suggestions=2
+    ) == [('c', 5004), ('d', 5002)]
+
 
 def test_get_suggestion_locations_returns_empty_without_context_match():
     a = FakeTrack('a', groups={'warm'}, bpm=120)
@@ -185,3 +189,6 @@ def test_resolve_suggestion_tracks_skips_missing_locations():
             return {'a': a, 'c': c}.get(loc)
 
     assert model.resolve_suggestion_tracks(Collection(), ['a', 'b', 'c']) == [a, c]
+    assert model.resolve_scored_suggestion_tracks(
+        Collection(), [('a', 10), ('b', 9), ('c', 8)]
+    ) == [(a, 10), (c, 8)]

--- a/tests/plugins/test_queuetrackpredictor_model.py
+++ b/tests/plugins/test_queuetrackpredictor_model.py
@@ -225,6 +225,65 @@ def test_tag_biases_use_geometric_mean_for_tracks_with_multiple_tags():
     assert adjusted['neutral'] == 100
 
 
+def test_bpm_bias_favors_bounded_directional_movement():
+    counts = {'slower': 100, 'same': 100, 'faster': 100, 'unknown': 100}
+    candidates = {
+        'slower': {'bpm_band': 90},
+        'same': {'bpm_band': 120},
+        'faster': {'bpm_band': 150},
+        'unknown': {'bpm_band': None},
+    }
+
+    faster = model.apply_bpm_bias(counts, candidates, 120, 30)
+    slower = model.apply_bpm_bias(counts, candidates, 120, -30)
+    ten_faster = model.apply_bpm_bias(counts, candidates, 120, 10)
+
+    assert faster == {
+        'slower': 50,
+        'same': 100,
+        'faster': 200,
+        'unknown': 100,
+    }
+    assert slower == {
+        'slower': 200,
+        'same': 100,
+        'faster': 50,
+        'unknown': 100,
+    }
+    assert round(ten_faster['faster'], 6) == round(100 * (2 ** (10 / 30)), 6)
+    assert round(ten_faster['slower'], 6) == round(100 * (2 ** (-10 / 30)), 6)
+
+
+def test_bpm_bias_reranks_candidates_before_selection():
+    recent = FakeTrack('recent', groups={'context'}, bpm=120)
+    slower = FakeTrack('a-slower', groups={'context'}, bpm=90)
+    faster = FakeTrack('z-faster', groups={'context'}, bpm=150)
+    candidates = model.make_candidate_features([slower, faster], get_groups)
+    trained = {
+        'version': model.MODEL_VERSION,
+        'included_tags': ['context'],
+        'transition_counts': {},
+        'candidate_features': candidates,
+        'bpm_bias': 30,
+    }
+
+    assert model.get_scored_suggestion_locations(
+        trained,
+        [recent],
+        get_groups,
+        max_suggestions=2,
+        candidate_features=candidates,
+    ) == [('z-faster', 8000.0), ('a-slower', 2000.0)]
+
+
+def test_clamp_bpm_bias_handles_out_of_range_and_invalid_values():
+    assert model.clamp_bpm_bias(150) == 30
+    assert model.clamp_bpm_bias(-150) == -30
+    assert model.clamp_bpm_bias('25') == 25
+    assert model.clamp_bpm_bias(None) == 0
+    assert model.clamp_bpm_bias(float('inf')) == 0
+
+
 def test_make_candidate_features_uses_model_feature_settings():
     track = FakeTrack(
         'collection-only',

--- a/tests/plugins/test_queuetrackpredictor_model.py
+++ b/tests/plugins/test_queuetrackpredictor_model.py
@@ -182,6 +182,49 @@ def test_get_suggestion_locations_can_score_untrained_collection_track():
     ) == ['collection-only']
 
 
+def test_tag_biases_rerank_candidates_before_selection():
+    recent = FakeTrack('recent', groups={'context'}, bpm=120)
+    plain = FakeTrack('a-plain', groups={'context'}, bpm=120)
+    preferred = FakeTrack(
+        'z-preferred', groups={'context', 'favorite'}, bpm=120
+    )
+    candidates = model.make_candidate_features(
+        [plain, preferred], get_groups
+    )
+    trained = {
+        'version': model.MODEL_VERSION,
+        'included_tags': ['context', 'favorite'],
+        'transition_counts': {},
+        'candidate_features': candidates,
+        'tag_biases': {'favorite': 2},
+    }
+
+    assert model.get_scored_suggestion_locations(
+        trained,
+        [recent],
+        get_groups,
+        max_suggestions=2,
+        candidate_features=candidates,
+    ) == [('z-preferred', 10000.0), ('a-plain', 5000)]
+
+
+def test_tag_biases_use_geometric_mean_for_tracks_with_multiple_tags():
+    counts = {'balanced': 100, 'preferred': 100, 'neutral': 100}
+    candidates = {
+        'balanced': {'groups': ('toward', 'away')},
+        'preferred': {'groups': ('toward',)},
+        'neutral': {'groups': ('other',)},
+    }
+
+    adjusted = model.apply_tag_biases(
+        counts, candidates, {'toward': 2, 'away': -2}
+    )
+
+    assert adjusted['balanced'] == 100
+    assert adjusted['preferred'] == 200
+    assert adjusted['neutral'] == 100
+
+
 def test_make_candidate_features_uses_model_feature_settings():
     track = FakeTrack(
         'collection-only',

--- a/tests/plugins/test_queuetrackpredictor_model.py
+++ b/tests/plugins/test_queuetrackpredictor_model.py
@@ -49,6 +49,33 @@ def test_track_features_sort_groups_and_bucket_bpm():
     assert model.track_features(track, get_groups) == (('blues', 'swing'), 120)
 
 
+def test_get_playlist_tags_collects_unique_tags():
+    a = FakeTrack('a', groups={'warm', 'swing'})
+    b = FakeTrack('b', groups={'warm', 'blues'})
+
+    assert model.get_playlist_tags([[a], [b]], get_groups) == {
+        'blues',
+        'swing',
+        'warm',
+    }
+
+
+def test_build_model_filters_and_remembers_included_tags():
+    a = FakeTrack('a', groups={'keep', 'ignore'}, bpm=120)
+    b = FakeTrack('b', groups={'ignore'}, bpm=125)
+
+    trained = model.build_model(
+        [[a, b]], get_groups, included_tags={'keep'}
+    )
+
+    assert trained['included_tags'] == ['keep']
+    assert trained['candidate_features']['a']['groups'] == ('keep',)
+    assert trained['candidate_features']['b']['groups'] == ()
+    assert model.track_features(
+        a, get_groups, included_tags=trained['included_tags']
+    ) == (('keep',), 120)
+
+
 def test_build_model_counts_feature_transitions():
     a = FakeTrack('a', groups={'warm'}, bpm=120)
     b = FakeTrack('b', groups={'cool'}, bpm=122)

--- a/tests/plugins/test_queuetrackpredictor_model_store.py
+++ b/tests/plugins/test_queuetrackpredictor_model_store.py
@@ -31,6 +31,18 @@ def test_catalog_operations_update_selection():
     assert catalog['selected'] == 'Quiet'
 
 
+def test_replace_model_preserves_selection():
+    catalog = store.empty_catalog()
+    store.add_model(catalog, 'Selected', {'track_count': 10})
+    store.add_model(catalog, 'Other', {'track_count': 20})
+    store.select_model(catalog, 'Selected')
+
+    store.replace_model(catalog, 'Other', {'track_count': 30})
+
+    assert catalog['models']['Other']['track_count'] == 30
+    assert catalog['selected'] == 'Selected'
+
+
 def test_catalog_rejects_empty_and_duplicate_names():
     catalog = store.empty_catalog()
     store.add_model(catalog, 'Party', {})

--- a/tests/plugins/test_queuetrackpredictor_model_store.py
+++ b/tests/plugins/test_queuetrackpredictor_model_store.py
@@ -1,0 +1,54 @@
+import importlib.util
+import os
+
+
+STORE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    '..',
+    '..',
+    'plugins',
+    'queuetrackpredictor',
+    'model_store.py',
+)
+SPEC = importlib.util.spec_from_file_location(
+    'queuetrackpredictor_model_store', STORE_PATH
+)
+store = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(store)
+
+
+def test_catalog_operations_update_selection():
+    catalog = store.empty_catalog()
+    store.add_model(catalog, 'Party', {'track_count': 10})
+    store.add_model(catalog, 'Quiet', {'track_count': 20})
+    assert catalog['selected'] == 'Quiet'
+
+    store.select_model(catalog, 'Party')
+    store.rename_model(catalog, 'Party', 'Dance')
+    assert catalog['selected'] == 'Dance'
+
+    store.remove_model(catalog, 'Dance')
+    assert catalog['selected'] == 'Quiet'
+
+
+def test_catalog_rejects_empty_and_duplicate_names():
+    catalog = store.empty_catalog()
+    store.add_model(catalog, 'Party', {})
+
+    for name in ('', '  ', 'Party'):
+        try:
+            store.add_model(catalog, name, {})
+        except ValueError:
+            pass
+        else:
+            assert False, 'Expected invalid model name to fail'
+
+
+def test_catalog_round_trip(tmp_path):
+    path = str(tmp_path / 'models.pickle')
+    catalog = store.empty_catalog()
+    store.add_model(catalog, 'Road trip', {'track_count': 42})
+
+    store.save_catalog(path, catalog)
+
+    assert store.load_catalog(path) == catalog

--- a/tests/plugins/test_queuetrackpredictor_model_store.py
+++ b/tests/plugins/test_queuetrackpredictor_model_store.py
@@ -43,6 +43,18 @@ def test_replace_model_preserves_selection():
     assert catalog['selected'] == 'Selected'
 
 
+def test_model_names_are_sorted_case_insensitively():
+    catalog = store.empty_catalog()
+    catalog['models'] = {
+        'zebra': {},
+        'Beta': {},
+        'alpha': {},
+        'Alpha': {},
+    }
+
+    assert store.model_names(catalog) == ['Alpha', 'alpha', 'Beta', 'zebra']
+
+
 def test_catalog_rejects_empty_and_duplicate_names():
     catalog = store.empty_catalog()
     store.add_model(catalog, 'Party', {})

--- a/xlgui/widgets/playlist.py
+++ b/xlgui/widgets/playlist.py
@@ -395,9 +395,11 @@ def __create_playlist_context_menu():
         """
         Returns True if the containing notebook's tab bar is hidden
         """
-        scrolledwindow = parent.get_parent()
-        page = scrolledwindow.get_parent()
-        return not page.tab.notebook.get_show_tabs()
+        page = parent.get_ancestor(PlaylistPageBase)
+        tab = getattr(page, 'tab', None)
+        if tab is None or tab.notebook is None:
+            return False
+        return not tab.notebook.get_show_tabs()
 
     items.append(
         smi(


### PR DESCRIPTION
This is an experimental plugin that GPT has been writing for me -- it's 100% slop, I've only barely reviewed the code (and so I don't expect anyone else to spent time to review it yet) but I've been actively using the plugin itself and it seems to work as advertised most of the time.

---

The goal of this plugin is to leverage my existing set of playlists, tags, and BPM on my music to create a sort of predictor that provides suggestions you can potentially add to your queue. When you ask for a suggestion it adds a playlist tab and puts the suggestions in that playlist. You can tune/bias the suggestions by tag and BPM, limit the input files by a smart playlist, and probably other things too.

Is it useful? Sorta. Try it out, let me know.